### PR TITLE
Make RAS dial-up survive a failed dial

### DIFF
--- a/WinHTTrack/RasLoad.cpp
+++ b/WinHTTrack/RasLoad.cpp
@@ -10,8 +10,22 @@ Purpose:	Dynamically loaded RAS.
 #include "stdafx.h"
 #include "RasLoad.h"
 
+// Absolute System32 path: an unqualified name searches the app directory first, so a
+// planted rasapi32.dll would win. (LOAD_LIBRARY_SEARCH_SYSTEM32 needs KB2533623 on Win7.)
+static HINSTANCE LoadSystemRas()
+{
+	TCHAR path[MAX_PATH];
+	const UINT len = GetSystemDirectory( path, MAX_PATH );
+	static const TCHAR dll[] = _T("\\rasapi32.dll");
+	// 0 means failure; len excludes the NUL that _countof(dll) counts
+	if ( len == 0 || len >= MAX_PATH - _countof(dll) )
+		return NULL;
+	_tcscat_s( path, MAX_PATH, dll );
+	return LoadLibrary( path );
+}
+
 CDynamicRAS::CDynamicRAS()
-	: m_hInst( LoadLibrary( _T("rasapi32") ) )
+	: m_hInst( LoadSystemRas() )
 	, pRasEnumConnections( NULL )
 	, pRasHangUp( NULL )
 	, pRasGetConnectStatus( NULL )

--- a/WinHTTrack/RasLoad.h
+++ b/WinHTTrack/RasLoad.h
@@ -26,19 +26,20 @@ public:
 
 	inline bool IsRASLoaded() const { return m_hInst ? true : false; }
 
-	inline DWORD RasEnumConnections( LPRASCONN lprasconn, LPDWORD lpcb, LPDWORD lpcConnections) { ASSERT( pRasEnumConnections ); return pRasEnumConnections( lprasconn, lpcb, lpcConnections ); }
-	inline DWORD RasHangUp( HRASCONN hrasconn ) { ASSERT( pRasHangUp ); return pRasHangUp( hrasconn ); }
-	inline DWORD RasGetConnectStatus( HRASCONN hrasconn , LPRASCONNSTATUS lprasconnstatus ) { ASSERT( pRasGetConnectStatus ); return pRasGetConnectStatus( hrasconn , lprasconnstatus ); }
-	inline DWORD RasDial( LPRASDIALEXTENSIONS lpRasDialExtensions, LPTSTR lpszPhonebook, LPRASDIALPARAMS lpRasDialParams, DWORD dwNotifierType, LPVOID lpvNotifier, LPHRASCONN lphRasConn) { 
-    ASSERT( pRasDial ); 
+	// ASSERT compiles out in Release, so a missing export became a NULL call: guard for real.
+	inline DWORD RasEnumConnections( LPRASCONN lprasconn, LPDWORD lpcb, LPDWORD lpcConnections) { if (!pRasEnumConnections) return ERROR_PROC_NOT_FOUND; return pRasEnumConnections( lprasconn, lpcb, lpcConnections ); }
+	inline DWORD RasHangUp( HRASCONN hrasconn ) { if (!pRasHangUp) return ERROR_PROC_NOT_FOUND; return pRasHangUp( hrasconn ); }
+	inline DWORD RasGetConnectStatus( HRASCONN hrasconn , LPRASCONNSTATUS lprasconnstatus ) { if (!pRasGetConnectStatus) return ERROR_PROC_NOT_FOUND; return pRasGetConnectStatus( hrasconn , lprasconnstatus ); }
+	inline DWORD RasDial( LPRASDIALEXTENSIONS lpRasDialExtensions, LPTSTR lpszPhonebook, LPRASDIALPARAMS lpRasDialParams, DWORD dwNotifierType, LPVOID lpvNotifier, LPHRASCONN lphRasConn) {
+    if (!pRasDial) return ERROR_PROC_NOT_FOUND;
     return pRasDial(lpRasDialExtensions, lpszPhonebook, lpRasDialParams, dwNotifierType, lpvNotifier, lphRasConn);
   }
   inline DWORD RasEnumEntries (LPTSTR reserved, LPTSTR lpszPhonebook, LPRASENTRYNAME lprasentryname, LPDWORD lpcb, LPDWORD lpcEntries) {
-    ASSERT( pRasEnumEntries ); 
+    if (!pRasEnumEntries) return ERROR_PROC_NOT_FOUND;
     return pRasEnumEntries(reserved, lpszPhonebook, lprasentryname, lpcb, lpcEntries);
   }
   inline DWORD RasGetEntryDialParams (LPTSTR lpszPhonebook, LPRASDIALPARAMS lprasdialparams, LPBOOL lpfPassword) {
-    ASSERT( pRasGetEntryDialParams ); 
+    if (!pRasGetEntryDialParams) return ERROR_PROC_NOT_FOUND;
     return pRasGetEntryDialParams(lpszPhonebook, lprasdialparams, lpfPassword);
   }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1051,9 +1051,18 @@ int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // a
     if (ShellOptions->_RasString.GetLength()>0) {    // sélection provider
       if (!LibRas->RasDial(NULL,NULL,&ShellOptions->_dial,NULL,NULL,&conn)) {
         RASCONNSTATUS status;
+        // RasGetConnectStatus can fail without touching rasconnstate: bail rather than poll on garbage.
+        const DWORD pollMs = 250;
+        const DWORD timeoutMs = 180000;   // slow modem handshakes are legitimate
+        DWORD waited = 0;
         do {
+          memset(&status, 0, sizeof(status));
           status.dwSize = sizeof(status);
-          LibRas->RasGetConnectStatus(conn,&status);
+          if (LibRas->RasGetConnectStatus(conn,&status) != 0) {
+            strcpybuff(connected_err,LANG(LANG_F3 /*"Could not connect to provider"*/));
+            connected=-1;
+            break;
+          }
           switch(status.rasconnstate) {
           case RASCS_Connected : 
             connected=1;
@@ -1062,6 +1071,14 @@ int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // a
             strcpybuff(connected_err,LANG(LANG_F3 /*"Could not connect to provider"*/));
             connected=-1;
             break;
+          }
+          if (connected==0) {
+            Sleep(pollMs);
+            waited += pollMs;
+            if (waited >= timeoutMs) {
+              strcpybuff(connected_err,LANG(LANG_F3 /*"Could not connect to provider"*/));
+              connected=-1;
+            }
           }
         } while(connected==0);
       } else {


### PR DESCRIPTION
Dial-up is still how HTTrack gets used where bandwidth is scarce or metered, and the failure path was the broken one.

`RasGetConnectStatus`'s return value was ignored, and only `dwSize` was initialised before the call. A failed call therefore left `rasconnstate` holding whatever was on the stack, matched neither switch arm, and left the poll loop spinning at 100% CPU with no sleep and no timeout. On a flaky modem link a failed dial is the ordinary case rather than a rare one, so this is the path most likely to run.

`ASSERT` was also the only null check on the six `GetProcAddress` results, and `ASSERT` compiles out in Release, so a missing export meant a NULL call in every shipped binary. The pointers are guarded properly now and return `ERROR_PROC_NOT_FOUND`. While in the file, `rasapi32` is loaded by absolute System32 path, since the unqualified name searched the application directory first.

The timeout is deliberately generous at three minutes, because a slow modem handshake legitimately takes a while and I would rather not break a working dial to fix a broken one.

CI cannot verify this. It needs a machine with a RAS entry configured, so the null guards and the load path are compile-checked only. Found during a program-scale audit, along with the note that this feature is a good deal less dead than it looks.