### PR TITLE
Fix the 'improper argument' box on a new project, and make crash reports name their culprit

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -248,6 +248,10 @@ jobs:
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           $eng = "httrack\src\${{ matrix.platform }}\${{ matrix.configuration }}"
           Copy-Item "$eng\*.dll" $bin
+          # Ship the PDBs: dbghelp resolves function and file:line from them at run time, so
+          # without them every frame of a user's crash report reads "unknown". The engine's
+          # is a bonus and is not ours to fix, so do not red the build over it.
+          Copy-Item "$eng\*.pdb" $bin -ErrorAction SilentlyContinue
           # lang.def is a FILE at the engine root, not inside lang\. The GUI reads it
           # from the app directory at startup and refuses to run without it. The old
           # installer swept it up with a wildcard; enumerating files by hand lost it.
@@ -280,6 +284,12 @@ jobs:
           }
           if (-not (Test-Path (Join-Path $bin 'lang.def'))) {
             throw "package is missing lang.def: the GUI refuses to start without it"
+          }
+          if (-not (Test-Path (Join-Path $bin 'WinHTTrack.pdb'))) {
+            throw "package is missing WinHTTrack.pdb: crash reports would name no function"
+          }
+          if (-not (Test-Path (Join-Path $bin 'libhttrack.pdb'))) {
+            Write-Host "::warning::no libhttrack.pdb: engine frames will not resolve"
           }
 
           # mfc140/vcruntime140/msvcp140 are NOT shipped here; they come from the
@@ -364,6 +374,8 @@ jobs:
           # --version only proves the binary LOADS: it exits before any data file is
           # touched. That is exactly why a missing lang.def shipped. --selftest runs
           # the real startup, through LANG_INIT, and exits before showing a window.
+          $report = Join-Path $env:TEMP 'WinHTTrack-exception.txt'
+          Remove-Item $report -ErrorAction SilentlyContinue
           $p = Start-Process $exe -ArgumentList '--selftest' -Wait -PassThru `
                  -RedirectStandardOutput "$PWD\selftest.txt" -RedirectStandardError "$PWD\selftest.err"
           $so = (Get-Content "$PWD\selftest.txt" -Raw -ErrorAction SilentlyContinue)
@@ -373,6 +385,20 @@ jobs:
           if ($se) { Write-Host "  stderr: $($se.Trim())" }
           if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
           if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
+
+          # --selftest throws one exception on purpose. A crash report that resolves nothing
+          # is indistinguishable from a working one until someone needs it, so assert the
+          # whole chain here: first-chance hook -> shipped PDB -> function, file and line.
+          if (-not (Test-Path $report)) { throw "no crash report written: the first-chance hook never ran" }
+          $trace = Get-Content $report -Raw
+          Write-Host "--- crash report ---`n$trace"
+          if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
+          # Anchored past the "throw site" header on purpose: CrashReportLogException is
+          # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
+          # the fallback stack and would still be green with the hook dead.
+          if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
+            throw "no file:line on the throw stack: the shipped PDB carries no line info"
+          }
 
           Write-Host "::notice::WinHTTrack $env:APPVER installs, starts and runs."
 

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,1 @@
+/home/roche/git/httrack-works/CLAUDE.httrack-windows.local.md

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -64,8 +64,9 @@ Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescri
 [Files]
 ; The program: exe, libhttrack.dll, the OpenSSL/zlib DLLs it imports, and lang/ and
 ; templates/. This is the same staged directory CI publishes, so what gets tested is
-; what gets shipped.
-Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.pdb,*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt"; Flags: recursesubdirs ignoreversion
+; what gets shipped. The PDBs ship too: without them a crash report names no function and
+; no line, and we already ship the sources they point into.
+Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt"; Flags: recursesubdirs ignoreversion
 
 ; Documentation that actually exists. The old script also listed readme, copying and
 ; file_id.diz, none of which are in the tree any more.

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -92,8 +92,10 @@ static BOOL ShowFile(const CHAR *const filename) {
   return SUCCEEDED(success);
 }
 
-static BOOL PrintStack_(char *const print_buffer, 
-                        const size_t print_buffer_size) {
+static BOOL PrintStack_(char *const print_buffer,
+                        const size_t print_buffer_size,
+                        const DWORD64 *const frames,
+                        const SIZE_T frame_count) {
   HMODULE kernel32 = LoadLibraryA("Kernel32");
   if (kernel32 == NULL)
     return FALSE;
@@ -185,29 +187,37 @@ static BOOL PrintStack_(char *const print_buffer,
   //
   // Dbghelp is is singlethreaded, so acquire a lock.
   //
-  // Note that the code assumes that 
-  // SymInitialize( GetCurrentProcess(), NULL, TRUE ) has 
+  // Note that the code assumes that
+  // SymInitialize( GetCurrentProcess(), NULL, TRUE ) has
   // already been called.
   //
-  while(StackCount < sizeof(Stack) / sizeof(Stack[0])
-    && sym.fun.StackWalk64 != NULL
-    && sym.fun.StackWalk64(MachineType,
-                           GetCurrentProcess(),
-                           GetCurrentThread(),
-                           &StackFrame,
-                           MachineType == IMAGE_FILE_MACHINE_I386 
-                           ? NULL
-                           : &Context,
-                           NULL,
-                           sym.fun.SymFunctionTableAccess64,
-                           sym.fun.SymGetModuleBase64,
-                           NULL)
-    && StackFrame.AddrPC.Offset != 0
-    && StackFrame.AddrReturn.Offset != 0
-    && StackFrame.AddrPC.Offset != StackFrame.AddrReturn.Offset
-    )
-  {
-    Stack[StackCount++] = StackFrame.AddrPC.Offset;
+  if (frames != NULL) {
+    // Frames captured elsewhere (the throw site): the live stack is not the interesting one.
+    StackCount = frame_count < sizeof(Stack) / sizeof(Stack[0])
+      ? frame_count
+      : sizeof(Stack) / sizeof(Stack[0]);
+    memcpy(Stack, frames, StackCount * sizeof(Stack[0]));
+  } else {
+    while(StackCount < sizeof(Stack) / sizeof(Stack[0])
+      && sym.fun.StackWalk64 != NULL
+      && sym.fun.StackWalk64(MachineType,
+                             GetCurrentProcess(),
+                             GetCurrentThread(),
+                             &StackFrame,
+                             MachineType == IMAGE_FILE_MACHINE_I386
+                             ? NULL
+                             : &Context,
+                             NULL,
+                             sym.fun.SymFunctionTableAccess64,
+                             sym.fun.SymGetModuleBase64,
+                             NULL)
+      && StackFrame.AddrPC.Offset != 0
+      && StackFrame.AddrReturn.Offset != 0
+      && StackFrame.AddrPC.Offset != StackFrame.AddrReturn.Offset
+      )
+    {
+      Stack[StackCount++] = StackFrame.AddrPC.Offset;
+    }
   }
 
   // Now print information
@@ -239,6 +249,16 @@ static BOOL PrintStack_(char *const print_buffer,
       module = pIHModule.ModuleName;
     }
 
+    // Offset within the module: keeps a frame resolvable offline when no PDB is around.
+    char rva[32];
+    rva[0] = '\0';
+    if (sym.fun.SymGetModuleBase64 != NULL) {
+      const DWORD64 base = sym.fun.SymGetModuleBase64(hProcess, dwAddr);
+      if (base != 0) {
+        sprintf(rva, "+0x%llx", (unsigned long long) (dwAddr - base));
+      }
+    }
+
     DWORD64 displacement;
     if (sym.fun.SymFromAddr != NULL
       && sym.fun.SymFromAddr(hProcess, dwAddr, &displacement, pSymbol)) {
@@ -261,8 +281,8 @@ static BOOL PrintStack_(char *const print_buffer,
     char lines[32];
     sprintf(lines, "%d", line);
 
-    if (print_buffer_size - print_buffer_offs 
-      < strlen(function) + strlen(file) + strlen(lines) + strlen(module) + 8)
+    if (print_buffer_size - print_buffer_offs
+      < strlen(function) + strlen(file) + strlen(lines) + strlen(module) + strlen(rva) + 8)
       break;
 
 #undef ADD_STR
@@ -281,6 +301,7 @@ static BOOL PrintStack_(char *const print_buffer,
     if (module != NULL && module[0] != '\0') {
       ADD_STR(" [");
       ADD_STR(module);
+      ADD_STR(rva);
       ADD_STR("]");
     }
     ADD_STR("\r\n");
@@ -302,12 +323,37 @@ static void PrintStackInit() {
   InitializeCriticalSection(&DbgHelpLock);
 }
 
-static BOOL PrintStack(char *const print_buffer, 
-                       const size_t print_buffer_size) {
+static BOOL PrintStack(char *const print_buffer,
+                       const size_t print_buffer_size,
+                       const DWORD64 *const frames,
+                       const SIZE_T frame_count) {
   EnterCriticalSection( &DbgHelpLock );
-  BOOL ret = PrintStack_(print_buffer, print_buffer_size);
+  BOOL ret = PrintStack_(print_buffer, print_buffer_size, frames, frame_count);
   LeaveCriticalSection( &DbgHelpLock );
   return ret;
+}
+
+/* The SEH code MSVC raises every C++ throw with. */
+#define EXCEPTION_MSVC_CXX 0xE06D7363
+
+/* Stack of the last C++ throw on this thread, held until someone reports the exception. */
+static __declspec(thread) DWORD64 ThrowStack[62];
+static __declspec(thread) USHORT ThrowStackCount;
+
+// A handler only ever sees the catch site: MFC has unwound the frames that threw by the
+// time it hands us the exception. First chance is the last moment they still exist.
+static LONG CALLBACK FirstChanceHandler(PEXCEPTION_POINTERS ptrs) {
+  if (ptrs->ExceptionRecord->ExceptionCode == EXCEPTION_MSVC_CXX) {
+    PVOID frames[sizeof(ThrowStack) / sizeof(ThrowStack[0])];
+    // Addresses only: this runs on every throw, so symbols wait until we actually report.
+    const USHORT count =
+      CaptureStackBackTrace(0, sizeof(frames) / sizeof(frames[0]), frames, NULL);
+    for(USHORT i = 0 ; i < count ; i++) {
+      ThrowStack[i] = (DWORD64) frames[i];
+    }
+    ThrowStackCount = count;
+  }
+  return EXCEPTION_CONTINUE_SEARCH;
 }
 
 // An exception MFC caught and handled: log where it came from, no dialog, keep running.
@@ -317,9 +363,12 @@ void CrashReportLogException(const char* msg) {
   CHAR path[MAX_PATH + 1 + filename_max];
   char *trace = NULL;
 
-  if (PrintStack(buffer, sizeof(buffer))) {
+  const BOOL thrown = ThrowStackCount != 0;
+  if (PrintStack(buffer, sizeof(buffer),
+                 thrown ? ThrowStack : NULL, ThrowStackCount)) {
     trace = buffer;
   }
+  ThrowStackCount = 0;    // consumed; never blame a later exception on this one
   if (GetTempPath(sizeof(path) - filename_max, path) != 0) {
     FILE *fp;
     strcat(path, "WinHTTrack-exception.txt");
@@ -327,7 +376,8 @@ void CrashReportLogException(const char* msg) {
       fprintf(fp, "HTTrack " HTTRACK_VERSIONID " caught: %s\r\n",
               msg != NULL ? msg : "(no description)");
       if (trace != NULL) {
-        fprintf(fp, "Stack trace:\r\n%s", trace);
+        fprintf(fp, "Stack trace (%s):\r\n%s",
+                thrown ? "throw site" : "handler", trace);
       }
       fprintf(fp, "\r\n");
       fflush(fp);
@@ -380,7 +430,7 @@ void CrashReportReportEx(const char* msg, const char* file, int line, const char
 void CrashReportReport(const char* msg, const char* file, int line) {
   static char buffer[2048];
   char *trace = NULL;
-  if (PrintStack(buffer, sizeof(buffer))) {
+  if (PrintStack(buffer, sizeof(buffer), NULL, 0)) {
     trace = buffer;
   }
   CrashReportReportEx(msg, file, line, trace);
@@ -422,4 +472,5 @@ static BOOL GlobalExceptionHandlerInit() {
 void CrashReportInit() {
   PrintStackInit();
   GlobalExceptionHandlerInit();
+  AddVectoredExceptionHandler(1, FirstChanceHandler);
 }

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -242,7 +242,11 @@ static BOOL PrintStack_(char *const print_buffer,
     const char *module = "";
     int line = 0;
 
-    const DWORD64 dwAddr = Stack[i];
+    /* A return address points just PAST the call, which is often the next source line --
+       that is how SetPathName got reported as the line below it. Step back into the call.
+       Only a walked frame 0 is a live PC; a captured stack is return addresses throughout. */
+    const DWORD64 dwAddr =
+      (frames == NULL && i == 0) ? Stack[i] : Stack[i] - 1;
 
     if (sym.fun.SymGetModuleInfo64 != NULL
       && sym.fun.SymGetModuleInfo64(hProcess, dwAddr, &pIHModule)) {

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -43,4 +43,6 @@ void CrashReportReport(const char* msg, const char* file, int line);
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace);
 
 // Append a caught, non-fatal exception and a stack trace to %TEMP%\WinHTTrack-exception.txt.
+// The trace is the one captured where the exception was thrown, not where it was caught;
+// CrashReportInit() must have run, or the throw site is lost and the caller's is used.
 void CrashReportLogException(const char* msg);

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -184,7 +184,13 @@ LRESULT CNewProj::OnWizardNext() {
   if (st.GetLength() > MAX_PATH) {
     return -1;
   }
-  this_CSplitterFrame->SetNewName(stp+st+".whtt");
+  const CString whtt = stp + st + ".whtt";
+  // Each half was checked against MAX_PATH, their concatenation never was, and MFC
+  // rejects a document path that long.
+  if (whtt.GetLength() >= MAX_PATH) {
+    return -1;
+  }
+  this_CSplitterFrame->SetNewName(whtt);
   //GetDlgItemText(IDC_projpath,st);
   //this_CSplitterFrame->GetActiveDocument()->SetPathName(st);
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -285,6 +285,18 @@ BOOL CWinHTTrackApp::InitInstance()
   /* --selftest: everything that depends on the installed data files has now run
      (lang.def above all). Report and leave before any window appears. */
   if (WhttSelfTest) {
+    /* Exercise the crash reporter for real: a Release PDB built without line info, or a
+       first-chance hook that never registered, both still produce a plausible-looking
+       report that names nothing. Only throwing proves the chain resolves. */
+    TRY {
+      AfxThrowInvalidArgException();
+    } CATCH_ALL(e) {
+      TCHAR reason[256];
+      if (!e->GetErrorMessage(reason, _countof(reason))) {
+        _tcscpy_s(reason, _countof(reason), _T("(no description)"));
+      }
+      CrashReportLogException(reason);
+    } END_CATCH_ALL
     printf("WinHTTrack %s: startup ok\n", HTTRACK_VERSION);
     fflush(stdout);
     ExitProcess(0);

--- a/WinHTTrack/WinHTTrack.vcxproj
+++ b/WinHTTrack/WinHTTrack.vcxproj
@@ -101,6 +101,12 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
+      <!-- Without this, /DEBUG yields a PDB with public symbols only: crash reports from a
+           release build then have no file:line, which is the half that matters. -->
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <!-- /O2 implies /Oy on x86, and x86 stack capture follows the EBP chain: omit the
+           frame pointer and a crash report from a 32-bit user truncates to noise. -->
+      <OmitFramePointers>false</OmitFramePointers>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/WinHTTrack/splitter.cpp
+++ b/WinHTTrack/splitter.cpp
@@ -312,12 +312,17 @@ BOOL CSplitterFrame::SetSaved() {
   return 1;
 }
 
-// Nommer le document
-BOOL CSplitterFrame::SetNewName(CString name) {
-  GetActiveDocument()->SetPathName(name);
-  int pos=max(name.ReverseFind('\\'),name.ReverseFind('/'))+1;
-  GetActiveDocument()->SetTitle(name.Mid(pos));
-  GetActiveDocument()->SetModifiedFlag();
+// Name the document. Deliberately not inlined: each MFC call below can throw, and LTCG
+// would fold them into the caller and report every one of them as the same source line.
+__declspec(noinline) BOOL CSplitterFrame::SetNewName(CString name) {
+  CDocument *const doc = GetActiveDocument();
+  if (doc == NULL) {
+    return 0;
+  }
+  doc->SetPathName(name);
+  const int pos = max(name.ReverseFind('\\'), name.ReverseFind('/')) + 1;
+  doc->SetTitle(name.Mid(pos));
+  doc->SetModifiedFlag();
   return 1;
 }
 

--- a/WinHTTrack/splitter.cpp
+++ b/WinHTTrack/splitter.cpp
@@ -319,7 +319,9 @@ __declspec(noinline) BOOL CSplitterFrame::SetNewName(CString name) {
   if (doc == NULL) {
     return 0;
   }
-  doc->SetPathName(name);
+  // bAddToMRU=FALSE: MFC's recent-file list throws on this not-yet-created path, and
+  // nothing reads it back -- ID_FILE_MRU_FILE1 is greyed and its handler is empty.
+  doc->SetPathName(name, FALSE);
   const int pos = max(name.ReverseFind('\\'), name.ReverseFind('/')) + 1;
   doc->SetTitle(name.Mid(pos));
   doc->SetModifiedFlag();

--- a/WinHTTrack/splitter.h
+++ b/WinHTTrack/splitter.h
@@ -22,6 +22,7 @@ protected:
 public:
   void SetMenuPrefs();
 	afx_msg void Onhide();
+  // Give the active document its path and title; FALSE if there is no active document.
   BOOL SetNewName(CString name);
   BOOL SetSaved();
   BOOL SetCurrentCategory(CString name);


### PR DESCRIPTION
Naming a new project raised "Encountered an improper argument". `CDocument::SetPathName` defaults to `bAddToMRU=TRUE`, so it pushed the not-yet-created `.whtt` into MFC's recent-file list and `CRecentFileList::Add` threw at it -- on every new project and never on an update, because `SetNewName` only runs when naming a new one. Nothing reads that list back: the menu item is greyed and `OnFileMruFile1()` is an empty stub. `OnWizardNext` also length-checked each half of the path but handed MFC their concatenation, which MFC rejects.

Finding it needed the crash reporter to work first, and it did not. `ProcessWndProcException` runs after MFC has unwound, so the frames that threw were already gone; a vectored handler now captures the stack at first chance. Release never set `DebugInformationFormat`, so `/DEBUG` was emitting a PDB with no line table at all -- hence `unknown` on every frame. That is fixed, frame pointers are kept (x86 stack capture walks the EBP chain), the PDBs ship, and a return address is symbolized one byte back so a frame stops being blamed on the line after the call.

`--selftest` throws once on purpose and CI asserts the report resolves to a function, a file and a line. A crash reporter that silently resolves nothing looks exactly like one that works, right up until you need it.