### PR TITLE
Cast the two CStrings reaching a printf the compiler cannot check

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -3012,7 +3012,7 @@ void Build_TopIndex(BOOL check_empty) {
               CString path=to_delete.Left(pos);
               to_delete=to_delete.Mid(pos+1);
               CString str;
-              str.Format(LANG_DELETEEMPTYCONF,path);
+              str.Format(LANG_DELETEEMPTYCONF,(LPCTSTR)path);
               if (AfxMessageBox(str,MB_OKCANCEL)==IDOK) {
                 /* éliminer au besoin le .whtt */
                 DeleteFile(path+".whtt");

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1630,7 +1630,7 @@ int inprogress_refresh() {
           } else {
             char byteb[256];
             sprintf(byteb, LLintP, SInfo.stat_bytes);
-            sprintf(info,LANG(LANG_F18),lnk,byteb);
+            sprintf(info,LANG(LANG_F18),(LPCTSTR)lnk,byteb);
           }
         }
         if (strcmp(info,last_info)) {       /* a changé */


### PR DESCRIPTION
Two `CString` values reach a variadic sink through a format string the compiler cannot see, which is the same undefined behaviour fixed in #10 and the reason C4477 stayed silent about them: `LANG(LANG_F18)` and `LANG_DELETEEMPTYCONF` are `LANGSEL()` lookups resolved at runtime, not literals, so MSVC has nothing to check the arguments against.

- `Shell.cpp:1633` — `sprintf(info, LANG(LANG_F18), lnk, byteb)`, where `lnk` is a `CString`.
- `Shell.cpp:3015` — `str.Format(LANG_DELETEEMPTYCONF, path)`, where `path` is a `CString`. `CString::Format` is variadic too.

I found the second one only after review pushed back on my claim that the first was the last of them. My audit had grepped `.Format()` calls for a `%s` — but a runtime format has no `%s` anywhere in the source, which is precisely why the compiler is blind to these as well. Searching properly, for every variadic sink whose format argument is not a string literal, turns up exactly two `CString` arguments in the tree, and these are both. The rest pass a `char[]`, an `int`, or a `const char*`, or have a literal-macro format that C4477 already vouches for.

Neither is a live miscompile today: MFC's `CString` holds nothing but the buffer pointer, so passing the object already pushed the same bytes the cast now pushes explicitly. What the casts remove is the formal UB, and the trap waiting for anyone who later builds this Unicode.
