### PR TITLE
Fix the tooltip pointer comparison, repair mangled Latin-1, and gate CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,12 +1,10 @@
-# Windows build bootstrap for WinHTTrack (VS2022 v143 + vcpkg).
+# Windows build for WinHTTrack (VS2022 v143 + vcpkg).
 #
-# NON-GATING for now: the build step is allowed to fail. A fully green build
-# still needs two things this workflow cannot provide yet:
-#   1. libhttrack.lib built on Windows (engine-side work, see ENGINE-HANDOFF).
-#   2. The MFC-MBCS libraries on the runner (a separate VS component; the probe
-#      step below reports whether they are present).
-# Until then this proves the toolchain, vcpkg, and engine-header wiring, and
-# uploads the MSBuild log so we can watch the port compile further each run.
+# The COMPILE is gating: the GUI compiles clean, and this keeps it that way.
+# The LINK is not, because it still needs libhttrack.lib built on Windows
+# (engine-side work). So we run the build, then fail only on compile errors and
+# report the link separately. Once the engine ships libhttrack.lib, drop the
+# link tolerance and let the whole build gate.
 name: windows-build
 
 on:
@@ -19,6 +17,51 @@ permissions:
   contents: read
 
 jobs:
+  # Cheap guard for the rules .gitattributes cannot enforce on its own.
+  encoding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Byte-exact on purpose. The sources are ISO-8859-1 (accented French
+      # comments), and grep-family tools treat them as binary and silently match
+      # nothing, so a shell-based guard here would never fire.
+      - name: Encoding and line endings
+        run: |
+          python3 - <<'EOF'
+          import subprocess, sys
+
+          def tracked(*globs):
+              out = subprocess.run(['git', 'ls-files', *globs],
+                                   capture_output=True, text=True, check=True).stdout
+              return [p for p in out.splitlines() if p]
+
+          LF_ONLY = tracked('*.cpp', '*.h')
+          CRLF_ONLY = tracked('*.rc', '*.rc2', '*.def', '*.idl', '*.rgs', '*.sln',
+                              '*.vcproj', '*.vcxproj', '*.props', '*.manifest',
+                              '*.dsp', '*.dsw')
+          bad = []
+
+          # A UTF-8-assuming editor rewrites the Latin-1 bytes to U+FFFD and
+          # destroys the text. That is silent in review; fail loudly instead.
+          for p in LF_ONLY + CRLF_ONLY + tracked('*.rc'):
+              if b'\xef\xbf\xbd' in open(p, 'rb').read():
+                  bad.append(f'{p}: contains U+FFFD; a UTF-8 tool mangled the Latin-1 text')
+
+          for p in LF_ONLY:
+              if b'\r' in open(p, 'rb').read():
+                  bad.append(f'{p}: has CRLF, must be LF')
+
+          for p in CRLF_ONLY:
+              data = open(p, 'rb').read()
+              if data and b'\n' in data and b'\r\n' not in data:
+                  bad.append(f'{p}: has LF, must stay CRLF (Windows tooling input)')
+
+          if bad:
+              print('\n'.join(bad))
+              sys.exit(1)
+          print(f'OK: {len(LF_ONLY)} LF sources, {len(CRLF_ONLY)} CRLF tooling files, no mojibake.')
+          EOF
+
   build:
     runs-on: windows-2022
     strategy:
@@ -32,8 +75,8 @@ jobs:
         with:
           path: httrack-windows
 
-      # The vcxproj resolves $(HttrackRoot) to ..\httrack, so the engine must be
-      # the sibling of httrack-windows in the workspace. coucal is its submodule.
+      # $(HttrackRoot) resolves to ..\httrack, so the engine must be a sibling.
+      # coucal is the engine's own submodule.
       - name: Checkout httrack engine (sibling)
         uses: actions/checkout@v4
         with:
@@ -44,25 +87,13 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
 
-      # Report VS version and whether MFC / MBCS components are installed.
-      # If MBCS is missing, the compile fails at <afxwin.h>, so the probe reports it up front.
-      - name: Probe toolchain
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          & $vswhere -latest -products * -property catalog_productDisplayVersion
-          $comps = & $vswhere -latest -products * -property packages
-          $mfc  = $comps | Select-String -Pattern 'MFC' -SimpleMatch
-          Write-Host "MFC-related components present:"
-          $mfc
-
       - name: Enable vcpkg MSBuild integration
         shell: pwsh
         run: vcpkg integrate install
 
-      # continue-on-error: the link cannot succeed until libhttrack.lib exists.
-      - name: Build WinHTTrack (bootstrap, non-gating)
-        id: build
+      # Runs to completion so we capture both compile and link results; the
+      # gate below decides what actually fails the job.
+      - name: Build
         continue-on-error: true
         working-directory: httrack-windows
         shell: pwsh
@@ -73,6 +104,30 @@ jobs:
             /p:Platform=${{ matrix.platform }} `
             /p:VcpkgEnableManifest=true `
             /flp:LogFile=msbuild.log`;Verbosity=normal
+
+      # GATE: any compiler error fails the job. The engine link gap does not.
+      - name: Gate on compile errors
+        working-directory: httrack-windows
+        shell: pwsh
+        run: |
+          if (-not (Test-Path msbuild.log)) { throw "msbuild.log missing; the build did not run" }
+          $log = Get-Content msbuild.log -Raw
+          $compileErrors = [regex]::Matches($log, 'error C\d+') | ForEach-Object { $_.Value } | Sort-Object -Unique
+          if ($compileErrors) {
+            Write-Host "::error::WinHTTrack no longer compiles clean: $($compileErrors -join ', ')"
+            [regex]::Matches($log, '(?m)^.*error C\d+.*$') |
+              Select-Object -First 25 | ForEach-Object { Write-Host $_.Value.Trim() }
+            exit 1
+          }
+          Write-Host "Compile is clean (0 compiler errors)."
+          if ($log -match "cannot open input file 'libhttrack\.lib'") {
+            Write-Host "::notice::Link is still blocked on libhttrack.lib (engine-side); not gating on it."
+          } elseif ($log -match 'error LNK\d+') {
+            $lnk = [regex]::Matches($log, 'error LNK\d+') | ForEach-Object { $_.Value } | Sort-Object -Unique
+            Write-Host "::warning::Unexpected link errors: $($lnk -join ', ')"
+          } else {
+            Write-Host "::notice::Link succeeded. Time to make the whole build gating."
+          }
 
       - name: Upload MSBuild log
         if: always()

--- a/WinHTTrack/AddFilter.cpp
+++ b/WinHTTrack/AddFilter.cpp
@@ -196,7 +196,7 @@ BOOL CAddFilter::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/CatchUrl.cpp
+++ b/WinHTTrack/CatchUrl.cpp
@@ -74,7 +74,7 @@ BOOL CCatchUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/DialogHtmlHelp.cpp
+++ b/WinHTTrack/DialogHtmlHelp.cpp
@@ -232,7 +232,7 @@ BOOL CDialogHtmlHelp::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResul
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/Infoend.cpp
+++ b/WinHTTrack/Infoend.cpp
@@ -189,7 +189,7 @@ BOOL Cinfoend::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -118,7 +118,7 @@ BOOL CInsertUrl::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/Iplog.cpp
+++ b/WinHTTrack/Iplog.cpp
@@ -281,7 +281,7 @@ BOOL Ciplog::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -291,7 +291,7 @@ BOOL CMainTab::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st = GetTip((int) nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -363,7 +363,7 @@ BOOL CNewProj::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab1.cpp
+++ b/WinHTTrack/OptionTab1.cpp
@@ -115,7 +115,7 @@ BOOL COptionTab1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab10.cpp
+++ b/WinHTTrack/OptionTab10.cpp
@@ -241,7 +241,7 @@ BOOL COptionTab10::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab11.cpp
+++ b/WinHTTrack/OptionTab11.cpp
@@ -168,7 +168,7 @@ BOOL COptionTab11::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -154,7 +154,7 @@ BOOL COptionTab2::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab3.cpp
+++ b/WinHTTrack/OptionTab3.cpp
@@ -140,7 +140,7 @@ BOOL COptionTab3::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab4.cpp
+++ b/WinHTTrack/OptionTab4.cpp
@@ -112,7 +112,7 @@ BOOL COptionTab4::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab5.cpp
+++ b/WinHTTrack/OptionTab5.cpp
@@ -127,7 +127,7 @@ BOOL COptionTab5::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -105,7 +105,7 @@ BOOL COptionTab6::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -273,7 +273,7 @@ BOOL COptionTab7::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -140,7 +140,7 @@ BOOL COptionTab8::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -130,7 +130,7 @@ BOOL COptionTab9::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/ProxyId.cpp
+++ b/WinHTTrack/ProxyId.cpp
@@ -119,7 +119,7 @@ BOOL CProxyId::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/StdAfx.h
+++ b/WinHTTrack/StdAfx.h
@@ -25,6 +25,9 @@
 #endif // _MSC_VER >= 1000
 
 #define VC_EXTRALEAN		// Exclude rarely-used stuff from Windows headers
+// Keep <windows.h> from pulling winsock v1, which would clash with the winsock2
+// headers below. VC_EXTRALEAN happens to imply this today; do not rely on that.
+#define WIN32_LEAN_AND_MEAN
 
 #include <afxwin.h>         // MFC core and standard components
 #include <afxext.h>         // MFC extensions

--- a/WinHTTrack/TreeViewToolTip.cpp
+++ b/WinHTTrack/TreeViewToolTip.cpp
@@ -61,7 +61,7 @@ BOOL CTreeViewToolTip::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResu
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -516,7 +516,7 @@ BOOL Wid1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st = GetTip((int) nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -217,14 +217,10 @@ BOOL CWinHTTrackApp::InitInstance()
     BOOL (WINAPI*const k32_SetDllDirectoryA)(LPCSTR) = 
       (BOOL (WINAPI *)(LPCSTR))
       GetProcAddress(GetModuleHandle("kernel32.dll"), "SetDllDirectoryA");
+    /* The old GetVersion() gate only existed to tolerate pre-Windows-2000, which
+       the Windows 7 floor rules out; the call is deprecated, so drop it. */
     if (k32_SetDllDirectoryA != NULL && !k32_SetDllDirectoryA("")) {
-      /* Do no choke on NT or 98SE with KernelEx NT API (James Blough) */
-      const DWORD dwVersion = GetVersion();
-      const DWORD dwMajorVersion = (DWORD)(LOBYTE(LOWORD(dwVersion)));
-      const DWORD dwMinorVersion = (DWORD)(HIBYTE(LOWORD(dwVersion)));
-      if (dwMajorVersion >= 5) {
-        assertf(!"SetDllDirectory failed");
-      }
+      assertf(!"SetDllDirectory failed");
     }
   }
 #endif
@@ -641,7 +637,7 @@ void CWinHTTrackApp::OnFileDelete()
       int pos=st.ReverseFind('.');
       CString dir=st.Left(pos)+"\\";
       char msg[1000];
-      sprintf(msg,"%s\r\n%s",LANG_DELETECONF,dir);
+      sprintf(msg,"%s\r\n%s",LANG_DELETECONF,(LPCTSTR)dir);
       if (AfxMessageBox(msg,MB_OKCANCEL)==IDOK) {
         if (remove(st)) {
           AfxMessageBox("Error deleting "+st);

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -332,7 +332,7 @@ BOOL CWizTab::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -229,7 +229,7 @@ BOOL Cabout::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -846,7 +846,7 @@ BOOL Cinprogress::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -260,7 +260,7 @@ void LANG_LOAD(char* limit_to) {
             }  while (strnotempty(test));
           }
 
-          if (!strnotempty(test)) {         // ï¿½viter doublons
+          if (!strnotempty(test)) {         // éviter doublons
             // conv_printf(key,key);
             size_t len;
             char* buff;
@@ -642,7 +642,7 @@ void LANG_DELETE() {
   coucal_delete(&NewLangStrKeys);
 }
 
-// sï¿½lection de la langue
+// sélection de la langue
 void LANG_INIT() {
   CWinApp* pApp = AfxGetApp();
   if (pApp) {

--- a/WinHTTrack/trans.cpp
+++ b/WinHTTrack/trans.cpp
@@ -268,7 +268,7 @@ BOOL Ctrans::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
     if(nID)
     {
       const char* st=GetTip((int)nID);
-      if (st != "") {
+      if (st != NULL && *st) {
         pTTT->lpszText = (LPSTR)st;
         pTTT->hinst = AfxGetResourceHandle();
         return(TRUE);


### PR DESCRIPTION
Follow-ups from the review of #8, plus the checks that would have caught them.

Two real bugs. The tooltip handlers tested `st != ""`, comparing the pointer from `GetTip` against the address of an unrelated `""` literal rather than the string. Whether that was ever true depended on the linker folding identical literals (`/GF` and `/OPT:ICF` are on in Release, and `LANGSEL`'s `""` lives in another translation unit), so the "no tip for this control" path was unreliable. All 26 `GetTip` sites now test the string; the five `st != ""` comparisons on a `CString` are left alone, since `operator!=` there does compare the text and was already correct. Separately, `sprintf` was handed a `CString` for a `%s` conversion (C4477), and the deprecated `GetVersion` (C4996) only gated an assert on "major >= 5" to tolerate Windows 98SE and NT, which the Windows 7 floor makes always true, so the whole probe goes with it.

One repair. The const pass in #8 ran a UTF-8-assuming editor over these ISO-8859-1 sources and rewrote two accented characters in `newlang.cpp` as U+FFFD, destroying them: `éviter doublons` and `sélection de la langue` both lost their e-acute. That reached master. The original bytes are restored here.

CI now enforces what it previously only reported. The compile is clean, so a compile regression fails the job; the link is still tolerated because it needs `libhttrack.lib` from the engine, and once that lands the tolerance should go and the whole build should gate. A new encoding job fails on U+FFFD, on CRLF in the LF-only C++ sources, and on LF in the Windows tooling inputs that must stay CRLF. It is written in Python deliberately: grep treats these Latin-1 files as binary and silently matches nothing, so a shell guard would never have fired. I verified it both ways, clean and against the real corruption.

Also hardened the PCH with an explicit `WIN32_LEAN_AND_MEAN`; the winsock2 headers currently avoid clashing with winsock v1 only because `VC_EXTRALEAN` happens to imply it.

Still out of reach here: dropping `Wspiapi` (the engine header is what drags the template in) and switching the `.sln` to the `.vcxproj` (wants the engine ported too).
