### PR TITLE
Sign only the binaries we maintain, not OpenSSL and zlib

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -8,7 +8,9 @@ name: windows-build
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    # The engine tags releases bare: 3.49.12, 3.49.8-2. Match that, and 'v' too in
+    # case anyone reaches for it. A 'v*'-only filter would silently never fire.
+    tags: ['[0-9]*', 'v*']
   pull_request:
   workflow_dispatch:
 
@@ -343,7 +345,7 @@ jobs:
       # human to approve each request. See SIGNING.md.
       - name: Collect the binaries to sign
         id: collect
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
@@ -362,7 +364,7 @@ jobs:
 
       - name: Upload the unsigned binaries
         id: unsigned-binaries
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-binaries-${{ matrix.platform }}
@@ -370,7 +372,7 @@ jobs:
           if-no-files-found: error
 
       - name: Sign the binaries
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -385,7 +387,7 @@ jobs:
           output-artifact-directory: signed
 
       - name: Put the signed binaries back into the package
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
@@ -444,7 +446,7 @@ jobs:
       # and UAC judge. Before the smoke test, so that what runs below is what ships.
       - name: Upload the unsigned installer
         id: unsigned-installer
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-installer-${{ matrix.platform }}
@@ -452,7 +454,7 @@ jobs:
           if-no-files-found: error
 
       - name: Sign the installer
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -466,7 +468,7 @@ jobs:
           output-artifact-directory: installer
 
       - name: Check the installer really is signed
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
         shell: pwsh
         run: |
           $setup = Get-ChildItem "$PWD\installer\*.exe" | Select-Object -First 1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -348,11 +348,15 @@ jobs:
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           New-Item -ItemType Directory -Force unsigned | Out-Null
-          # OpenSSL and zlib included: vcpkg builds them from source, and an allow-by-
-          # publisher policy (WDAC, AppLocker) loads a half-signed package then refuses.
-          Copy-Item "$bin\*.exe", "$bin\*.dll" unsigned
-          foreach ($f in @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')) {
-            if (-not (Test-Path (Join-Path 'unsigned' $f))) { throw "nothing to sign: $f is missing" }
+          # Ours only. SignPath's code of conduct: "upstream OSS projects' binaries must
+          # not be signed using your subscription, but may be included in signed packages".
+          # So OpenSSL and zlib ship unsigned inside the signed installer, even though we
+          # do build them from source -- the rule is about who maintains the sources.
+          $ours = @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')
+          foreach ($f in $ours) {
+            $p = Join-Path $bin $f
+            if (-not (Test-Path $p)) { throw "nothing to sign: $f is missing" }
+            Copy-Item $p unsigned
           }
           Get-ChildItem unsigned | ForEach-Object { Write-Host "  will sign $($_.Name)" }
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -15,20 +15,27 @@ installer. That is expected, and many other open-source projects sign the same w
 
 ## What is signed
 
-Everything this project's CI builds and ships:
+The code we maintain ourselves, and the installer that carries it:
 
 | File | What it is |
 | --- | --- |
 | `WinHTTrack.exe` | the GUI |
 | `httrack.exe` | the command-line version |
 | `libhttrack.dll` | the engine, built from [xroche/httrack](https://github.com/xroche/httrack) |
-| `libssl-*.dll`, `libcrypto-*.dll`, `z.dll` | OpenSSL and zlib, which vcpkg compiles from source during the build |
 | `httrack_*_*.exe` | the Inno Setup installer |
 
-The uninstaller that Inno Setup embeds (`unins000.exe`) stays unsigned. Inno can only sign
-it by calling out to a `signtool`-style helper while it compiles, and SignPath's submission
-API does not work that way. The installer you actually download and double-click is signed,
-and that is the file Windows judges.
+Two things inside that installer stay unsigned, on purpose.
+
+The OpenSSL and zlib DLLs (`libssl-*.dll`, `libcrypto-*.dll`, `z.dll`) belong to their own
+upstream projects. We compile them from source during the build, but we do not maintain
+their code, and SignPath's code of conduct is clear that a project signs only binaries
+built from source its own team maintains. Upstream libraries may travel unsigned inside a
+signed package, so that is how they travel here.
+
+The uninstaller that Inno Setup embeds (`unins000.exe`) is the other one. Inno can only
+sign it by calling out to a `signtool`-style helper while it compiles, and SignPath's
+submission API does not work that way. The installer you actually download and double-click
+is signed, and that is the file Windows judges.
 
 ## Team roles
 
@@ -65,6 +72,15 @@ executable and cannot reach the files packed inside it:
 
 Before either certificate is used, a human approves the request in SignPath's web
 interface.
+
+## Privacy policy
+
+This program will not transfer any information to other networked systems unless
+specifically requested by the user or the person installing or operating it.
+
+Copying a website is exactly such a request: when you give HTTrack a URL, it contacts that
+site, and the sites it links to if you tell it to follow them. It sends nothing anywhere
+else, and it reports nothing back to us. HTTrack obeys `robots.txt` by default.
 
 ## Verifying a signature
 


### PR DESCRIPTION
## What

Sign only `WinHTTrack.exe`, `httrack.exe`, `libhttrack.dll` and the installer. OpenSSL and zlib ride unsigned inside it. Fixes the tag filter; adds the privacy policy to `SIGNING.md`.

## Why

#24 signed the OpenSSL and zlib DLLs, which SignPath forbid: upstream binaries "must not be signed using your subscription, but may be included in signed packages". Building them from source does not make them ours.

The tag filter matched `refs/tags/v*`, but releases here are tagged bare (`3.49.12`), so signing would never have fired.

Nothing was signed; the steps stay dormant until `SIGNPATH_ORGANIZATION_ID` exists. Lands before we apply, as SignPath read the repo during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
