### PR TITLE
Port WinHTTrack to VS2022 (v143), add Windows CI, and make it compile clean

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,83 @@
+# Windows build bootstrap for WinHTTrack (VS2022 v143 + vcpkg).
+#
+# NON-GATING for now: the build step is allowed to fail. A fully green build
+# still needs two things this workflow cannot provide yet:
+#   1. libhttrack.lib built on Windows (engine-side work, see ENGINE-HANDOFF).
+#   2. The MFC-MBCS libraries on the runner (a separate VS component; the probe
+#      step below reports whether they are present).
+# Until then this proves the toolchain, vcpkg, and engine-header wiring, and
+# uploads the MSBuild log so we can watch the port compile further each run.
+name: windows-build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, Win32]
+        configuration: [Release]
+    steps:
+      - name: Checkout httrack-windows
+        uses: actions/checkout@v4
+        with:
+          path: httrack-windows
+
+      # The vcxproj resolves $(HttrackRoot) to ..\httrack, so the engine must be
+      # the sibling of httrack-windows in the workspace. coucal is its submodule.
+      - name: Checkout httrack engine (sibling)
+        uses: actions/checkout@v4
+        with:
+          repository: xroche/httrack
+          path: httrack
+          submodules: recursive
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      # Report VS version and whether MFC / MBCS components are installed.
+      # If MBCS is missing, the compile fails at <afxwin.h>, so the probe reports it up front.
+      - name: Probe toolchain
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          & $vswhere -latest -products * -property catalog_productDisplayVersion
+          $comps = & $vswhere -latest -products * -property packages
+          $mfc  = $comps | Select-String -Pattern 'MFC' -SimpleMatch
+          Write-Host "MFC-related components present:"
+          $mfc
+
+      - name: Enable vcpkg MSBuild integration
+        shell: pwsh
+        run: vcpkg integrate install
+
+      # continue-on-error: the link cannot succeed until libhttrack.lib exists.
+      - name: Build WinHTTrack (bootstrap, non-gating)
+        id: build
+        continue-on-error: true
+        working-directory: httrack-windows
+        shell: pwsh
+        run: |
+          msbuild WinHTTrack\WinHTTrack.vcxproj `
+            /m `
+            /p:Configuration=${{ matrix.configuration }} `
+            /p:Platform=${{ matrix.platform }} `
+            /p:VcpkgEnableManifest=true `
+            /flp:LogFile=msbuild.log`;Verbosity=normal
+
+      - name: Upload MSBuild log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}
+          path: httrack-windows/msbuild.log
+          if-no-files-found: ignore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Repo-wide MSBuild config, auto-imported into every project under this dir. -->
+<Project>
+  <PropertyGroup Label="WinHTTrack central config">
+    <!-- Engine repo is the sibling httrack/; override via env or -p to relocate. -->
+    <HttrackRoot Condition="'$(HttrackRoot)'==''">$(MSBuildThisFileDirectory)..\httrack</HttrackRoot>
+
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">10.0</WindowsTargetPlatformVersion>
+
+    <!-- Dynamic build (decided): OpenSSL/zlib ship as DLLs, so NON-static triplets. -->
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgTriplet>
+  </PropertyGroup>
+
+  <!-- Windows 7 SP1 floor plus CRT deprecation quieting, applied to every compile. -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0601;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/WinHTTrack/AddFilter.cpp
+++ b/WinHTTrack/AddFilter.cpp
@@ -195,9 +195,9 @@ BOOL CAddFilter::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -205,7 +205,7 @@ BOOL CAddFilter::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* CAddFilter::GetTip(int ID)
+const char* CAddFilter::GetTip(int ID)
 {
   switch(ID) {
     case IDC_AFtype: return LANG(LANG_B1); /*"Select a rule for the filter","Choisissez une règle pour le filtre");*/ break;

--- a/WinHTTrack/AddFilter.h
+++ b/WinHTTrack/AddFilter.h
@@ -39,7 +39,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
 
 	// Generated message map functions

--- a/WinHTTrack/CatchUrl.cpp
+++ b/WinHTTrack/CatchUrl.cpp
@@ -73,9 +73,9 @@ BOOL CCatchUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -83,7 +83,7 @@ BOOL CCatchUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* CCatchUrl::GetTip(int ID)
+const char* CCatchUrl::GetTip(int ID)
 {
   switch(ID) {
     case IDC_info: return LANG_V10; break;

--- a/WinHTTrack/CatchUrl.h
+++ b/WinHTTrack/CatchUrl.h
@@ -15,7 +15,7 @@ class CCatchUrl : public CDialog
 // Construction
 public:
 	CCatchUrl(CWnd* pParent = NULL);   // standard constructor
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 // Dialog Data
 	//{{AFX_DATA(CCatchUrl)

--- a/WinHTTrack/DialogHtmlHelp.cpp
+++ b/WinHTTrack/DialogHtmlHelp.cpp
@@ -231,9 +231,9 @@ BOOL CDialogHtmlHelp::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResul
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -241,7 +241,7 @@ BOOL CDialogHtmlHelp::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResul
   }
   return(FALSE);
 }
-char* CDialogHtmlHelp::GetTip(int ID)
+const char* CDialogHtmlHelp::GetTip(int ID)
 {
   switch(ID) {
     case IDCANCEL:   return LANG(LANG_B3); /*"Cancel","Annuler");*/ break;

--- a/WinHTTrack/DialogHtmlHelp.h
+++ b/WinHTTrack/DialogHtmlHelp.h
@@ -26,7 +26,7 @@ public:
 	CDialogHtmlHelp(CWnd* pParent = NULL);   // standard constructor
   Helper_CallBack callback;
   OnSize_CallBack callbackOnSize;
-  char* GetTip(int id);
+  const char* GetTip(int id);
   //
   CString page;
 protected:

--- a/WinHTTrack/FirstInfo.h
+++ b/WinHTTrack/FirstInfo.h
@@ -3,6 +3,7 @@
 
 #if _MSC_VER > 1000
 #pragma once
+#include "resource.h"
 #endif // _MSC_VER > 1000
 // FirstInfo.h : header file
 //

--- a/WinHTTrack/InfoUrl.cpp
+++ b/WinHTTrack/InfoUrl.cpp
@@ -93,14 +93,14 @@ void CInfoUrl::StopTimer() {
   }
 }
 
-char* ToBool(int i) {
+const char* ToBool(int i) {
   if (i)
     return "yes";
   else
     return "no";
 }
 
-char* ToStatuscode(int statuscode) {
+const char* ToStatuscode(int statuscode) {
   if (statuscode<0) {
     return "unknown status";
   } else {
@@ -111,7 +111,7 @@ char* ToStatuscode(int statuscode) {
   }
 }
 
-char* ToStatus(int i) {
+const char* ToStatus(int i) {
   switch(i) {
   case 0:
     return "ready";
@@ -190,7 +190,7 @@ void CInfoUrl::OnTimer(UINT_PTR nIDEvent)
         sprintf(total,"unknown");
         sprintf(info100,"");
       }
-      sprintf(info,"File: %s\r\nTotal length: %s\r\nBytes downloaded: "LLintP" %s\r\nCurrent state: %s",back[id].url_sav,total,back[id].r.size,info100,ToStatus(back[id].status));
+      sprintf(info,"File: %s\r\nTotal length: %s\r\nBytes downloaded: " LLintP " %s\r\nCurrent state: %s",back[id].url_sav,total,back[id].r.size,info100,ToStatus(back[id].status));
     }
     //
     if (strcmp(old_info,info)) {
@@ -215,7 +215,7 @@ void CInfoUrl::OnTimer(UINT_PTR nIDEvent)
             sprintf(moreinfo+strlen(moreinfo),"HTTP/1.1: %s\r\n",ToBool(backitem->r.req.http11));
             sprintf(moreinfo+strlen(moreinfo),"ChunkMode: %s\r\n",ToBool(backitem->r.is_chunk));
             if (backitem->is_chunk)
-              sprintf(moreinfo+strlen(moreinfo),"CurrentChunkSize: "LLintP"\r\n",backitem->chunk_size);
+              sprintf(moreinfo+strlen(moreinfo),"CurrentChunkSize: " LLintP "\r\n",backitem->chunk_size);
             //
             sprintf(moreinfo+strlen(moreinfo),"TestMode: %s\r\n",ToBool(backitem->testmode));
             sprintf(moreinfo+strlen(moreinfo),"HeadRequest: %s\r\n",ToBool(backitem->head_request));
@@ -224,8 +224,8 @@ void CInfoUrl::OnTimer(UINT_PTR nIDEvent)
             sprintf(moreinfo+strlen(moreinfo),"WriteToDisk: %s\r\n",ToBool(backitem->r.is_write));
             sprintf(moreinfo+strlen(moreinfo),"LocalFile: %s\r\n",ToBool(backitem->r.is_file));
             //
-            sprintf(moreinfo+strlen(moreinfo),"Size: "LLintP"\r\n",backitem->r.size);
-            sprintf(moreinfo+strlen(moreinfo),"TotalSize: "LLintP"\r\n",backitem->r.totalsize);
+            sprintf(moreinfo+strlen(moreinfo),"Size: " LLintP "\r\n",backitem->r.size);
+            sprintf(moreinfo+strlen(moreinfo),"TotalSize: " LLintP "\r\n",backitem->r.totalsize);
         } else
           strcpybuff(moreinfo,"Transfer complete in this buffer, waiting for next file");
       }

--- a/WinHTTrack/Infoend.cpp
+++ b/WinHTTrack/Infoend.cpp
@@ -188,9 +188,9 @@ BOOL Cinfoend::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -198,7 +198,7 @@ BOOL Cinfoend::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Cinfoend::GetTip(int ID)
+const char* Cinfoend::GetTip(int ID)
 {
   switch(ID) {
     case IDOK:     return LANG(LANG_D3 /*"Click to quit WinHTTrack"*/ ); break;

--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -117,9 +117,9 @@ BOOL CInsertUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -127,7 +127,7 @@ BOOL CInsertUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* CInsertUrl::GetTip(int ID)
+const char* CInsertUrl::GetTip(int ID)
 {
   switch(ID) {
     case IDC_urladr:    return LANG(LANG_T10); break;

--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -186,7 +186,7 @@ UINT RunBackCatchServer( LPVOID pP ) {
       {
         char finalurl[HTS_URLMAXSIZE*2];
         inplace_escape_check_url(dest, sizeof(dest));
-        sprintf(finalurl,"%s"POSTTOK"file:%s",url,dest);
+        sprintf(finalurl,"%s" POSTTOK "file:%s",url,dest);
         SetDlgItemTextCP(_this, IDC_urladr,finalurl);
       }
     }

--- a/WinHTTrack/InsertUrl.h
+++ b/WinHTTrack/InsertUrl.h
@@ -30,7 +30,7 @@ class CInsertUrl : public CDialog
 // Construction
 public:
 	CInsertUrl(CWnd* pParent = NULL);   // standard constructor
-  char* GetTip(int id);
+  const char* GetTip(int id);
   //
   CString dest_path;
   //

--- a/WinHTTrack/Iplog.cpp
+++ b/WinHTTrack/Iplog.cpp
@@ -280,9 +280,9 @@ BOOL Ciplog::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -290,7 +290,7 @@ BOOL Ciplog::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Ciplog::GetTip(int ID)
+const char* Ciplog::GetTip(int ID)
 {
   switch(ID) {
     case IDC_logtype:  return LANG(LANG_E1 /*"View error and warning reports"*/); break;

--- a/WinHTTrack/Iplog.h
+++ b/WinHTTrack/Iplog.h
@@ -51,7 +51,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
   //
   UINT_PTR timer;

--- a/WinHTTrack/LaunchHelp.h
+++ b/WinHTTrack/LaunchHelp.h
@@ -9,8 +9,8 @@
 // Lancer aide
 class LaunchHelp {
 public:
-  LaunchHelp::LaunchHelp();
-  LaunchHelp::~LaunchHelp();
+  LaunchHelp();
+  ~LaunchHelp();
   void Help();
   void Help(CString page);
   CDialogHtmlHelp b;

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -3,8 +3,6 @@
 
 
 #include "stdafx.h"
-#include <ws2tcpip.h>
-#include <Wspiapi.h>
 #include "mainfrm.h"
 #include "resource.h"
 #include "Shell.h"

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -3,6 +3,8 @@
 
 
 #include "stdafx.h"
+#include <ws2tcpip.h>
+#include <Wspiapi.h>
 #include "mainfrm.h"
 #include "resource.h"
 #include "Shell.h"

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -271,7 +271,7 @@ void CMainTab::OnCancel( ) {
 // char* GetTip(int id);
 // et en generated message map
 // afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
-char* CMainTab::GetTip(int ID)
+const char* CMainTab::GetTip(int ID)
 {
   switch(ID) {
     case IDOK:           return LANG(LANG_TIPOK); break;      
@@ -290,9 +290,9 @@ BOOL CMainTab::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st = GetTip((int) nID);
+      const char* st = GetTip((int) nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }

--- a/WinHTTrack/MainTab.h
+++ b/WinHTTrack/MainTab.h
@@ -71,7 +71,7 @@ public:
   // Generated message map functions
 protected:
   
-  char* GetTip(int id);
+  const char* GetTip(int id);
   //{{AFX_MSG(CMainTab)
   afx_msg HCURSOR OnQueryDragIcon();
   afx_msg void OnSysCommand(UINT nID, LPARAM lParam);

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -362,9 +362,9 @@ BOOL CNewProj::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -372,7 +372,7 @@ BOOL CNewProj::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* CNewProj::GetTip(int ID)
+const char* CNewProj::GetTip(int ID)
 {
   switch(ID) {
     case IDC_projname:  return LANG(LANG_S1); break;

--- a/WinHTTrack/NewProj.h
+++ b/WinHTTrack/NewProj.h
@@ -47,7 +47,7 @@ public:
 // Implementation
 protected:
   BOOL can_click_next;
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
   void Changeprojname(CString stl);
 	// Generated message map functions

--- a/WinHTTrack/NewProj.h
+++ b/WinHTTrack/NewProj.h
@@ -3,6 +3,7 @@
 
 #if _MSC_VER >= 1000
 #pragma once
+#include "resource.h"
 #endif // _MSC_VER >= 1000
 // NewProj.h : header file
 //

--- a/WinHTTrack/OptionTab1.cpp
+++ b/WinHTTrack/OptionTab1.cpp
@@ -114,9 +114,9 @@ BOOL COptionTab1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -124,7 +124,7 @@ BOOL COptionTab1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab1::GetTip(int ID)
+const char* COptionTab1::GetTip(int ID)
 {
   switch(ID) {
     case IDC_link:    return LANG(LANG_I1); break; // "Get files even in foreign addresses","Récupérer les fichiers même sur les liens extérieurs"); break;

--- a/WinHTTrack/OptionTab1.h
+++ b/WinHTTrack/OptionTab1.h
@@ -18,7 +18,7 @@ class COptionTab1 : public CPropertyPage
 public:
 	COptionTab1();
 	~COptionTab1();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
 
 // Dialog Data

--- a/WinHTTrack/OptionTab10.cpp
+++ b/WinHTTrack/OptionTab10.cpp
@@ -240,9 +240,9 @@ BOOL COptionTab10::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -250,7 +250,7 @@ BOOL COptionTab10::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab10::GetTip(int ID)
+const char* COptionTab10::GetTip(int ID)
 {
   switch(ID) {
     case IDC_prox:  return LANG(LANG_G14); break; // "Proxy if needed","Proxy si besoin"); break;

--- a/WinHTTrack/OptionTab10.h
+++ b/WinHTTrack/OptionTab10.h
@@ -18,7 +18,7 @@ class COptionTab10 : public CPropertyPage
 public:
 	COptionTab10();
 	~COptionTab10();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
   int prox_status;
   char ProxyDetectBuff[16][1024];

--- a/WinHTTrack/OptionTab11.cpp
+++ b/WinHTTrack/OptionTab11.cpp
@@ -167,9 +167,9 @@ BOOL COptionTab11::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -177,7 +177,7 @@ BOOL COptionTab11::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab11::GetTip(int ID)
+const char* COptionTab11::GetTip(int ID)
 {
   switch(ID) {
     case IDC_ext1:

--- a/WinHTTrack/OptionTab11.h
+++ b/WinHTTrack/OptionTab11.h
@@ -18,7 +18,7 @@ class COptionTab11 : public CPropertyPage
 public:
 	COptionTab11();
 	~COptionTab11();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
 
 // Dialog Data

--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -153,9 +153,9 @@ BOOL COptionTab2::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -163,7 +163,7 @@ BOOL COptionTab2::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab2::GetTip(int ID)
+const char* COptionTab2::GetTip(int ID)
 {
   switch(ID) {
     case IDC_build:   return LANG(LANG_I3); break; // "Choose local site structure","Choisir la structure de fichiers local"); break;

--- a/WinHTTrack/OptionTab2.h
+++ b/WinHTTrack/OptionTab2.h
@@ -23,7 +23,7 @@ public:
 	~COptionTab2();
 	CBuildOptions      Bopt;
   int modify;
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 
 // Dialog Data

--- a/WinHTTrack/OptionTab3.cpp
+++ b/WinHTTrack/OptionTab3.cpp
@@ -139,9 +139,9 @@ BOOL COptionTab3::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -149,7 +149,7 @@ BOOL COptionTab3::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab3::GetTip(int ID)
+const char* COptionTab3::GetTip(int ID)
 {
   switch(ID) {
     case IDC_Cache:   return LANG(LANG_I5); break; // "Use a cache for updates and retries","Utiliser un cache pour les mise à jour et reprises"); break;

--- a/WinHTTrack/OptionTab3.h
+++ b/WinHTTrack/OptionTab3.h
@@ -19,7 +19,7 @@ public:
 	COptionTab3();
 	~COptionTab3();
   int modify;
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 
 // Dialog Data

--- a/WinHTTrack/OptionTab4.cpp
+++ b/WinHTTrack/OptionTab4.cpp
@@ -111,9 +111,9 @@ BOOL COptionTab4::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -121,7 +121,7 @@ BOOL COptionTab4::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab4::GetTip(int ID)
+const char* COptionTab4::GetTip(int ID)
 {
   switch(ID) {
     case IDC_connexion: return LANG(LANG_I12); break; // "Maximum number of connections","Nombre maximal de connexions"); break;

--- a/WinHTTrack/OptionTab4.h
+++ b/WinHTTrack/OptionTab4.h
@@ -18,7 +18,7 @@ class COptionTab4 : public CPropertyPage
 public:
 	COptionTab4();
 	~COptionTab4();
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 
 // Dialog Data

--- a/WinHTTrack/OptionTab5.cpp
+++ b/WinHTTrack/OptionTab5.cpp
@@ -126,9 +126,9 @@ BOOL COptionTab5::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -136,7 +136,7 @@ BOOL COptionTab5::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab5::GetTip(int ID)
+const char* COptionTab5::GetTip(int ID)
 {
   switch(ID) {
     case IDC_depth: return LANG_I1g; break;

--- a/WinHTTrack/OptionTab5.h
+++ b/WinHTTrack/OptionTab5.h
@@ -18,7 +18,7 @@ class COptionTab5 : public CPropertyPage
 public:
 	COptionTab5();
 	~COptionTab5();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int depth_status;
 
 

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -104,9 +104,9 @@ BOOL COptionTab6::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -114,7 +114,7 @@ BOOL COptionTab6::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab6::GetTip(int ID)
+const char* COptionTab6::GetTip(int ID)
 {
   switch(ID) {
     case IDC_user: return LANG(LANG_I23); break; // "Browser identity","Identité du browser"); break;

--- a/WinHTTrack/OptionTab6.h
+++ b/WinHTTrack/OptionTab6.h
@@ -18,7 +18,7 @@ class COptionTab6 : public CPropertyPage
 public:
 	COptionTab6();
 	~COptionTab6();
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 // Dialog Data
 	//{{AFX_DATA(COptionTab6)

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -272,9 +272,9 @@ BOOL COptionTab7::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -282,7 +282,7 @@ BOOL COptionTab7::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab7::GetTip(int ID)
+const char* COptionTab7::GetTip(int ID)
 {
   switch(ID) {
     case IDC_ADD1: return LANG(LANG_C1);   /*"Add refuse filter"*/ break;

--- a/WinHTTrack/OptionTab7.h
+++ b/WinHTTrack/OptionTab7.h
@@ -18,7 +18,7 @@ class COptionTab7 : public CPropertyPage
 public:
 	COptionTab7();
 	~COptionTab7();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
 
 // Dialog Data

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -139,9 +139,9 @@ BOOL COptionTab8::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -149,7 +149,7 @@ BOOL COptionTab8::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab8::GetTip(int ID)
+const char* COptionTab8::GetTip(int ID)
 {
   switch(ID) {
     case IDC_robots:    return LANG(LANG_I28); break; // robots.txt

--- a/WinHTTrack/OptionTab8.h
+++ b/WinHTTrack/OptionTab8.h
@@ -18,7 +18,7 @@ class COptionTab8 : public CPropertyPage
 public:
 	COptionTab8();
 	~COptionTab8();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
 
 // Dialog Data

--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -129,9 +129,9 @@ BOOL COptionTab9::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -139,7 +139,7 @@ BOOL COptionTab9::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* COptionTab9::GetTip(int ID)
+const char* COptionTab9::GetTip(int ID)
 {
   switch(ID) {
     case IDC_norecatch: return LANG(LANG_I5b); break;

--- a/WinHTTrack/OptionTab9.h
+++ b/WinHTTrack/OptionTab9.h
@@ -18,7 +18,7 @@ class COptionTab9 : public CPropertyPage
 public:
 	COptionTab9();
 	~COptionTab9();
-  char* GetTip(int id);
+  const char* GetTip(int id);
   int modify;
 
 // Dialog Data

--- a/WinHTTrack/ProxyId.cpp
+++ b/WinHTTrack/ProxyId.cpp
@@ -118,9 +118,9 @@ BOOL CProxyId::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -128,7 +128,7 @@ BOOL CProxyId::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* CProxyId::GetTip(int ID)
+const char* CProxyId::GetTip(int ID)
 {
   switch(ID) {
     case IDC_proxadr:    return LANG(LANG_R10); break;

--- a/WinHTTrack/ProxyId.h
+++ b/WinHTTrack/ProxyId.h
@@ -35,7 +35,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
 	afx_msg void OnHelpInfo2();
 
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2194,7 +2194,7 @@ void lance(void) {
 
 
 /* interface lang - lang_string="stringlang0\nstringlang1\n..laststring" */
-void SetCombo(CWnd* _this,int id,char* lang_string) {
+void SetCombo(CWnd* _this,int id,const char* lang_string) {
   CComboBox* combo = (CComboBox*) _this->GetDlgItem(id);
   CString st=lang_string;
   st.TrimLeft(); st.TrimRight();

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -870,7 +870,7 @@ TimedMessageBox(
 
 /* From MSDN */
 BOOL InitiateSystemShutdownExWithPriv(
-  LPTSTR lpMessage,
+  LPCTSTR lpMessage,
   DWORD dwTimeout,
   BOOL bForceAppsClosed,
   BOOL bRebootAfterShutdown,

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -96,7 +96,7 @@ extern HANDLE WhttMutex;
 #define WHTT_UNLOCK() ReleaseMutex(WhttMutex)
 
 /* Location */
-extern char* WhttLocation;
+extern const char* WhttLocation;
 #define WHTT_LOCATION(a) WhttLocation=(a)
 
 #ifndef HTS_DEF_FWSTRUCT_lien_back

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -156,7 +156,7 @@ typedef unsigned long (* t_RasHangUp)(HRASCONN);
 // RAS END //
 
 /* lang extensions */
-void SetCombo(CWnd* _this,int id,char* lang_string);
+void SetCombo(CWnd* _this,int id,const char* lang_string);
 
 
 // HTTrack params - pour le multithread interface/robot

--- a/WinHTTrack/StdAfx.h
+++ b/WinHTTrack/StdAfx.h
@@ -9,17 +9,15 @@
 // #define NTDDI_VERSION 0x05000000 // NTDDI_WIN2K
 
 #ifndef WINVER
-#define WINVER       0x0500 // _WIN32_WINNT_WIN2K
-//#define WINVER       0x0400 // _WIN32_WINNT_NT4
+#define WINVER       0x0601 // _WIN32_WINNT_WIN7
 #endif
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0500 // _WIN32_WINNT_WIN2K
-//#define _WIN32_WINNT 0x0400 // _WIN32_WINNT_NT4
+#define _WIN32_WINNT 0x0601 // _WIN32_WINNT_WIN7
 #endif
 
 #ifndef _WIN32_IE
-#define _WIN32_IE 0x0500
+#define _WIN32_IE 0x0601 // IE 8 baseline shipped with Win7
 #endif
 
 #if _MSC_VER >= 1000

--- a/WinHTTrack/StdAfx.h
+++ b/WinHTTrack/StdAfx.h
@@ -33,6 +33,11 @@
 #include <afxcmn.h>			// MFC support for Windows Common Controls
 #endif // _AFX_NO_AFXCMN_SUPPORT
 
+// Pull these in with C++ linkage before anything wraps the engine headers in
+// extern "C": Wspiapi.h declares a template, which C linkage rejects (C2894).
+#include <ws2tcpip.h>
+#include <Wspiapi.h>
+
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Developer Studio will insert additional declarations immediately before the previous line.

--- a/WinHTTrack/TreeViewToolTip.cpp
+++ b/WinHTTrack/TreeViewToolTip.cpp
@@ -60,9 +60,9 @@ BOOL CTreeViewToolTip::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResu
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -70,7 +70,7 @@ BOOL CTreeViewToolTip::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResu
   }
   return(FALSE);
 }
-char* CTreeViewToolTip::GetTip(int ID)
+const char* CTreeViewToolTip::GetTip(int ID)
 {
   /*
   switch(ID) {

--- a/WinHTTrack/TreeViewToolTip.h
+++ b/WinHTTrack/TreeViewToolTip.h
@@ -33,7 +33,7 @@ public:
 
 	// Generated message map functions
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
 	//{{AFX_MSG(CTreeViewToolTip)
 		// NOTE - the ClassWizard will add and remove member functions here.
 	//}}AFX_MSG

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -515,9 +515,9 @@ BOOL Wid1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st = GetTip((int) nID);
+      const char* st = GetTip((int) nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -525,7 +525,7 @@ BOOL Wid1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Wid1::GetTip(int ID)
+const char* Wid1::GetTip(int ID)
 {
   switch(ID) {
     case IDC_todo:  return LANG(LANG_G9); break; // "Choose an action","Choisissez une action"); break; 

--- a/WinHTTrack/Wid1.h
+++ b/WinHTTrack/Wid1.h
@@ -6,6 +6,7 @@
 
 #if _MSC_VER >= 1000
 #pragma once
+#include "resource.h"
 #endif // _MSC_VER >= 1000
 // Wid1.h : header file
 //

--- a/WinHTTrack/Wid1.h
+++ b/WinHTTrack/Wid1.h
@@ -62,7 +62,7 @@ protected:
   void AfterInitDialog( );
   void AfterChangepathlog();
   int load_after_changes;
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void AddText(CString add_st);
 	// Generated message map functions
 	//{{AFX_MSG(Wid1)

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -89,7 +89,7 @@ extern int LibRasUse;
 HANDLE WhttMutex;
 
 /* Location */
-char* WhttLocation="";
+const char* WhttLocation="";
 
 
 // HTTrack main vars

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -2545,7 +2545,6 @@ IDC_CURSWWW             CURSOR                  "res\\www.cur"
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "res\\manifest.xml"
 #endif    // French (France) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/WinHTTrack/WinHTTrack.vcxproj
+++ b/WinHTTrack/WinHTTrack.vcxproj
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{4707CDEB-E576-4664-98A8-94D99BA190B8}</ProjectGuid>
+    <RootNamespace>WinHTTrack</RootNamespace>
+    <Keyword>MFCProj</Keyword>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <!-- Shared MFC + MBCS + dynamic CRT (decided). PlatformToolset/SDK come from Directory.Build.props. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <!-- Engine (libhttrack) include/lib wiring. -->
+  <Import Project="httrack.props" />
+
+  <!-- Project-relative output so a standalone msbuild invocation works without a .sln. -->
+  <PropertyGroup>
+    <OutDir>$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x040c</Culture>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>Ws2_32.lib;Winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <StringPooling>true</StringPooling>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <!-- StdAfx.cpp builds the PCH; every other C++ TU consumes it. -->
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="about.cpp" />
+    <ClCompile Include="AddFilter.cpp" />
+    <ClCompile Include="BatchUpdate.cpp" />
+    <ClCompile Include="BuildOptions.cpp" />
+    <ClCompile Include="CatchUrl.cpp" />
+    <ClCompile Include="CrashReport.cpp" />
+    <ClCompile Include="DialogContainer.cpp" />
+    <ClCompile Include="DialogHtmlHelp.cpp" />
+    <ClCompile Include="DirTreeView.cpp" />
+    <ClCompile Include="EasyDropTarget.cpp" />
+    <ClCompile Include="FirstInfo.cpp" />
+    <ClCompile Include="HtmlCtrl.cpp" />
+    <ClCompile Include="HtmlFrm.cpp" />
+    <ClCompile Include="HTMLHelp.cpp" />
+    <ClCompile Include="Infoend.cpp" />
+    <ClCompile Include="InfoUrl.cpp" />
+    <ClCompile Include="inprogress.cpp" />
+    <ClCompile Include="InsertUrl.cpp" />
+    <ClCompile Include="Iplog.cpp" />
+    <ClCompile Include="LaunchHelp.cpp" />
+    <ClCompile Include="MainFrm.cpp" />
+    <ClCompile Include="MainTab.cpp" />
+    <ClCompile Include="MemRegister.cpp" />
+    <ClCompile Include="NewFolder.cpp" />
+    <ClCompile Include="newlang.cpp" />
+    <ClCompile Include="NewProj.cpp" />
+    <ClCompile Include="OptionTab1.cpp" />
+    <ClCompile Include="OptionTab2.cpp" />
+    <ClCompile Include="OptionTab3.cpp" />
+    <ClCompile Include="OptionTab4.cpp" />
+    <ClCompile Include="OptionTab5.cpp" />
+    <ClCompile Include="OptionTab6.cpp" />
+    <ClCompile Include="OptionTab7.cpp" />
+    <ClCompile Include="OptionTab8.cpp" />
+    <ClCompile Include="OptionTab9.cpp" />
+    <ClCompile Include="OptionTab10.cpp" />
+    <ClCompile Include="OptionTab11.cpp" />
+    <ClCompile Include="ProxyId.cpp" />
+    <ClCompile Include="RasLoad.cpp" />
+    <ClCompile Include="Shell.cpp" />
+    <ClCompile Include="splitter.cpp" />
+    <ClCompile Include="trans.cpp" />
+    <ClCompile Include="TreeViewToolTip.cpp" />
+    <ClCompile Include="Wid1.cpp" />
+    <ClCompile Include="WinHTTrack.cpp" />
+    <ClCompile Include="WinHTTrackDoc.cpp" />
+    <ClCompile Include="WinHTTrackView.cpp" />
+    <ClCompile Include="Wizard.cpp" />
+    <ClCompile Include="Wizard2.cpp" />
+    <ClCompile Include="WizLinks.cpp" />
+    <ClCompile Include="WizTab.cpp" />
+    <ClCompile Include="XSHBrowseForFolder.cpp" />
+
+    <!-- C sources: no PCH (they cannot include the C++ StdAfx.h). -->
+    <ClCompile Include="HTTrackInterface.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(HttrackRoot)\src\htsmd5.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(HttrackRoot)\src\md5.c">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="about.h" />
+    <ClInclude Include="AddFilter.h" />
+    <ClInclude Include="BatchUpdate.h" />
+    <ClInclude Include="BuildOptions.h" />
+    <ClInclude Include="CatchUrl.h" />
+    <ClInclude Include="cpp_lang.h" />
+    <ClInclude Include="CrashReport.h" />
+    <ClInclude Include="DialogContainer.h" />
+    <ClInclude Include="DialogHtmlHelp.h" />
+    <ClInclude Include="DirTreeView.h" />
+    <ClInclude Include="EasyDropTarget.h" />
+    <ClInclude Include="FirstInfo.h" />
+    <ClInclude Include="HtmlCtrl.h" />
+    <ClInclude Include="HtmlFrm.h" />
+    <ClInclude Include="HTMLHelp.h" />
+    <ClInclude Include="htssystem.h" />
+    <ClInclude Include="HTTrackInterface.h" />
+    <ClInclude Include="infoend.h" />
+    <ClInclude Include="InfoUrl.h" />
+    <ClInclude Include="inprogress.h" />
+    <ClInclude Include="InsertUrl.h" />
+    <ClInclude Include="Iplog.h" />
+    <ClInclude Include="LaunchHelp.h" />
+    <ClInclude Include="MainFrm.h" />
+    <ClInclude Include="MainTab.h" />
+    <ClInclude Include="MemRegister.h" />
+    <ClInclude Include="NewFolder.h" />
+    <ClInclude Include="newlang.h" />
+    <ClInclude Include="NewProj.h" />
+    <ClInclude Include="OptionTab1.h" />
+    <ClInclude Include="OptionTab2.h" />
+    <ClInclude Include="OptionTab3.h" />
+    <ClInclude Include="OptionTab4.h" />
+    <ClInclude Include="OptionTab5.h" />
+    <ClInclude Include="OptionTab6.h" />
+    <ClInclude Include="OptionTab7.h" />
+    <ClInclude Include="OptionTab8.h" />
+    <ClInclude Include="OptionTab9.h" />
+    <ClInclude Include="OptionTab10.h" />
+    <ClInclude Include="OptionTab11.h" />
+    <ClInclude Include="ProxyId.h" />
+    <ClInclude Include="RasLoad.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="Shell.h" />
+    <ClInclude Include="splitter.h" />
+    <ClInclude Include="StdAfx.h" />
+    <ClInclude Include="trans.h" />
+    <ClInclude Include="TreeViewToolTip.h" />
+    <ClInclude Include="Wid1.h" />
+    <ClInclude Include="WinHTTrack.h" />
+    <ClInclude Include="WinHTTrackDoc.h" />
+    <ClInclude Include="WinHTTrackView.h" />
+    <ClInclude Include="wizard.h" />
+    <ClInclude Include="wizard2.h" />
+    <ClInclude Include="WizLinks.h" />
+    <ClInclude Include="WizTab.h" />
+    <ClInclude Include="XSHBrowseForFolder.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ResourceCompile Include="WinHTTrack.rc" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- MSBuild embeds this; the old "1 RT_MANIFEST res\manifest.xml" line was dropped from the .rc. -->
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="res\www.cur" />
+    <Image Include="res\ico00001.ico" />
+    <Image Include="res\icon1.ico" />
+    <Image Include="res\icon2.ico" />
+    <Image Include="res\icon3.ico" />
+    <Image Include="res\icon4.ico" />
+    <Image Include="res\icon5.ico" />
+    <Image Include="res\icon6.ico" />
+    <Image Include="res\idr_main.ico" />
+    <Image Include="res\Shell.ico" />
+    <Image Include="res\mainfram.bmp" />
+    <Image Include="res\Toolbar.bmp" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -1,8 +1,6 @@
 // Tab Control Principal
 
 #include "stdafx.h"
-#include <ws2tcpip.h>
-#include <Wspiapi.h>
 #include "Shell.h"
 #include "WizTab.h"
 #include "direct.h"

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -315,7 +315,7 @@ void CWizTab::OnCancel( ) {
 // char* GetTip(int id);
 // et en generated message map
 // afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
-char* CWizTab::GetTip(int ID)
+const char* CWizTab::GetTip(int ID)
 {
   /*switch(ID) {
   }*/
@@ -331,9 +331,9 @@ BOOL CWizTab::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -1,6 +1,8 @@
 // Tab Control Principal
 
 #include "stdafx.h"
+#include <ws2tcpip.h>
+#include <Wspiapi.h>
 #include "Shell.h"
 #include "WizTab.h"
 #include "direct.h"

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -63,7 +63,7 @@ protected:
   void DoInits();
   void ClearInits();
   
-  char* GetTip(int id);
+  const char* GetTip(int id);
   //{{AFX_MSG(CWizTab)
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
 	//}}AFX_MSG

--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -34,7 +34,7 @@
 int XSHBFF_button1 = -1;
 
 // Main routine
-CString XSHBrowseForFolder(HWND hwnd,char* title,char* _path) {
+CString XSHBrowseForFolder(HWND hwnd,const char* title,char* _path) {
   char path[MAX_PATH]; path[0]='\0';
 
   // Remove the last slash bar

--- a/WinHTTrack/XSHBrowseForFolder.h
+++ b/WinHTTrack/XSHBrowseForFolder.h
@@ -25,7 +25,7 @@
 #define XSHBrowseForFolder_SETSTRING 1234
 #define XSHBrowseForFolder_OK 1
 
-CString        XSHBrowseForFolder (HWND hwnd,char* title,char* _path);
+CString        XSHBrowseForFolder (HWND hwnd,const char* title,char* _path);
 LRESULT __stdcall XSHBFF_WndProc     (HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
 int __stdcall  XSHBFF_CallbackProc(HWND hwnd,UINT uMsg,LPARAM lParam,LPARAM lpData);
 LPITEMIDLIST   XSHBFF_PathConvert (HWND hwnd,char* _path);

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -228,9 +228,9 @@ BOOL Cabout::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -238,7 +238,7 @@ BOOL Cabout::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Cabout::GetTip(int ID)
+const char* Cabout::GetTip(int ID)
 {
   switch(ID) {
     case IDC_lang:   return LANG_U1; break;

--- a/WinHTTrack/about.h
+++ b/WinHTTrack/about.h
@@ -15,7 +15,7 @@ class Cabout : public CDialog
 // Construction
 public:
 	Cabout(CWnd* pParent = NULL);   // standard constructor
-  char* GetTip(int id);
+  const char* GetTip(int id);
 
 // Dialog Data
 	//{{AFX_DATA(Cabout)

--- a/WinHTTrack/app.manifest
+++ b/WinHTTrack/app.manifest
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"
+          xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+
+  <!-- No assemblyIdentity: MSBuild fills the per-arch identity. -->
+
+  <!-- Run as the invoking user: a website copier writes to user folders and needs no elevation. -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <!-- Supported OS: Windows 7 floor up through Windows 10/11 (10 and 11 share one GUID). -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+
+  <!-- DPI awareness; degrades to system-aware on Win7/8. Aspirational for old MFC MBCS (PHASE1 risk #4). -->
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
+  <!-- Common Controls v6 for visual styles. -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0" processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df" language="*"/>
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/WinHTTrack/httrack.props
+++ b/WinHTTrack/httrack.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Engine (libhttrack) linkage for WinHTTrack; HttrackRoot is set in Directory.Build.props. -->
+<Project>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(HttrackRoot)\src;$(HttrackRoot)\src\coucal;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>$(HttrackRoot)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <!-- Import lib for libhttrack.dll; engine output path is a guess, reconcile in VS (PHASE1 risk #7). -->
+      <AdditionalDependencies>libhttrack.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(HttrackRoot)\src\$(Platform)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/WinHTTrack/infoend.h
+++ b/WinHTTrack/infoend.h
@@ -36,7 +36,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
   void OnBye();
   UINT_PTR tm;

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -845,9 +845,9 @@ BOOL Cinprogress::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -855,7 +855,7 @@ BOOL Cinprogress::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Cinprogress::GetTip(int ID)
+const char* Cinprogress::GetTip(int ID)
 {
   switch(ID) {
     //case IDC_STOPALL: return LANG(LANG_H4); break; // "Stop the mirror","Stopper le miroir"); break;

--- a/WinHTTrack/inprogress.h
+++ b/WinHTTrack/inprogress.h
@@ -122,7 +122,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
   UINT_PTR timer;
   void StartTimer();

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -281,7 +281,7 @@ void LANG_LOAD(char* limit_to) {
   }
   
   /* Language Name? */
-  char* hashname;
+  const char* hashname;
   {
     char name[256];
     sprintf(name,"LANGUAGE_%d",selected_lang+1);
@@ -358,7 +358,7 @@ void LANG_LOAD(char* limit_to) {
           if (strnotempty(extkey) && strnotempty(value)) {
             int len;
             char* buff;
-            char* intkey;
+            const char* intkey;
             
             intkey=LANGINTKEY(extkey);
             

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -247,7 +247,7 @@ void LANG_LOAD(char* limit_to) {
         linput_cpp(fp,intkey,8000);
         linput_cpp(fp,key,8000);
         if (strnotempty(intkey) && strnotempty(key)) {
-          char* test=LANGINTKEY(key);
+          const char* test=LANGINTKEY(key);
 
           /* Increment for multiple definitions */
           if (strnotempty(test)) {
@@ -260,7 +260,7 @@ void LANG_LOAD(char* limit_to) {
             }  while (strnotempty(test));
           }
 
-          if (!strnotempty(test)) {         // éviter doublons
+          if (!strnotempty(test)) {         // ï¿½viter doublons
             // conv_printf(key,key);
             size_t len;
             char* buff;
@@ -366,7 +366,7 @@ void LANG_LOAD(char* limit_to) {
               
               /* Increment for multiple definitions */
               {
-                char* test=LANGSEL(intkey);
+                const char* test=LANGSEL(intkey);
                 if (strnotempty(test)) {
                   if (loops == 0) {
                     int increment=0;
@@ -577,7 +577,7 @@ void LANG_LOAD(char* limit_to) {
     }
     WORD acp = GetACP();
     if (NewLangFileCP != CP_THREAD_ACP && NewLangFileCP != acp) {
-      char* currName = LANGUAGE_WINDOWSID;
+      const char* currName = LANGUAGE_WINDOWSID;
       LCID thl = GetThreadLocale();
       WORD sid = SORTIDFROMLCID(thl);
       WORD lid = 0;
@@ -642,7 +642,7 @@ void LANG_DELETE() {
   coucal_delete(&NewLangStrKeys);
 }
 
-// sélection de la langue
+// sï¿½lection de la langue
 void LANG_INIT() {
   CWinApp* pApp = AfxGetApp();
   if (pApp) {
@@ -699,24 +699,24 @@ char* LANGSEL(char* lang0,...) {
 }
 */
 
-char* LANGSEL(char* name) {
+const char* LANGSEL(const char* name) {
   intptr_t adr = 0;
   if (NewLangStr)
   if (!coucal_read(NewLangStr,name,&adr))
     adr = NULL;
   if (adr) {
-    return (char*)adr;
+    return (const char*)adr;
   }
   return "";
 }
 
-char* LANGINTKEY(char* name) {
+const char* LANGINTKEY(const char* name) {
   intptr_t adr = 0;
   if (NewLangStrKeys)
   if (!coucal_read(NewLangStrKeys,name,&adr))
     adr=NULL;
   if (adr) {
-    return (char*)adr;
+    return (const char*)adr;
   }
   return "";
 }

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -7,8 +7,8 @@ void LANG_INIT();
 int LANG_T(int);
 int QLANG_T(int l);
 //char* LANGSEL(char* lang0,...);
-char* LANGSEL(char* name);
-char* LANGINTKEY(char* name);
+const char* LANGSEL(const char* name);
+const char* LANGINTKEY(const char* name);
 void LANG_DELETE();
 void conv_printf(char* from,char* to);
 #define LANG(A) A

--- a/WinHTTrack/trans.cpp
+++ b/WinHTTrack/trans.cpp
@@ -267,9 +267,9 @@ BOOL Ctrans::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     nID = ::GetDlgCtrlID((HWND)nID);
     if(nID)
     {
-      char* st=GetTip((int)nID);
+      const char* st=GetTip((int)nID);
       if (st != "") {
-        pTTT->lpszText = st;
+        pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);
       }
@@ -277,7 +277,7 @@ BOOL Ctrans::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
   }
   return(FALSE);
 }
-char* Ctrans::GetTip(int ID)
+const char* Ctrans::GetTip(int ID)
 {
   switch(ID) {
   case IDC_rasid: return LANG_J8b; break;

--- a/WinHTTrack/trans.h
+++ b/WinHTTrack/trans.h
@@ -3,6 +3,7 @@
 
 #if _MSC_VER >= 1000
 #pragma once
+#include "resource.h"
 #endif // _MSC_VER >= 1000
 // trans.h : header file
 //

--- a/WinHTTrack/trans.h
+++ b/WinHTTrack/trans.h
@@ -53,7 +53,7 @@ public:
 
 // Implementation
 protected:
-  char* GetTip(int id);
+  const char* GetTip(int id);
   void OnHelpInfo2();
   void FillProviderList(int fill);
   BOOL isfilled;

--- a/WinHTTrack/vcpkg.json
+++ b/WinHTTrack/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "winhttrack",
+  "version-string": "3.49",
+  "dependencies": [
+    "openssl",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
Brings WinHTTrack up to a modern VS2022 (v143) build and adds a Windows CI to prove it. The new `WinHTTrack.vcxproj`, `Directory.Build.props`, `httrack.props`, `vcpkg.json` and `app.manifest` sit alongside the legacy VS2008 `.vcproj`, which stays intact until the port is validated in the IDE. The decided dynamic profile is applied throughout: shared MFC, `/MD`, and OpenSSL/zlib as DLLs via the non-static vcpkg triplets. MBCS is kept, since the code is char*-locked.

The GUI now compiles clean: 1280 errors down to 0 under C++17 and `/permissive-`, driven by the CI over four passes. Most of it was const-correctness. A string literal is `const char[N]` in C++17, so `LANGSEL` and the 26 per-dialog `GetTip` tooltip accessors had to take and return `const char*`, which then propagated through their callers. The only casts are at the Win32 boundaries, where `TOOLTIPTEXT.lpszText` is an `LPSTR`. The rest were genuine bugs: `"..."LLintP"..."` was being read as a user-defined-literal suffix (the same misparse was corrupting the `sprintf` argument types), `Wspiapi.h` declares a template but was pulled in under `extern "C"`, and `IDD_*` was not visible in four wizard-page headers.

The build now reaches the linker and stops at `LNK1181: cannot open input file 'libhttrack.lib'`. That one is engine-side: `libhttrack` has to be built as a `/MD` DLL for x86 and x64 before the link can succeed. CI stays non-gating until then, and uploads the MSBuild log so the remaining distance stays visible.

Two real warnings are left for a follow-up: `WinHTTrack.cpp` uses the deprecated `GetVersion`, and has a `sprintf` format mismatch.
