### PR TITLE
Hand the engine UTF-8, not the ANSI codepage

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -563,6 +563,12 @@ jobs:
           if ($se) { Write-Host "  stderr: $($se.Trim())" }
           if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
           if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
+          # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into
+          # a dialog. --selftest exercises it; assert it actually RAN, or the check silently
+          # skips (its ANSI-codepage guard) and proves nothing.
+          if ("$so" -notmatch 'MBCS->UTF-8 ok') {
+            throw "selftest did not exercise the MBCS->UTF-8 conversion"
+          }
 
           # --selftest throws one exception on purpose. A crash report that resolves nothing
           # is indistinguishable from a working one until someone needs it, so assert the

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1700,6 +1700,44 @@ static void StripControls(char* chaine)
   }
 }
 
+/* The engine reads every char* as UTF-8 on Windows -- its own main() runs the command line
+   through hts_argv_utf8() before using it. MFC hands us the ANSI codepage instead, so an
+   accented path or a non-Latin URL reached the engine as invalid UTF-8. Convert, and keep
+   the engine's allocator: these strings are released with freet(). */
+char *strdupt_utf8(const char *const s) {
+  const int wlen = MultiByteToWideChar(CP_ACP, 0, s, -1, NULL, 0);
+  WCHAR *wide;
+  int len;
+  char *utf8;
+
+  if (wlen <= 0)
+    return strdupt(s);
+  wide = (WCHAR *) malloct(wlen * sizeof(WCHAR));
+  if (wide == NULL)
+    return strdupt(s);
+  if (MultiByteToWideChar(CP_ACP, 0, s, -1, wide, wlen) != wlen) {
+    freet(wide);
+    return strdupt(s);
+  }
+  len = WideCharToMultiByte(CP_UTF8, 0, wide, -1, NULL, 0, NULL, NULL);
+  if (len <= 0) {
+    freet(wide);
+    return strdupt(s);
+  }
+  utf8 = (char *) malloct(len);
+  if (utf8 == NULL) {
+    freet(wide);
+    return strdupt(s);
+  }
+  if (WideCharToMultiByte(CP_UTF8, 0, wide, -1, utf8, len, NULL, NULL) != len) {
+    freet(utf8);
+    freet(wide);
+    return strdupt(s);
+  }
+  freet(wide);
+  return utf8;
+}
+
 #if SHELL_MULTITHREAD
 
 static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtrs) {
@@ -2012,7 +2050,7 @@ void lance(void) {
   argv = (char**) malloct(argvAlloc * sizeof(char*));
   argv[0] = strdupt("winhttrack");
   for(int i = 0; i < args.GetSize(); i++) {
-    argv[i + 1] = strdupt((const char*) args[i]);
+    argv[i + 1] = strdupt_utf8((const char*) args[i]);
 
     // For debugging only
     ShellOptions->LINE_back += ' ';

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1700,10 +1700,7 @@ static void StripControls(char* chaine)
   }
 }
 
-/* The engine reads every char* as UTF-8 on Windows -- its own main() runs the command line
-   through hts_argv_utf8() before using it. MFC hands us the ANSI codepage instead, so an
-   accented path or a non-Latin URL reached the engine as invalid UTF-8. Convert, and keep
-   the engine's allocator: these strings are released with freet(). */
+// The engine reads char* as UTF-8 on Windows; MFC hands us the ANSI codepage. Contract in Shell.h.
 char *strdupt_utf8(const char *const s) {
   const int wlen = MultiByteToWideChar(CP_ACP, 0, s, -1, NULL, 0);
   WCHAR *wide;

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -99,9 +99,8 @@ extern HANDLE WhttMutex;
 extern const char* WhttLocation;
 #define WHTT_LOCATION(a) WhttLocation=(a)
 
-// Duplicate an MBCS (ANSI codepage) string as UTF-8, which is what the engine reads every
-// char* as on Windows. Caller frees with freet(). Returns the bytes unchanged if the
-// conversion fails, never NULL for a non-NULL argument.
+// Duplicate an MBCS (ANSI codepage) string as UTF-8, what the engine reads char* as on Windows.
+// Caller frees with freet(); returns the bytes unchanged if conversion fails, never NULL.
 char *strdupt_utf8(const char *const s);
 
 // Drop a trailing '/' or '\\', reporting whether there was one. Empty-string safe.

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -99,6 +99,11 @@ extern HANDLE WhttMutex;
 extern const char* WhttLocation;
 #define WHTT_LOCATION(a) WhttLocation=(a)
 
+// Duplicate an MBCS (ANSI codepage) string as UTF-8, which is what the engine reads every
+// char* as on Windows. Caller frees with freet(). Returns the bytes unchanged if the
+// conversion fails, never NULL for a non-NULL argument.
+char *strdupt_utf8(const char *const s);
+
 // Drop a trailing '/' or '\\', reporting whether there was one. Empty-string safe.
 inline bool StripTrailingSlash(char* s) {
   const size_t len = (s != NULL) ? strlen(s) : 0;

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -285,15 +285,11 @@ BOOL CWinHTTrackApp::InitInstance()
   /* --selftest: everything that depends on the installed data files has now run
      (lang.def above all). Report and leave before any window appears. */
   if (WhttSelfTest) {
-    /* The engine reads char* as UTF-8; MFC hands us the ANSI codepage. Nothing else can
-       test that conversion -- it is only reachable by typing into a dialog. Build the ANSI
-       form the way MFC would, and check what the engine would receive. */
+    // Only reachable by typing into a dialog, so test the MBCS->UTF-8 conversion here instead.
     {
       static const WCHAR wide[] = { 'c', 'a', 'f', 0x00E9, 0 };   /* cafe-acute */
       BOOL lost = FALSE;
-      /* lpUsedDefaultChar must be NULL when the code page is CP_UTF8, or the call fails
-         outright -- and a UTF-8 ANSI codepage ("Beta: Use Unicode UTF-8") is precisely a
-         configuration this check has to keep working in, not skip. */
+      // WideCharToMultiByte rejects a non-NULL lpUsedDefaultChar when the code page is CP_UTF8.
       BOOL *const plost = (GetACP() == CP_UTF8) ? NULL : &lost;
       char ansi[16];
       const int n = WideCharToMultiByte(CP_ACP, 0, wide, -1, ansi, sizeof(ansi),

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -285,6 +285,27 @@ BOOL CWinHTTrackApp::InitInstance()
   /* --selftest: everything that depends on the installed data files has now run
      (lang.def above all). Report and leave before any window appears. */
   if (WhttSelfTest) {
+    /* The engine reads char* as UTF-8; MFC hands us the ANSI codepage. Nothing else can
+       test that conversion -- it is only reachable by typing into a dialog. Build the ANSI
+       form the way MFC would, and check what the engine would receive. */
+    {
+      static const WCHAR wide[] = { 'c', 'a', 'f', 0x00E9, 0 };   /* cafe-acute */
+      BOOL lost = FALSE;
+      char ansi[16];
+      const int n = WideCharToMultiByte(CP_ACP, 0, wide, -1, ansi, sizeof(ansi),
+                                        NULL, &lost);
+      if (n > 0 && !lost) {   /* skip where the ANSI codepage cannot hold it at all */
+        char *const got = strdupt_utf8(ansi);
+        if (got == NULL || strcmp(got, "caf\xc3\xa9") != 0) {
+          fprintf(stderr, "FATAL: MBCS->UTF-8 gave '%s', expected caf\xc3\xa9\n",
+                  got != NULL ? got : "(null)");
+          fflush(stderr);
+          ExitProcess(3);
+        }
+        freet(got);
+        printf("MBCS->UTF-8 ok\n");
+      }
+    }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking
        report that names nothing. Only throwing proves the chain resolves. */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -295,7 +295,7 @@ BOOL CWinHTTrackApp::InitInstance()
       const int n = WideCharToMultiByte(CP_ACP, 0, wide, -1, ansi, sizeof(ansi),
                                         NULL, &lost);
       if (n > 0 && !lost) {   /* skip where the ANSI codepage cannot hold it at all */
-        char *const got = strdupt_utf8(ansi);
+        char *got = strdupt_utf8(ansi);   /* freet() nulls it, so not const */
         if (got == NULL || strcmp(got, "caf\xc3\xa9") != 0) {
           fprintf(stderr, "FATAL: MBCS->UTF-8 gave '%s', expected caf\xc3\xa9\n",
                   got != NULL ? got : "(null)");

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -291,9 +291,13 @@ BOOL CWinHTTrackApp::InitInstance()
     {
       static const WCHAR wide[] = { 'c', 'a', 'f', 0x00E9, 0 };   /* cafe-acute */
       BOOL lost = FALSE;
+      /* lpUsedDefaultChar must be NULL when the code page is CP_UTF8, or the call fails
+         outright -- and a UTF-8 ANSI codepage ("Beta: Use Unicode UTF-8") is precisely a
+         configuration this check has to keep working in, not skip. */
+      BOOL *const plost = (GetACP() == CP_UTF8) ? NULL : &lost;
       char ansi[16];
       const int n = WideCharToMultiByte(CP_ACP, 0, wide, -1, ansi, sizeof(ansi),
-                                        NULL, &lost);
+                                        NULL, plost);
       if (n > 0 && !lost) {   /* skip where the ANSI codepage cannot hold it at all */
         char *got = strdupt_utf8(ansi);   /* freet() nulls it, so not const */
         if (got == NULL || strcmp(got, "caf\xc3\xa9") != 0) {


### PR DESCRIPTION
The engine reads every `char*` as UTF-8 on Windows (xroche/httrack#573), but the GUI builds its own argv from MFC dialog strings and calls `hts_main2()` directly, so an accented path or non-Latin URL arrived as ANSI. `Shell.cpp` now converts it. `--selftest` exercises the conversion and CI asserts it ran.

Existing projects under an accented path will re-mirror: the GUI wrote the profile to the right directory while the engine mirrored into a mojibake one, and this makes them agree. One for the release notes.