### PR TITLE
Use SetWindowLongPtr in the (disabled) BFF subclass block

### DIFF
--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -196,7 +196,7 @@ int __stdcall XSHBFF_CallbackProc(HWND hwnd,UINT uMsg,LPARAM lParam,LPARAM lpDat
         }
         
         // initial selection
-        LONG* Param = (LONG*) lpData;
+        LPARAM* Param = (LPARAM*) lpData;
         if (Param) {
           // Send init dir
           SendMessage(hwnd,BFFM_SETSELECTION,WPARAM(false),Param[0]);  // init dir

--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -182,7 +182,7 @@ int __stdcall XSHBFF_CallbackProc(HWND hwnd,UINT uMsg,LPARAM lParam,LPARAM lpDat
         int style = WS_CHILD | WS_CLIPSIBLINGS | BS_PUSHBUTTON | WS_TABSTOP | WS_VISIBLE;
         // create button, parent=hwnd
         HWND b = CreateWindow("BUTTON","New folder",style,x,y,w,h,hwnd,NULL,0,NULL);
-        LONG Ladr=NULL;
+        LONG_PTR Ladr=NULL;
         if (b!=NULL) {
           // Send Font notification so that the font be the same as default font
           HFONT hFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
@@ -192,7 +192,7 @@ int __stdcall XSHBFF_CallbackProc(HWND hwnd,UINT uMsg,LPARAM lParam,LPARAM lpDat
           // Get the control ID of our button
           XSHBFF_button1 = GetDlgCtrlID(b);
           // Place our function
-          Ladr = SetWindowLong(hwnd,GWL_WNDPROC,(LONG) XSHBFF_WndProc);
+          Ladr = SetWindowLongPtr(hwnd,GWLP_WNDPROC,(LONG_PTR) XSHBFF_WndProc);
         }
         
         // initial selection


### PR DESCRIPTION
## What
Use the pointer-safe `SetWindowLongPtr`/`GWLP_WNDPROC` idiom in the folder-browser window-subclass code.

## Why
`SetWindowLong(hwnd, GWL_WNDPROC, (LONG) proc)` truncates a 64-bit function pointer to 32 bits on x64. This block is currently **dead code** — it lives inside the `#if 0000` ("DO NOT ADD BUTTON") section of `XSHBFF_CallbackProc`, so it is not a live crash and does not even warn today. Fixing it now keeps the block x64-correct in case it is ever re-enabled during the VS2022 modernization.

## How
- `LONG Ladr` → `LONG_PTR Ladr`.
- `SetWindowLong(hwnd, GWL_WNDPROC, (LONG) XSHBFF_WndProc)` → `SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR) XSHBFF_WndProc)`.

Behaviour is unchanged on both x86 and x64 (dead code); this is a latent-correctness fix only.
