### PR TITLE
Ship lang.def, and make the smoke test able to notice it is gone

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -213,6 +213,10 @@ jobs:
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           $eng = "httrack\src\${{ matrix.platform }}\${{ matrix.configuration }}"
           Copy-Item "$eng\*.dll" $bin
+          # lang.def is a FILE at the engine root, not inside lang\. The GUI reads it
+          # from the app directory at startup and refuses to run without it. The old
+          # installer swept it up with a wildcard; enumerating files by hand lost it.
+          Copy-Item "httrack\lang.def" $bin
           foreach ($d in @('lang', 'html', 'templates')) {
             Copy-Item "httrack\$d" (Join-Path $bin $d) -Recurse -Force
           }
@@ -238,6 +242,9 @@ jobs:
           }
           if (-not (Test-Path (Join-Path $bin 'lang\English.txt'))) {
             throw "package is missing lang/: the GUI would start with no interface strings"
+          }
+          if (-not (Test-Path (Join-Path $bin 'lang.def'))) {
+            throw "package is missing lang.def: the GUI refuses to start without it"
           }
 
           # mfc140/vcruntime140/msvcp140 are NOT shipped here; they come from the
@@ -319,7 +326,20 @@ jobs:
           # `-notmatch ''` false: the version assertion would quietly stop asserting.
           if ([string]::IsNullOrWhiteSpace($env:APPVER)) { throw 'APPVER is unset: the version check would be vacuous' }
           if ($out -notmatch [regex]::Escape($env:APPVER)) { throw "expected version $env:APPVER, got '$out'" }
-          Write-Host "::notice::WinHTTrack $env:APPVER installs and runs."
+          # --version only proves the binary LOADS: it exits before any data file is
+          # touched. That is exactly why a missing lang.def shipped. --selftest runs
+          # the real startup, through LANG_INIT, and exits before showing a window.
+          $p = Start-Process $exe -ArgumentList '--selftest' -Wait -PassThru `
+                 -RedirectStandardOutput "$PWD\selftest.txt" -RedirectStandardError "$PWD\selftest.err"
+          $so = (Get-Content "$PWD\selftest.txt" -Raw -ErrorAction SilentlyContinue)
+          $se = (Get-Content "$PWD\selftest.err" -Raw -ErrorAction SilentlyContinue)
+          Write-Host "WinHTTrack.exe --selftest -> exit=$($p.ExitCode)"
+          if ($so) { Write-Host "  stdout: $($so.Trim())" }
+          if ($se) { Write-Host "  stderr: $($se.Trim())" }
+          if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
+          if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
+
+          Write-Host "::notice::WinHTTrack $env:APPVER installs, starts and runs."
 
           $unins = Get-ChildItem "$dir\unins*.exe" | Select-Object -First 1
           $p = Start-Process $unins.FullName -Wait -PassThru -ArgumentList '/VERYSILENT','/NORESTART'

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -73,6 +73,9 @@ Source: "{#EngineDir}\httrack-doc.html"; DestDir: "{app}"; Flags: ignoreversion 
 Source: "{#EngineDir}\history.txt"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#EngineDir}\license.txt"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#EngineDir}\greetings.txt"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "{#EngineDir}\COPYING"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "{#EngineDir}\AUTHORS"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "{#EngineDir}\gpl-fr.txt"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
 ; Sources, kept: HTTrack is GPL and shipping them is how that offer is met. The
 ; excludes are load-bearing -- CI builds inside these trees, so without them the

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -45,6 +45,9 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 
+/* Defined in WinHTTrack.cpp; set by --selftest. */
+extern int WhttSelfTest;
+
 static BOOL ShowFile(const CHAR *const filename) {
   //Load Shell helper
   const HRESULT hr = CoInitialize(NULL);
@@ -308,6 +311,15 @@ static BOOL PrintStack(char *const print_buffer,
 }
 
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace) {
+  /* Under --selftest there is no one to dismiss a system-modal box, and no one to
+     close the report viewer either: a headless run would hang on them instead of
+     failing. Report and die. Exit 2 to distinguish a crash from a plain refusal to
+     start (1). */
+  if (WhttSelfTest) {
+    fprintf(stderr, "FATAL: %s (%s:%d)\n", msg != NULL ? msg : "crash", file, line);
+    fflush(stderr);
+    ExitProcess(2);
+  }
   // Produce audit file
   const size_t filename_max = 32;
   CHAR path[MAX_PATH + 1 + filename_max];

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -206,6 +206,26 @@ static void httrackErrorCallback(const char* msg, const char* file, int line) {
   CrashReportReport(msg, file, line);
 }
 
+/* Set by --selftest. Startup failures must then report on stderr and exit non-zero
+   rather than raise a message box: nobody is there to click it, and a modal dialog
+   would hang a headless run instead of failing it. */
+int WhttSelfTest = 0;
+
+/* A GUI-subsystem process has no console of its own, so borrow the caller's -- but
+   only when stdout is not already going somewhere. If it has been redirected to a
+   pipe or a file that handle is valid, and reopening CONOUT$ would throw the output
+   away. */
+void WhttEnsureConsole(void) {
+  const HANDLE hout = GetStdHandle(STD_OUTPUT_HANDLE);
+  if (hout == NULL || hout == INVALID_HANDLE_VALUE) {
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+      FILE *out = NULL;
+      freopen_s(&out, "CONOUT$", "w", stdout);
+      freopen_s(&out, "CONOUT$", "w", stderr);
+    }
+  }
+}
+
 BOOL CWinHTTrackApp::InitInstance()
 {
   /* Answer --version without bringing up the UI, so a smoke test can prove the
@@ -216,20 +236,16 @@ BOOL CWinHTTrackApp::InitInstance()
      future Unicode switch cannot turn this into a null dereference. */
   for (int i = 1; __argv != NULL && i < __argc; i++) {
     if (strcmp(__argv[i], "--version") == 0) {
-      /* A GUI-subsystem process has no console of its own, so borrow the caller's
-         -- but only when stdout is not already going somewhere. If it has been
-         redirected to a pipe or a file, that handle is valid and reopening
-         CONOUT$ would throw the output away. */
-      const HANDLE hout = GetStdHandle(STD_OUTPUT_HANDLE);
-      if (hout == NULL || hout == INVALID_HANDLE_VALUE) {
-        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-          FILE *out = NULL;
-          freopen_s(&out, "CONOUT$", "w", stdout);
-        }
-      }
+      WhttEnsureConsole();
       printf("WinHTTrack %s\n", HTTRACK_VERSION);
       fflush(stdout);
       ExitProcess(0);
+    } else if (strcmp(__argv[i], "--selftest") == 0) {
+      /* Carry on through the real startup and report from there. --version only
+         proves the binary loads; it says nothing about whether the installation
+         is complete, which is what actually broke. */
+      WhttSelfTest = 1;
+      WhttEnsureConsole();
     }
   }
 
@@ -265,6 +281,14 @@ BOOL CWinHTTrackApp::InitInstance()
   // such as the name of your company or organization.
   SetRegistryKey("WinHTTrack Website Copier");
   LANG_INIT();    // petite init langue
+
+  /* --selftest: everything that depends on the installed data files has now run
+     (lang.def above all). Report and leave before any window appears. */
+  if (WhttSelfTest) {
+    printf("WinHTTrack %s: startup ok\n", HTTRACK_VERSION);
+    fflush(stdout);
+    ExitProcess(0);
+  }
   
   /* INDISPENSABLE pour le drag&drop! */
   InitCommonControls();

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -275,8 +275,13 @@ void LANG_LOAD(char* limit_to) {
       }  // while
       fclose(fp);
     } else {
+      if (WhttSelfTest) {
+        fprintf(stderr, "FATAL: 'lang.def' not found: the installation is incomplete\n");
+        fflush(stderr);
+        ExitProcess(1);
+      }
       AfxMessageBox("FATAL ERROR\r\n'lang.def' file NOT FOUND!\r\nEnsure that the installation was complete!");
-      exit(0);
+      exit(1);
     }
   }
   
@@ -405,8 +410,13 @@ void LANG_LOAD(char* limit_to) {
         }  // while
         fclose(fp);
       } else {
+        if (WhttSelfTest) {
+          fprintf(stderr, "FATAL: 'lang.def' not found: the installation is incomplete\n");
+          fflush(stderr);
+          ExitProcess(1);
+        }
         AfxMessageBox("FATAL ERROR\r\n'lang.def' file NOT FOUND!\r\nEnsure that the installation was complete!");
-        exit(0);
+        exit(1);
       }
     }
     if (err_msg.GetLength()>0) {

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -215,6 +215,12 @@ void LANG_LOAD(char* limit_to) {
     NewLangStr=coucal_new(NewLangStrSz);
     NewLangStrKeys=coucal_new(NewLangStrKeysSz);
     if ((NewLangStr==NULL) || (NewLangStrKeys==NULL)) {
+      /* Last modal on the --selftest path: it would hang a headless run. */
+      if (WhttSelfTest) {
+        fprintf(stderr, "FATAL: cannot allocate the language tables\n");
+        fflush(stderr);
+        ExitProcess(1);
+      }
       AfxMessageBox("Error in lang.h: not enough memory");
     } else {
       coucal_value_is_malloc(NewLangStr,1);
@@ -410,12 +416,14 @@ void LANG_LOAD(char* limit_to) {
         }  // while
         fclose(fp);
       } else {
+        /* This branch is the per-language file, not lang.def: say which one. */
         if (WhttSelfTest) {
-          fprintf(stderr, "FATAL: 'lang.def' not found: the installation is incomplete\n");
+          fprintf(stderr, "FATAL: cannot open %s: the installation is incomplete\n",
+                  (const char*)LPCTSTR(lbasename));
           fflush(stderr);
           ExitProcess(1);
         }
-        AfxMessageBox("FATAL ERROR\r\n'lang.def' file NOT FOUND!\r\nEnsure that the installation was complete!");
+        AfxMessageBox("FATAL ERROR\r\n" + lbasename + " NOT FOUND!\r\nEnsure that the installation was complete!");
         exit(1);
       }
     }

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -7,6 +7,11 @@ void LANG_INIT();
 int LANG_T(int);
 int QLANG_T(int l);
 //char* LANGSEL(char* lang0,...);
+/* Set by --selftest (WinHTTrack.cpp): report fatals on stderr and exit non-zero
+   instead of raising a message box nobody can click. */
+extern int WhttSelfTest;
+void WhttEnsureConsole(void);
+
 const char* LANGSEL(const char* name);
 const char* LANGINTKEY(const char* name);
 void LANG_DELETE();


### PR DESCRIPTION
WinHTTrack refuses to start without `lang.def`. It reads the file from the app directory at startup and otherwise puts up *"FATAL ERROR, 'lang.def' file NOT FOUND"*. The file lives at the engine root, not inside `lang\`, and the old installer swept it up with a wildcard over that directory; replacing that wildcard with an explicit list of files lost it. It now goes into the staged payload, which fixes the published artifact and the installer together.

CI missed it because `--version` exits before any data file is touched: it proves the binary *loads*, not that it can *start*. There is now a `--selftest` that runs the real startup through `LANG_INIT` and exits before a window appears, so a missing data file fails it.

That path could not have failed honestly anyway. Both live `FATAL ERROR` branches called `exit(0)` — success — so a test that reached them would still have gone green on a broken install. They exit non-zero now, and under `--selftest` they report on stderr rather than raising a message box, since nobody is there to click it and a modal dialog would hang a headless run instead of failing it.

Also ships `COPYING`, `AUTHORS` and `gpl-fr.txt`, which that same wildcard used to cover.
