### PR TITLE
Fix the duplicate dpiAware that stopped the exe from starting

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -171,6 +171,35 @@ jobs:
           if ($fail) { $fail | ForEach-Object { Write-Host "::error::$_" }; exit 1 }
           Write-Host "CRT check passed: both share [$exeRt]."
 
+      # An invalid embedded manifest does not fail the build: Windows refuses to
+      # start the exe with "side-by-side configuration is incorrect", which only
+      # shows up on a user's machine. That shipped once, because mt.exe merges
+      # manifest inputs by concatenation and MSBuild was quietly adding its own
+      # dpiaware.manifest next to ours, leaving two <dpiAware> elements.
+      - name: Validate the embedded manifest
+        shell: pwsh
+        run: |
+          $exe = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}\WinHTTrack.exe"
+          $mt = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\mt.exe" |
+                Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $mt) { throw "mt.exe not found" }
+          & $mt.FullName -nologo -inputresource:"$exe;#1" -out:embedded.manifest
+          if ($LASTEXITCODE -ne 0) { throw "the exe has no embedded manifest" }
+
+          $txt = Get-Content embedded.manifest -Raw
+          try { [xml]$null = $txt } catch { throw "embedded manifest is not well-formed XML: $_" }
+
+          # windowsSettings takes each element at most once; a repeat is what makes
+          # the loader reject the whole side-by-side configuration.
+          $names = [regex]::Matches($txt, '<(dpiAware|dpiAwareness|longPathAware|heapType)\b') |
+                   ForEach-Object { $_.Groups[1].Value }
+          $dupes = $names | Group-Object | Where-Object { $_.Count -gt 1 }
+          if ($dupes) {
+            Write-Host $txt
+            throw "embedded manifest repeats: $($dupes.Name -join ', ') -- Windows will refuse to start the app"
+          }
+          Write-Host "Embedded manifest OK: $($names -join ', ')"
+
       # Stage a package that actually runs. The OpenSSL and zlib DLLs are NOT
       # beside the exe: the GUI calls neither, so it imports neither, and vcpkg's
       # applocal deploy only copies what the binary it just linked imports. They

--- a/WinHTTrack/WinHTTrack.vcxproj
+++ b/WinHTTrack/WinHTTrack.vcxproj
@@ -53,6 +53,11 @@
   <PropertyGroup>
     <OutDir>$(MSBuildThisFileDirectory)bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <!-- Supply the manifest ourselves. Left on, MSBuild also feeds its own
+         dpiaware.manifest to mt.exe, which concatenates rather than merges: the
+         exe ends up with two <dpiAware> elements and Windows rejects it with
+         "side-by-side configuration is incorrect". -->
+    <EnableDpiAwareness>false</EnableDpiAwareness>
     <LinkIncremental Condition="'$(Configuration)'=='Debug'">true</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)'=='Release'">false</LinkIncremental>
   </PropertyGroup>

--- a/WinHTTrack/app.manifest
+++ b/WinHTTrack/app.manifest
@@ -23,11 +23,11 @@
     </application>
   </compatibility>
 
-  <!-- DPI awareness; degrades to system-aware on Win7/8. Aspirational for old MFC MBCS (PHASE1 risk #4). -->
+  <!-- System-DPI aware. Per-monitor was claimed here before it was ever tested,
+       and this dialog layout dates from 1998; claim it again only with evidence. -->
   <asmv3:application>
     <asmv3:windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
 


### PR DESCRIPTION
A fresh install would not launch WinHTTrack: *"its side-by-side configuration is incorrect"*. It is not the redistributable. Since VS2015 the CRT and MFC are ordinary DLLs, not side-by-side assemblies, and a missing redist says `VCRUNTIME140.dll was not found` instead.

Pulling the manifest back out of the shipped exe shows the real cause. It contains `<dpiAware>` twice:

```xml
<dpiAware ...>true/pm</dpiAware>
<dpiAware ...>true</dpiAware>
```

`mt.exe` merges manifest inputs by concatenating them, and the project left `EnableDpiAwareness` on, so MSBuild passed it its own `dpiaware.manifest` alongside ours. Two elements where the schema permits one, and the loader rejects the entire side-by-side configuration. The build never complains; it fails on the user's machine, which is the worst place to find out.

So `EnableDpiAwareness` is off and `app.manifest` is the only source. I also stopped claiming `PerMonitorV2` while I was in there. That was written before any of this had ever been run, over dialogs laid out in 1998, and review had already called it aspirational; system-DPI is what we can actually stand behind. Claim per-monitor again when there is evidence for it.

CI now extracts the manifest from the linked exe and fails on a repeated `windowsSettings` element. I ran the check against the broken binary first to confirm it fires, rather than assume it would.
