### PR TITLE
Fix the CString printf calls and the PCH-hidden define

### DIFF
--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -172,7 +172,7 @@ UINT RunBackCatchServer( LPVOID pP ) {
         structcheck(dest);
       }
       do {
-        sprintf(dest,"%s%s%d",_this->dest_path,"hts-post",i);
+        sprintf(dest,"%s%s%d",(LPCTSTR)_this->dest_path,"hts-post",i);
         i++;
       } while(fexist(dest));
       {

--- a/WinHTTrack/LaunchHelp.cpp
+++ b/WinHTTrack/LaunchHelp.cpp
@@ -1,9 +1,11 @@
 // LaunchHelp.cpp : implementation file
 //
 
-#define VIEW_HELP 0
-
 #include "stdafx.h"
+
+/* Must follow the PCH include: anything before it is discarded, so defining
+   this above would silently do nothing. */
+#define VIEW_HELP 0
 #include "LaunchHelp.h"
 #include "DialogHtmlHelp.h"
 #include "process.h"

--- a/WinHTTrack/OptionTab10.cpp
+++ b/WinHTTrack/OptionTab10.cpp
@@ -160,6 +160,11 @@ BOOL COptionTab10::OnInitDialog()
     
     // Launch proxy name search
     int i=0;
+    /* WSAAsyncGetHostByName is deprecated (IPv4-only). This whole block is a
+       1990s LAN heuristic that DNS-probes "proxy", "gateway", "firewall" and
+       friends on first run; it is a candidate for removal rather than a port. */
+#pragma warning(push)
+#pragma warning(disable: 4996)
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="proxy")   ,this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="www")     ,this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="ns")      ,this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
@@ -169,6 +174,7 @@ BOOL COptionTab10::OnInitDialog()
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="gateway") ,this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="firewall"),this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
     WSAAsyncGetHostByName(this->m_hWnd,wm_ProxySearch+i,(ProxyDetectName[i]="cache")   ,this->ProxyDetectBuff[i],sizeof(this->ProxyDetectBuff[i])); i++;
+#pragma warning(pop)
     
   }
   

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -395,7 +395,7 @@ int Save_current_profile(int ask) {
       return IDNO;
     int r;
     char msg[256];
-    sprintf(msg,"%s?\r\n%s",LANG_SAVEPROJECT,dialog0->GetName());
+    sprintf(msg,"%s?\r\n%s",LANG_SAVEPROJECT,(LPCTSTR)dialog0->GetName());
     if ((r=AfxMessageBox(msg,MB_YESNOCANCEL)) != IDYES)
       return r;
   }
@@ -1626,7 +1626,7 @@ int inprogress_refresh() {
           }
         } else {
           if (icn) {  // minimisée
-            sprintf(info,"[%s]",lnk);
+            sprintf(info,"[%s]",(LPCTSTR)lnk);
           } else {
             char byteb[256];
             sprintf(byteb, LLintP, SInfo.stat_bytes);
@@ -2304,7 +2304,7 @@ int MyWriteProfileInt(CString path,CString dummy,CString name,int value) {
 }
 int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value) {
   if (fp) {
-    fprintf(fp,"%s=%d\x0d\x0a", name, value);
+    fprintf(fp,"%s=%d\x0d\x0a", (LPCTSTR)name, value);
   }
   return 0;
 }
@@ -2331,7 +2331,7 @@ int MyWriteProfileString(CString path,CString dummy,CString name,CString value) 
 }
 int MyWriteProfileStringFile(FILE* fp,CString dummy,CString name,CString value) {
   if (fp) {
-    fprintf(fp,"%s=%s\x0d\x0a", name, profile_code(value.GetBuffer(0)).GetBuffer(0));
+    fprintf(fp,"%s=%s\x0d\x0a", (LPCTSTR)name, profile_code(value.GetBuffer(0)).GetBuffer(0));
   }
   return 0;
 }
@@ -2360,7 +2360,7 @@ int MyGetProfileIntFile(FILE* fp,CString dummy,CString name,int value) {
   if (fp) {
     char srch[256];
     fseek(fp,0,SEEK_SET);
-    sprintf(srch,"%s=",name);
+    sprintf(srch,"%s=",(LPCTSTR)name);
     while(!feof(fp)) {
       char s[2048]; s[0]='\0';
       linput(fp,s,2000);
@@ -2400,7 +2400,7 @@ CString MyGetProfileStringFile(FILE* fp,CString dummy,CString name,CString value
   if (fp) {
     char srch[256];
     fseek(fp,0,SEEK_SET);
-    sprintf(srch,"%s",name);
+    sprintf(srch,"%s",(LPCTSTR)name);
     strcatbuff(srch,"=");
     while(!feof(fp)) {
       char s[32768]; s[0]='\0';


### PR DESCRIPTION
Clears the warnings the VS2022 build surfaced, now that it compiles clean.

Seven of them were the same real bug: `sprintf`/`fprintf` handed a `CString` for a `%s` conversion (C4477), in `Shell.cpp` and `InsertUrl.cpp`. It only appears to work because `CString`'s single member is the pointer; passing a class through varargs is undefined, and MSVC now warns about it. They take `(LPCTSTR)` now. This is the same bug already fixed once in `WinHTTrack.cpp`.

One was a latent trap. `LaunchHelp.cpp` defined `VIEW_HELP` *before* including `stdafx.h`, and everything ahead of the precompiled-header include is discarded, so the define never reached the `#if VIEW_HELP` blocks below it (C4603). It was harmless only by luck: the value is 0, and an undefined macro also tests false. Setting it to 1 would have been silently ignored. It now follows the include.

The last one is a question rather than a fix. `OptionTab10.cpp` calls the deprecated, IPv4-only `WSAAsyncGetHostByName` nine times to DNS-probe `proxy`, `www`, `ns`, `web`, `ntserv`, `gate`, `gateway`, `firewall` and `cache` on first run, looking for a LAN proxy. Modern networks use WPAD or the system proxy settings, so porting this to `GetAddrInfoEx` would be effort spent on something that probably wants deleting. I scoped the warning and left a comment rather than decide that unilaterally.
