### PR TITLE
WinHTTrack.exe still reports 3.49-12 after the engine bump to 3.49-13

### DIFF
--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -770,8 +770,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,49,12,0
- PRODUCTVERSION 3,49,12,0
+ FILEVERSION 3,49,13,0
+ PRODUCTVERSION 3,49,13,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -789,13 +789,13 @@ BEGIN
             VALUE "Comments", "Website Copier [Offline Browser]"
             VALUE "CompanyName", "HTTrack"
             VALUE "FileDescription", "WinHTTrack Website Copier, Copy Websites to Your Computer"
-            VALUE "FileVersion", "3.49.12"
+            VALUE "FileVersion", "3.49.13"
             VALUE "InternalName", "WinHTTrack"
             VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors"
             VALUE "LegalTrademarks", "This software is covered by the GNU General Public License version 3"
             VALUE "OriginalFilename", "WinHTTrack.exe"
             VALUE "ProductName", "HTTrack Website Copier"
-            VALUE "ProductVersion", "3.49-12"
+            VALUE "ProductVersion", "3.49-13"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
The engine released 3.49.13, and the Windows CI checks out the engine from master unpinned, so the bump reached the build right away while `WinHTTrack.exe`'s own resource stayed at 3.49-12. Both arches now fail the version-agreement check, with `httrack.exe` and `libhttrack.dll` reporting 3.49-13 against `WinHTTrack.exe`'s 3.49-12. This bumps the four version fields in `WinHTTrack.rc`. The version CI hands to ISCC is read from `htsglobal.h` at build time and needed no change.

The check runs before the installer is built, so a red master uploads only msbuild logs. There is nothing to stage for the mirror preview until this lands.