### PR TITLE
Drop the CLAUDE.local.md symlink committed by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Local, untracked Claude Code rules (often a symlink outside the repo)
+CLAUDE.local.md

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,1 +1,0 @@
-/home/roche/git/httrack-works/CLAUDE.httrack-windows.local.md


### PR DESCRIPTION
`CLAUDE.local.md` is a symlink into a private working tree and dangles for everyone else. It rode in on a stray `git add -A` in #20. Removed, and added to `.gitignore` so it cannot happen again.