### PR TITLE
Make the directory tree find what it was asked for, and stop re-reading it

### DIFF
--- a/WinHTTrack/DirTreeView.cpp
+++ b/WinHTTrack/DirTreeView.cpp
@@ -307,12 +307,21 @@ CString CDirTreeView::GetItemPath(HTREEITEM position) {
     return "";
 }
 
+HTREEITEM CDirTreeView::FindSibling(HTREEITEM first,const CString& lname) {
+  CTreeCtrl& tree=GetTreeCtrl();
+  for(HTREEITEM it=first ; it!=NULL ; it=tree.GetNextSiblingItem(it)) {
+    CString name=GetItemName(it);
+    name.MakeLower();
+    if (name==lname)
+      return it;
+  }
+  return NULL;
+}
+
 HTREEITEM CDirTreeView::GetPathItem(CString path,BOOL open,BOOL nofail,BOOL nohide,HTREEITEM rootposition) {
   CTreeCtrl& tree=GetTreeCtrl();
   if (!tree) return NULL;   /* error */
-  //
-  HTREEITEM return_value=NULL;
-  //
+
   CString left="",right="";
   int pos=path.Find('\\');
   if (pos<0)
@@ -324,50 +333,45 @@ HTREEITEM CDirTreeView::GetPathItem(CString path,BOOL open,BOOL nofail,BOOL nohi
 
   if (!nohide)
     tree.ModifyStyle(WS_VISIBLE,0);
-  
-  HTREEITEM position;
-  if (!rootposition) {
-    rootposition=tree.GetRootItem();
-    /* position initiale */
-    position=rootposition;
-  } else {
-    // Ouvrir?
-    if (open) {
-      if (tree.ItemHasChildren(rootposition)) {        /* si enfants */
-        if (!(tree.GetItemState(rootposition,TVIF_STATE) & TVIS_EXPANDED)) {    /* si non ouvert */
-          /*tree.SetItemState(rootposition,TVIF_STATE,
-            tree.GetItemState(rootposition,TVIF_STATE) | TVIS_EXPANDED);
-            */
-          tree.Expand(rootposition,TVE_EXPAND);
-          RefreshDir(rootposition,TRUE);
-        }
-      }
-      
-    }
 
-    /* position initiale */
-    position=tree.GetChildItem(rootposition);
+  const BOOL at_root=(rootposition==NULL);
+  HTREEITEM first;
+  if (at_root) {
+    rootposition=tree.GetRootItem();
+    first=rootposition;
+  } else {
+    // The mask has to be a TVIS_* bit: with TVIF_STATE this test was always true, so every
+    // lookup re-expanded and re-read the whole directory -- the FIXME in NewProj.
+    if (open
+      && tree.ItemHasChildren(rootposition)
+      && !(tree.GetItemState(rootposition,TVIS_EXPANDED) & TVIS_EXPANDED)) {
+      tree.Expand(rootposition,TVE_EXPAND);
+      // Expanding a hidden tree raises no TVN_ITEMEXPANDING, so read the directory here.
+      RefreshDir(rootposition,TRUE);
+    }
+    first=tree.GetChildItem(rootposition);
   }
 
   left.MakeLower();
-  while(position) {
-    CString st=GetItemName(position);
-    st.MakeLower();
-    if (st==left) {
-      if (right.GetLength())
-        position=GetPathItem(right,open,nofail,TRUE,position);
-      else
-        return_value=position;      // trouvé
-      position=NULL;
-    }
-    if (position)
-      position=tree.GetNextSiblingItem(position);
+  HTREEITEM found=FindSibling(first,left);
+  if (found==NULL && open && !at_root) {
+    // Created since we last read this directory -- a project folder we just made, say.
+    // Re-read it once before reporting the path missing.
+    RefreshDir(rootposition,TRUE);
+    found=FindSibling(tree.GetChildItem(rootposition),left);
   }
 
-  // liste visible
+  HTREEITEM return_value=NULL;
+  if (found!=NULL) {
+    // Keep what the recursion found: assigning it and dropping it left every nested lookup
+    // returning the top-level ancestor, so nothing ever scrolled to the item asked for.
+    return_value = right.GetLength()
+      ? GetPathItem(right,open,nofail,TRUE,found)
+      : found;
+  }
+
   if (!nohide) {
     tree.ModifyStyle(0,WS_VISIBLE);
-    //RedrawWindow();
     tree.GetParent()->RedrawWindow();
   }
   if (return_value)

--- a/WinHTTrack/DirTreeView.cpp
+++ b/WinHTTrack/DirTreeView.cpp
@@ -341,10 +341,10 @@ HTREEITEM CDirTreeView::GetPathItem(CString path,BOOL open,BOOL nofail,BOOL nohi
     first=rootposition;
   } else {
     // The mask has to be a TVIS_* bit: with TVIF_STATE this test was always true, so every
-    // lookup re-expanded and re-read the whole directory -- the FIXME in NewProj.
-    if (open
-      && tree.ItemHasChildren(rootposition)
-      && !(tree.GetItemState(rootposition,TVIS_EXPANDED) & TVIS_EXPANDED)) {
+    // lookup re-expanded and re-read the whole directory -- the FIXME in NewProj. No
+    // ItemHasChildren guard: a directory left empty has no children and no expanded state,
+    // and is precisely the one that must still be read.
+    if (open && !(tree.GetItemState(rootposition,TVIS_EXPANDED) & TVIS_EXPANDED)) {
       tree.Expand(rootposition,TVE_EXPAND);
       // Expanding a hidden tree raises no TVN_ITEMEXPANDING, so read the directory here.
       RefreshDir(rootposition,TRUE);
@@ -425,6 +425,10 @@ BOOL CDirTreeView::RefreshDir(HTREEITEM position,BOOL nohide) {
 
   CWaitCursor wait;
   CString path=GetItemPath(position);
+  // GetItemPath only appends the separator when the item has children, and an emptied
+  // directory has none -- without this the glob below would enumerate the PARENT.
+  if (path.GetLength() && path.Right(1)!="\\")
+    path+="\\";
   CString backup_visibles="\n";
 
   // Pour FindFirstFile/FindNextFile

--- a/WinHTTrack/DirTreeView.h
+++ b/WinHTTrack/DirTreeView.h
@@ -49,6 +49,9 @@ public:
 
 protected:
   BOOL RefreshDir(HTREEITEM position,BOOL nohide=FALSE);
+  // First item in the sibling chain from first whose name is lname (must be lowercase);
+  // NULL if none matches.
+  HTREEITEM FindSibling(HTREEITEM first,const CString& lname);
   void RestoreVisibles(HTREEITEM position,CString& backup_visibles);
   void RefreshPos(HTREEITEM position);
   CString GetItemPath(HTREEITEM position);


### PR DESCRIPTION
`CTreeCtrl::GetItemState` takes a `TVIS_*` state mask, and `GetPathItem` passed `TVIF_STATE` — a mask-field flag. The "is this node already expanded?" test could never be true, so every lookup re-expanded each node on the path and re-read its whole directory. That is the `// FIXME: VERY SLOW!!` in `NewProj`.

The re-read turned out to be load-bearing: it is the only thing that made a just-created folder appear, so correcting the mask alone would have stopped new projects from showing up in the tree. Re-read on a miss instead — free when the tree is current, still correct when it is not.

While in there: a nested lookup assigned the recursive result and then dropped it, falling through to the `nofail` path, which in the top frame returns `GetRootItem()`. `EnsureVisible` has never scrolled to the item it was asked for, only to the first drive. It keeps the result now.

Needs a click-through CI cannot do: create a project and check the tree reveals the new folder, and that `hts-cache` appears after Next.

The same `TVIF_STATE`-for-`TVIS_*` mistake sits at `DirTreeView.cpp:446` and `:577`, left alone here — `:577` would start allocating `FindFirstChangeNotification` handles in code that has never run, and that code writes into `whandle[1024]` unbounded while `WaitForMultipleObjects` caps out at 64.