### PR TITLE
Say which file type the installer associates, and honour the choice

### DIFF
--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -64,7 +64,7 @@ SignedUninstaller=no
 #endif
 
 [Tasks]
-Name: "regfiles"; Description: "Register WinHTTrack file types and program setup"; GroupDescription: "Setup:"
+Name: "regfiles"; Description: "Associate the .whtt project file type with WinHTTrack, and add ""New > WinHTTrack Project"" to the Explorer menu"; GroupDescription: "Setup:"
 Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "Additional icons:"
 Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescription: "Additional icons:"; Flags: unchecked
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -432,15 +432,18 @@ BOOL CWinHTTrackApp::InitInstance()
   {
     // enable file manager drag/drop and DDE Execute open
     EnableShellOpen();
-    RegisterShellFileTypes();
 
     CWinApp* pApp = AfxGetApp();
 
-    // register "New File" handler
+    // Portable runs always associate; an installed one obeys the setup's file-types task.
     if (pApp->GetProfileInt("Interface","SetupRun",0) != 1
       || pApp->GetProfileInt("Interface","SetupHasRegistered",0) == 1) {
         HKEY phkResult;
         DWORD creResult;
+
+      RegisterShellFileTypes();
+
+      // register "New File" handler
       if (RegCreateKeyEx(HKEY_CLASSES_ROOT,".whtt",0,NULL,REG_OPTION_NON_VOLATILE,KEY_ALL_ACCESS,NULL,&phkResult,&creResult)==ERROR_SUCCESS) {
         RegCloseKey(phkResult);
         if (RegCreateKeyEx(HKEY_CLASSES_ROOT,".whtt\\ShellNew",0,NULL,REG_OPTION_NON_VOLATILE,KEY_ALL_ACCESS,NULL,&phkResult,&creResult)==ERROR_SUCCESS) {


### PR DESCRIPTION
The setup's file-types checkbox named no extension, so there was no way to decide whether to want it. It now says what it does: it associates `.whtt` and adds the Explorer "New > WinHTTrack Project" entry.

Unchecking it did not actually prevent the association. The installer's task only writes uninstall markers and `SetupHasRegistered`; the association itself is `RegisterShellFileTypes()` in `WinHTTrack.cpp`, which ran unconditionally. It is now gated on the same condition that already guarded the `ShellNew` entry, so a portable run still associates and an installed one obeys the checkbox. Naming the extension without this would have made the label precise and still wrong. The installer has no `[Languages]` or `[CustomMessages]` section, so there is no translated copy of this string to update.

Closes #187
