### PR TITLE
Log a stack trace for the exception behind "improper argument"

### DIFF
--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -310,11 +310,7 @@ static BOOL PrintStack(char *const print_buffer,
   return ret;
 }
 
-/* An exception MFC caught and handled -- the program lives, so no crash dialog and no
-   viewer. This exists to locate "Encountered an improper argument.": modern MFC's ENSURE
-   macros throw a CInvalidArgException in release builds where the old MFC only ASSERTed
-   in debug, so a bad argument this code has always passed now surfaces, and the box it
-   raises says nothing about where it came from. The stack trace does. */
+// An exception MFC caught and handled: log where it came from, no dialog, keep running.
 void CrashReportLogException(const char* msg) {
   static char buffer[8192];
   const size_t filename_max = 32;

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -310,6 +310,36 @@ static BOOL PrintStack(char *const print_buffer,
   return ret;
 }
 
+/* An exception MFC caught and handled -- the program lives, so no crash dialog and no
+   viewer. This exists to locate "Encountered an improper argument.": modern MFC's ENSURE
+   macros throw a CInvalidArgException in release builds where the old MFC only ASSERTed
+   in debug, so a bad argument this code has always passed now surfaces, and the box it
+   raises says nothing about where it came from. The stack trace does. */
+void CrashReportLogException(const char* msg) {
+  static char buffer[8192];
+  const size_t filename_max = 32;
+  CHAR path[MAX_PATH + 1 + filename_max];
+  char *trace = NULL;
+
+  if (PrintStack(buffer, sizeof(buffer))) {
+    trace = buffer;
+  }
+  if (GetTempPath(sizeof(path) - filename_max, path) != 0) {
+    FILE *fp;
+    strcat(path, "WinHTTrack-exception.txt");
+    if ((fp = fopen(path, "ab")) != NULL) {
+      fprintf(fp, "HTTrack " HTTRACK_VERSIONID " caught: %s\r\n",
+              msg != NULL ? msg : "(no description)");
+      if (trace != NULL) {
+        fprintf(fp, "Stack trace:\r\n%s", trace);
+      }
+      fprintf(fp, "\r\n");
+      fflush(fp);
+      fclose(fp);
+    }
+  }
+}
+
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace) {
   /* Under --selftest there is no one to dismiss a system-modal box, and no one to
      close the report viewer either: a headless run would hang on them instead of

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -42,6 +42,5 @@ void CrashReportReport(const char* msg, const char* file, int line);
 // also include an optional trace, or no trace if trace is NULL
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace);
 
-// Append a caught (non-fatal) exception and a stack trace to %TEMP%\WinHTTrack-exception.txt.
-// The program keeps running: this only records where the exception came from.
+// Append a caught, non-fatal exception and a stack trace to %TEMP%\WinHTTrack-exception.txt.
 void CrashReportLogException(const char* msg);

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -41,3 +41,7 @@ void CrashReportReport(const char* msg, const char* file, int line);
 // Report a crash, with msg as additional message, and file:line information
 // also include an optional trace, or no trace if trace is NULL
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace);
+
+// Append a caught (non-fatal) exception and a stack trace to %TEMP%\WinHTTrack-exception.txt.
+// The program keeps running: this only records where the exception came from.
+void CrashReportLogException(const char* msg);

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -141,20 +141,12 @@ LRESULT CNewProj::OnWizardNext() {
   char tempo[8192];
 
   GetDlgItemText(IDC_projpath,stp);
-  /* stp, not st: st is still empty here, so this guard never fired. */
+  // stp, not st: st is still empty here, so this guard never fired
   if (stp.GetLength() > MAX_PATH) {
     return -1;
   }
   strcpybuff(tempo,stp);
-  /* An empty base path -- a new project on a fresh install, before DefaultValues\BasePath
-     exists -- made strlen() zero and indexed tempo[-1], reading and then writing one byte
-     off the front of the buffer. */
-  {
-    const size_t len = strlen(tempo);
-    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
-      tempo[len-1]='\0';
-    }
-  }
+  StripTrailingSlash(tempo);   // an empty base path made this index tempo[-1]
   stp=tempo;
 
   // ecrire
@@ -283,14 +275,7 @@ void CNewProj::OnChangeprojpath()
 
   tempo[0] = '\0';
   strcatbuff(tempo, st);
-  /* Empty field: strlen() is 0 and this indexed tempo[-1]. */
-  {
-    const size_t len = strlen(tempo);
-    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
-      tempo[len-1]='\0';
-      //SetDlgItemTextCP(this, IDC_projpath,tempo);
-    }
-  }
+  StripTrailingSlash(tempo);
   strcatbuff(tempo,"\\");
 
   TStamp t_start = mtime_local();
@@ -598,13 +583,8 @@ BOOL CNewProj::OnKillActive( ) {
     return FALSE;
   }
   strcpybuff(tempo,st);
-  /* Empty field: strlen() is 0 and this indexed tempo[-1]. */
-  {
-    const size_t len = strlen(tempo);
-    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
-      tempo[len-1]='\0';
-      SetDlgItemTextCP(this, IDC_projpath,tempo);
-    }
+  if (StripTrailingSlash(tempo)) {
+    SetDlgItemTextCP(this, IDC_projpath,tempo);
   }
 
   UpdateData(TRUE);         // DoDataExchange

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -141,12 +141,20 @@ LRESULT CNewProj::OnWizardNext() {
   char tempo[8192];
 
   GetDlgItemText(IDC_projpath,stp);
-  if (st.GetLength() > MAX_PATH) {
+  /* stp, not st: st is still empty here, so this guard never fired. */
+  if (stp.GetLength() > MAX_PATH) {
     return -1;
   }
   strcpybuff(tempo,stp);
-  if ((tempo[strlen(tempo)-1]=='/') || (tempo[strlen(tempo)-1]=='\\'))
-    tempo[strlen(tempo)-1]='\0';
+  /* An empty base path -- a new project on a fresh install, before DefaultValues\BasePath
+     exists -- made strlen() zero and indexed tempo[-1], reading and then writing one byte
+     off the front of the buffer. */
+  {
+    const size_t len = strlen(tempo);
+    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
+      tempo[len-1]='\0';
+    }
+  }
   stp=tempo;
 
   // ecrire
@@ -275,9 +283,13 @@ void CNewProj::OnChangeprojpath()
 
   tempo[0] = '\0';
   strcatbuff(tempo, st);
-  if ((tempo[strlen(tempo)-1]=='/') || (tempo[strlen(tempo)-1]=='\\')) {
-    tempo[strlen(tempo)-1]='\0';
-    //SetDlgItemTextCP(this, IDC_projpath,tempo);
+  /* Empty field: strlen() is 0 and this indexed tempo[-1]. */
+  {
+    const size_t len = strlen(tempo);
+    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
+      tempo[len-1]='\0';
+      //SetDlgItemTextCP(this, IDC_projpath,tempo);
+    }
   }
   strcatbuff(tempo,"\\");
 
@@ -586,9 +598,13 @@ BOOL CNewProj::OnKillActive( ) {
     return FALSE;
   }
   strcpybuff(tempo,st);
-  if ((tempo[strlen(tempo)-1]=='/') || (tempo[strlen(tempo)-1]=='\\')) {
-    tempo[strlen(tempo)-1]='\0';
-    SetDlgItemTextCP(this, IDC_projpath,tempo);
+  /* Empty field: strlen() is 0 and this indexed tempo[-1]. */
+  {
+    const size_t len = strlen(tempo);
+    if (len > 0 && (tempo[len-1]=='/' || tempo[len-1]=='\\')) {
+      tempo[len-1]='\0';
+      SetDlgItemTextCP(this, IDC_projpath,tempo);
+    }
   }
 
   UpdateData(TRUE);         // DoDataExchange

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -99,6 +99,16 @@ extern HANDLE WhttMutex;
 extern const char* WhttLocation;
 #define WHTT_LOCATION(a) WhttLocation=(a)
 
+// Drop a trailing '/' or '\\', reporting whether there was one. Empty-string safe.
+inline bool StripTrailingSlash(char* s) {
+  const size_t len = (s != NULL) ? strlen(s) : 0;
+  if (len > 0 && (s[len-1] == '/' || s[len-1] == '\\')) {
+    s[len-1] = '\0';
+    return true;
+  }
+  return false;
+}
+
 #ifndef HTS_DEF_FWSTRUCT_lien_back
 #define HTS_DEF_FWSTRUCT_lien_back
 typedef struct lien_back lien_back;

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -966,12 +966,7 @@ void CWinHTTrackApp::DeleteTabs() {
   m_tabend=NULL;
 }
 
-/* "Encountered an improper argument." and friends land here: MFC catches whatever a
-   window procedure threw, shows a message box, and carries on. The box names neither
-   the call nor the argument. Modern MFC turned many of the old debug-only ASSERTs into
-   ENSURE macros that throw in release too, so arguments this code has always passed
-   are only now being rejected -- and we have no idea which. Record a stack trace, then
-   let MFC do exactly what it did before. */
+// MFC's box for a thrown exception names neither the call nor the argument; a trace does.
 LRESULT CWinHTTrackApp::ProcessWndProcException(CException* e, const MSG* pMsg) {
   TCHAR reason[512];
   CString what;

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -966,6 +966,26 @@ void CWinHTTrackApp::DeleteTabs() {
   m_tabend=NULL;
 }
 
+/* "Encountered an improper argument." and friends land here: MFC catches whatever a
+   window procedure threw, shows a message box, and carries on. The box names neither
+   the call nor the argument. Modern MFC turned many of the old debug-only ASSERTs into
+   ENSURE macros that throw in release too, so arguments this code has always passed
+   are only now being rejected -- and we have no idea which. Record a stack trace, then
+   let MFC do exactly what it did before. */
+LRESULT CWinHTTrackApp::ProcessWndProcException(CException* e, const MSG* pMsg) {
+  TCHAR reason[512];
+  CString what;
+
+  if (e == NULL || !e->GetErrorMessage(reason, _countof(reason))) {
+    _tcscpy_s(reason, _countof(reason), _T("(no description)"));
+  }
+  what.Format("%s [window message 0x%04x]", reason,
+              pMsg != NULL ? (unsigned) pMsg->message : 0u);
+  CrashReportLogException((LPCTSTR) what);
+
+  return CWinApp::ProcessWndProcException(e, pMsg);
+}
+
 int CWinHTTrackApp::ExitInstance() 
 {
   LANG_DELETE();

--- a/WinHTTrack/WinHTTrack.h
+++ b/WinHTTrack/WinHTTrack.h
@@ -58,8 +58,7 @@ private:
 	public:
 	virtual BOOL InitInstance();
 	virtual int ExitInstance();
-	// MFC catches exceptions thrown inside a window procedure and shows a box that
-	// says nothing about where they came from. Log a stack trace before it does.
+	// Log a stack trace for exceptions MFC catches in a window procedure.
 	virtual LRESULT ProcessWndProcException(CException* e, const MSG* pMsg);
 	//}}AFX_VIRTUAL
 

--- a/WinHTTrack/WinHTTrack.h
+++ b/WinHTTrack/WinHTTrack.h
@@ -58,6 +58,9 @@ private:
 	public:
 	virtual BOOL InitInstance();
 	virtual int ExitInstance();
+	// MFC catches exceptions thrown inside a window procedure and shows a box that
+	// says nothing about where they came from. Log a stack trace before it does.
+	virtual LRESULT ProcessWndProcException(CException* e, const MSG* pMsg);
 	//}}AFX_VIRTUAL
 
 // Implementation


### PR DESCRIPTION
"Encountered an improper argument." is MFC's `CInvalidArgException`: modern MFC throws where the old one only asserted in debug. The box names neither the call nor the argument, so `ProcessWndProcException` now writes a stack trace to `%TEMP%\WinHTTrack-exception.txt` and hands over to MFC unchanged. One reproduction names the throw site.

Two bugs on that path are fixed regardless: a `MAX_PATH` guard testing the wrong (empty) string, and `tempo[strlen(tempo)-1]` indexing `tempo[-1]` on an empty base path — which is what a new project has, and not an update.
