### PR TITLE
Convert argv through the engine's own UTF-8 converter

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -130,6 +130,7 @@ httrackp *global_opt = NULL;
 // htslib.c
 extern "C" {
   HTSEXT_API void qsec2str(char *st,TStamp t);
+  HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size);
 }
 
 // construction index général
@@ -1702,37 +1703,11 @@ static void StripControls(char* chaine)
 
 // The engine reads char* as UTF-8 on Windows; MFC hands us the ANSI codepage. Contract in Shell.h.
 char *strdupt_utf8(const char *const s) {
-  const int wlen = MultiByteToWideChar(CP_ACP, 0, s, -1, NULL, 0);
-  WCHAR *wide;
-  int len;
-  char *utf8;
-
-  if (wlen <= 0)
-    return strdupt(s);
-  wide = (WCHAR *) malloct(wlen * sizeof(WCHAR));
-  if (wide == NULL)
-    return strdupt(s);
-  if (MultiByteToWideChar(CP_ACP, 0, s, -1, wide, wlen) != wlen) {
-    freet(wide);
-    return strdupt(s);
-  }
-  len = WideCharToMultiByte(CP_UTF8, 0, wide, -1, NULL, 0, NULL, NULL);
-  if (len <= 0) {
-    freet(wide);
-    return strdupt(s);
-  }
-  utf8 = (char *) malloct(len);
-  if (utf8 == NULL) {
-    freet(wide);
-    return strdupt(s);
-  }
-  if (WideCharToMultiByte(CP_UTF8, 0, wide, -1, utf8, len, NULL, NULL) != len) {
-    freet(utf8);
-    freet(wide);
-    return strdupt(s);
-  }
-  freet(wide);
-  return utf8;
+  // Delegate to the engine's own converter (htscharset.c) instead of repeating the
+  // CP_ACP -> UTF-8 dance. GetACP() there matches CP_ACP here. Never returns NULL, so an
+  // argv[] entry is always non-NULL and freet()-able (same libc heap under /MD).
+  char *const utf8 = hts_convertStringSystemToUTF8(s, strlen(s));
+  return utf8 != NULL ? utf8 : strdupt(s);
 }
 
 #if SHELL_MULTITHREAD


### PR DESCRIPTION
## What

Replace the GUI's private `strdupt_utf8()` — 30 lines of hand-rolled `CP_ACP -> wide -> CP_UTF8` — with a thin wrapper that delegates to the engine's own converter, `hts_convertStringSystemToUTF8()`.

## Why

PR #28 added `strdupt_utf8()` so the GUI hands the engine UTF-8 argv (MFC gives us the ANSI codepage; the engine reads every `char*` as UTF-8). The engine has always done the identical conversion for its own command line, and it now **exports** that converter as `HTSEXT_API` (engine #582). Two copies of the same MBCS→UTF-8 logic is exactly the duplication that export was meant to remove.

## How

The wrapper stays (so the argv call site and the `--selftest` are untouched); only its body changes. Verified equivalent before swapping:

- **Codepage** — the engine converter uses `GetACP()`, precisely the `CP_ACP` the GUI passed. Same bytes in, same bytes out.
- **Lifetime** — `malloct`/`freet`/`strdupt` are thin aliases over libc `malloc`/`free` (`htssafe.h`), and the conversion path returns plain `malloc`'d memory. Under `/MD` everything shares the one ucrtbase heap, so an `argv[]` entry stays `freet()`-able across the DLL boundary.
- **Contract** — the engine returns `NULL` on failure; `strdupt_utf8()` must not, since `argv[]` entries have to be non-NULL. The wrapper keeps the `strdupt(s)` fallback.

`hts_convertStringSystemToUTF8` is declared locally with `extern "C"` (the GUI's pattern for engine functions) rather than by including `htscharset.h`, which has no `extern "C"` guard.

CI still asserts `MBCS->UTF-8 ok` via `--selftest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)