### PR TITLE
Pin and verify everything that feeds a signed release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Keeps the SHA pins in windows-build.yml current, rewriting the trailing "# v4"
+  # comment as it goes. Without this, pinning just means silently going stale.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
       interval: monthly
     commit-message:
       prefix: ci
+
+  # Bumps builtin-baseline in WinHTTrack/vcpkg.json. directory must be the manifest's
+  # folder, not "/", or this silently never fires. Version updates only: Dependabot does
+  # not do vcpkg security updates, so a CVE will not open a PR here.
+  - package-ecosystem: vcpkg
+    directory: /WinHTTrack
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: deps

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -99,14 +99,18 @@ jobs:
 
       - name: Record engine provenance
         shell: pwsh
+        # Via env, not ${{ }} interpolation: a value containing $(...) would otherwise run.
+        env:
+          ENGINE_REF: ${{ vars.HTTRACK_ENGINE_REF }}
+          GH_REF: ${{ github.ref }}
         run: |
           $sha = (git -C httrack rev-parse HEAD).Trim()
-          Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='${{ vars.HTTRACK_ENGINE_REF }}')"
+          Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='$env:ENGINE_REF')"
           "ENGINE_SHA=$sha" | Out-File -Append $env:GITHUB_ENV
           # Two thirds of what we sign is built from the engine tree, so a tag that floats
-          # cannot say what it shipped. Pin HTTRACK_ENGINE_REF to a SHA before tagging.
-          if ('${{ github.ref }}' -like 'refs/tags/*' -and -not '${{ vars.HTTRACK_ENGINE_REF }}') {
-            throw 'Tagged build with no HTTRACK_ENGINE_REF: refusing to sign an unpinned engine'
+          # cannot say what it shipped. A branch name is not a pin, so require a full SHA.
+          if ($env:GH_REF -like 'refs/tags/*' -and $env:ENGINE_REF -notmatch '^[0-9a-f]{40}$') {
+            throw "Tagged build needs HTTRACK_ENGINE_REF pinned to a 40-hex SHA (got '$env:ENGINE_REF')"
           }
 
       # Located with vswhere rather than microsoft/setup-msbuild. A repo that
@@ -128,7 +132,15 @@ jobs:
 
       - name: Enable vcpkg MSBuild integration
         shell: pwsh
-        run: vcpkg integrate install
+        run: |
+          # The runner's preinstalled C:\vcpkg is a checkout frozen at image-build time and
+          # never fetches, so our pinned baseline has to be pulled in or resolution fails.
+          $baseline = (Get-Content httrack-windows/WinHTTrack/vcpkg.json -Raw | ConvertFrom-Json).'builtin-baseline'
+          git -C C:\vcpkg fetch --depth 1 origin $baseline
+          git -C C:\vcpkg cat-file -e "${baseline}:versions/baseline.json"
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg baseline $baseline is still unreachable after fetch" }
+          Write-Host "vcpkg baseline $baseline reachable"
+          vcpkg integrate install
 
       # WinHTTrack links src\$(Platform)\$(Configuration)\libhttrack.lib, so the
       # engine has to be built first.
@@ -433,21 +445,21 @@ jobs:
         shell: pwsh
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
-          # Assert before overwriting: a request that came back unsigned would otherwise
-          # sail on and ship an unsigned installer every later step still calls signed.
-          # Name the expected set -- validating only what came back passes happily when
-          # SignPath returns two of three, leaving the third unsigned inside the installer.
+          # Enumerate once, recursively: SignPath may return a nested layout, and a flat
+          # glob would then copy nothing while every later step still calls these signed.
+          $files = @(Get-ChildItem 'signed' -Recurse -Include *.exe, *.dll -File)
+          # Assert the expected set by name. Validating only what came back passes happily
+          # when SignPath returns two of three, leaving the third unsigned in the installer.
           $expected = @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')
-          $got = @(Get-ChildItem 'signed\*' -Include *.exe, *.dll | ForEach-Object { $_.Name })
-          $missing = $expected | Where-Object { $_ -notin $got }
+          $missing = $expected | Where-Object { $_ -notin $files.Name }
           if ($missing) { throw "SignPath did not return: $($missing -join ', ')" }
-          foreach ($f in Get-ChildItem 'signed\*' -Include *.exe, *.dll) {
+          foreach ($f in $files) {
             $sig = Get-AuthenticodeSignature $f.FullName
             Write-Host "  $($f.Name): $($sig.Status) $($sig.SignerCertificate.Subject)"
             if ($sig.Status -ne 'Valid') { throw "$($f.Name) came back $($sig.Status), not Valid" }
           }
-          Copy-Item 'signed\*' $bin -Force
-          Write-Host "::notice::signed $((Get-ChildItem 'signed\*').Count) binaries"
+          $files | Copy-Item -Destination $bin -Force
+          Write-Host "::notice::signed $($files.Count) binaries"
 
       # Build the installer, install it, and run the thing. Until now nothing had
       # ever executed: the manifest bug that stopped the exe from starting got

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,7 +25,7 @@ jobs:
   encoding:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # Byte-exact on purpose. The sources are ISO-8859-1 (accented French
       # comments), and grep-family tools treat them as binary and silently match
       # nothing, so a shell-based guard here would never fire.
@@ -82,18 +82,32 @@ jobs:
         configuration: [Release]
     steps:
       - name: Checkout httrack-windows
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           path: httrack-windows
 
       # $(HttrackRoot) resolves to ..\httrack, so the engine must be the sibling.
       # coucal is the engine's own submodule.
       - name: Checkout httrack engine (sibling)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: xroche/httrack
+          # Empty follows master, so engine bumps still surface on branch CI at once.
+          ref: ${{ vars.HTTRACK_ENGINE_REF }}
           path: httrack
           submodules: recursive
+
+      - name: Record engine provenance
+        shell: pwsh
+        run: |
+          $sha = (git -C httrack rev-parse HEAD).Trim()
+          Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='${{ vars.HTTRACK_ENGINE_REF }}')"
+          "ENGINE_SHA=$sha" | Out-File -Append $env:GITHUB_ENV
+          # Two thirds of what we sign is built from the engine tree, so a tag that floats
+          # cannot say what it shipped. Pin HTTRACK_ENGINE_REF to a SHA before tagging.
+          if ('${{ github.ref }}' -like 'refs/tags/*' -and -not '${{ vars.HTTRACK_ENGINE_REF }}') {
+            throw 'Tagged build with no HTTRACK_ENGINE_REF: refusing to sign an unpinned engine'
+          }
 
       # Located with vswhere rather than microsoft/setup-msbuild. A repo that
       # restricts Actions to GitHub-owned ones kills a third-party action as a
@@ -393,7 +407,7 @@ jobs:
       - name: Upload the unsigned binaries
         id: unsigned-binaries
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unsigned-binaries-${{ matrix.platform }}
           path: unsigned/*
@@ -401,7 +415,7 @@ jobs:
 
       - name: Sign the binaries
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
@@ -421,6 +435,12 @@ jobs:
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           # Assert before overwriting: a request that came back unsigned would otherwise
           # sail on and ship an unsigned installer every later step still calls signed.
+          # Name the expected set -- validating only what came back passes happily when
+          # SignPath returns two of three, leaving the third unsigned inside the installer.
+          $expected = @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')
+          $got = @(Get-ChildItem 'signed\*' -Include *.exe, *.dll | ForEach-Object { $_.Name })
+          $missing = $expected | Where-Object { $_ -notin $got }
+          if ($missing) { throw "SignPath did not return: $($missing -join ', ')" }
           foreach ($f in Get-ChildItem 'signed\*' -Include *.exe, *.dll) {
             $sig = Get-AuthenticodeSignature $f.FullName
             Write-Host "  $($f.Name): $($sig.Status) $($sig.SignerCertificate.Subject)"
@@ -456,6 +476,15 @@ jobs:
           Invoke-WebRequest "https://aka.ms/vs/17/release/vc_redist.$arch.exe" -OutFile $redist
           if ((Get-Item $redist).Length -lt 1MB) { throw 'vc_redist download looks wrong' }
 
+          # Bundled into a signed installer and run elevated, so verify who produced the
+          # bytes: aka.ms redirects, and TLS only authenticates the host we fetched from.
+          $sig = Get-AuthenticodeSignature $redist
+          if ($sig.Status -ne 'Valid') { throw "vc_redist signature is $($sig.Status)" }
+          if ($sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+            throw "vc_redist signed by an unexpected party: $($sig.SignerCertificate.Subject)"
+          }
+          Write-Host "vc_redist signer verified: $($sig.SignerCertificate.Subject)"
+
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress | Out-Null }
           if (-not (Test-Path $iscc)) { throw 'Inno Setup is not available' }
@@ -489,7 +518,7 @@ jobs:
       - name: Upload the unsigned installer
         id: unsigned-installer
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unsigned-installer-${{ matrix.platform }}
           path: installer/*.exe
@@ -497,7 +526,7 @@ jobs:
 
       - name: Sign the installer
         if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
@@ -607,14 +636,14 @@ jobs:
           if (Test-Path $exe) { throw "uninstall left WinHTTrack.exe behind" }
 
       - name: Upload the installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: httrack-setup-${{ matrix.platform }}
           path: installer/*.exe
           if-no-files-found: error
 
       - name: Upload the runnable build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: WinHTTrack-${{ matrix.platform }}-${{ matrix.configuration }}
           path: |
@@ -625,7 +654,7 @@ jobs:
 
       - name: Upload MSBuild log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}
           path: httrack-windows/msbuild.log

--- a/WinHTTrack/vcpkg.json
+++ b/WinHTTrack/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "winhttrack",
   "version-string": "3.49",
+  "builtin-baseline": "a51bb4d1434e6d0927ff79db8033bed8522b85df",
   "dependencies": [
     "openssl",
     "zlib"

--- a/WinHTTrack/vcpkg.json
+++ b/WinHTTrack/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "winhttrack",
   "version-string": "3.49",
-  "builtin-baseline": "a51bb4d1434e6d0927ff79db8033bed8522b85df",
+  "builtin-baseline": "44819aa2a6c10e56065e2b0330e7d6c89d1d2574",
   "dependencies": [
     "openssl",
     "zlib"


### PR DESCRIPTION
Once SignPath is live, anything that reaches the build reaches a binary carrying a trusted signature. The inputs are currently much less controlled than the output.

All nine actions were on mutable tags, including the two signpath steps that hold the signing token. They are now pinned to commit SHAs. SignPath's origin verification does not help here: the signing steps hand it an artifact-id rather than bytes, so it authenticates the producer and not the product, which puts `upload-artifact` and `checkout` inside the same trust boundary as the signpath action itself.

The engine was checked out from unpinned master while supplying two of the three signed binaries, so a tagged release could not say which engine it shipped. Tagged builds now refuse to run without an explicit `HTTRACK_ENGINE_REF`, and every build records the resolved SHA in the log. Branch CI still follows master, so an engine bump surfaces here immediately, as before.

`vc_redist` was fetched through a redirector and accepted on a size check, then bundled into the signed installer and run elevated on the user's machine. Its Authenticode signature and signer are now verified. Separately, the post-signing check validated whatever files came back rather than the files we expect, so SignPath returning two of three would have shipped the third unsigned inside a signed installer on a green build. The expected set is now asserted by name. The vcpkg baseline is pinned so OpenSSL and zlib resolve reproducibly.

Found during a program-scale audit. None of this is exploitable by an outsider today. Fork PRs cannot reach secrets, there is no `pull_request_target` or `workflow_run` chaining, and no credentials are in history. The point is to narrow what a compromised dependency could reach once a real certificate is attached to the output.

One thing this PR does not fix, because it lives in repo settings rather than in the tree: there is no branch protection, no tag protection, and no deployment environment on this repo. Anyone holding the maintainer credential can push a tag straight to a signing request. Worth adding a protected environment on the signing job.