### PR TITLE
Show the selected language in the About box

### DIFF
--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -100,17 +100,8 @@ BOOL Cabout::OnInitDialog()
     //LANG_T(min(old_lang,i-1));
   }
 
-  /* sel */
-  int i;
-  int max=m_ctl_lang.GetCount();
-  m_ctl_lang.SetCurSel(-1);
-  for(i=0;i<max;i++) {
-    CString st;
-    m_ctl_lang.GetLBText(i,st);
-    if (strcmp(st,LANGUAGE_NAME)==0) {
-      m_ctl_lang.SetCurSel(i);
-    }
-  }
+  /* sel: items were added in language-index order above */
+  m_ctl_lang.SetCurSel(LANG_T(-1));
   
   EnableToolTips(true);     // TOOL TIPS
   setlang();


### PR DESCRIPTION
The About box's language field was empty for six of the shipped languages. It picked the combo entry by comparing the item text against `LANGUAGE_NAME`, but the combo is filled from `LANG_LOAD`'s out-parameter, which yields the `lang/<name>.txt` basename, while `LANGUAGE_NAME` is the translated name inside that file. `Francais` never equals `Français`, so the loop fell through and left `SetCurSel(-1)`. English matched only because its two spellings coincide.

Affected: Francais, Cesky, Croatian, Portugues, Portugues-Brasil, Uzbek. The items are added in language-index order, so the selection is just `LANG_T(-1)` and the comparison loop can go. `OnSelchangelang` compares against the same basename and was always right, so it is untouched. Reported as part of #188, whose main symptom (corrupted tab labels after a language change) is a separate use-after-free and is not addressed here.

Refs #188
