### PR TITLE
Normalize copyright years and add SPDX identifiers

### DIFF
--- a/InnoSetup/setup_license.txt
+++ b/InnoSetup/setup_license.txt
@@ -1,7 +1,7 @@
 HTTrack Website Copier License Agreement:
 
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 
 This program is free software; you can redistribute it and/or

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -1,7 +1,9 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 1998-2014 Xavier Roche and other contributors
+Copyright (C) 2014 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -1,7 +1,9 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 1998-2014 Xavier Roche and other contributors
+Copyright (C) 2014 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/WinHTTrack/HTTrackInterface.c
+++ b/WinHTTrack/HTTrackInterface.c
@@ -1,7 +1,9 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -779,7 +779,7 @@ BEGIN
             VALUE "FileDescription", "WinHTTrack Website Copier, Copy Websites to Your Computer"
             VALUE "FileVersion", "3.49.2"
             VALUE "InternalName", "WinHTTrack"
-            VALUE "LegalCopyright", "Copyright (C) Xavier Roche and other contributors"
+            VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors"
             VALUE "LegalTrademarks", "This software is covered by the GNU General Public License version 3"
             VALUE "OriginalFilename", "WinHTTrack.exe"
             VALUE "ProductName", "WinHTTrack Website Copier"

--- a/WinHTTrack/setup_license.txt
+++ b/WinHTTrack/setup_license.txt
@@ -1,7 +1,7 @@
 HTTrack Website Copier License Agreement:
 
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 
 This program is free software; you can redistribute it and/or

--- a/WinHTTrackIEBar/WinHTTrackIEBar.rc
+++ b/WinHTTrackIEBar/WinHTTrackIEBar.rc
@@ -72,7 +72,7 @@ BEGIN
             VALUE "FileDescription", "WinHTTrackIEBar Module"
             VALUE "FileVersion", "1, 0, 0, 1"
             VALUE "InternalName", "WinHTTrackIEBar"
-            VALUE "LegalCopyright", "Copyright 1998-2006 Xavier Roche"
+            VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors"
             VALUE "OriginalFilename", "WinHTTrackIEBar.DLL"
             VALUE "ProductName", "WinHTTrackIEBar Module"
             VALUE "ProductVersion", "1, 0, 0, 1"

--- a/WinHTTrackIEBar/setup_license.txt
+++ b/WinHTTrackIEBar/setup_license.txt
@@ -1,7 +1,7 @@
 HTTrack Website Copier License Agreement:
 
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 
 This program is free software; you can redistribute it and/or

--- a/htsswf/setup_license.txt
+++ b/htsswf/setup_license.txt
@@ -1,7 +1,7 @@
 HTTrack Website Copier License Agreement:
 
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 
 This program is free software; you can redistribute it and/or

--- a/setup_license.txt
+++ b/setup_license.txt
@@ -1,7 +1,7 @@
 HTTrack Website Copier License Agreement:
 
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 
 This program is free software; you can redistribute it and/or

--- a/warning.txt
+++ b/warning.txt
@@ -15,7 +15,7 @@ Xavier Roche (Author)
 ---
 
 WinHTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Mirrors xroche/httrack#346's follow-up copyright cleanup on the Windows side.

The HTTrack-authored source headers get a single earliest year and an SPDX-License-Identifier: GPL-3.0-or-later line. HTTrackInterface.c has been here since the project's start, so it uses 1998; CrashReport.cpp/.h were added in 2014 and drop the inherited 1998 boilerplate for 2014. SPDX goes only in these C/C++ headers, not in the resource or text files.

The user-facing notices now carry a 1998-2026 range: the WinHTTrack and WinHTTrackIEBar .rc version banners (the IEBar one was a stale 1998-2006) plus the setup_license.txt and warning.txt installer text. A Windows .rc version block is static, so the end year is fixed rather than computed at build time the way the engine repo does it for its about banner.

Third-party notices (Microsoft, Gipsysoft) and the GPL license text are left alone. Every file keeps its existing line endings.