### PR TITLE
Fetch the engine's vcpkg baseline in CI

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -133,13 +133,17 @@ jobs:
       - name: Enable vcpkg MSBuild integration
         shell: pwsh
         run: |
-          # The runner's preinstalled C:\vcpkg is a checkout frozen at image-build time and
-          # never fetches, so our pinned baseline has to be pulled in or resolution fails.
-          $baseline = (Get-Content httrack-windows/WinHTTrack/vcpkg.json -Raw | ConvertFrom-Json).'builtin-baseline'
-          git -C C:\vcpkg fetch --depth 1 origin $baseline
-          git -C C:\vcpkg cat-file -e "${baseline}:versions/baseline.json"
-          if ($LASTEXITCODE -ne 0) { throw "vcpkg baseline $baseline is still unreachable after fetch" }
-          Write-Host "vcpkg baseline $baseline reachable"
+          # The runner's preinstalled C:\vcpkg is frozen at image-build time and never
+          # fetches, so every pinned baseline we build against has to be pulled in first.
+          # Both manifests are pinned now (the engine got its own in xroche/httrack#643).
+          foreach ($m in 'httrack-windows/WinHTTrack/vcpkg.json', 'httrack/src/vcpkg.json') {
+            $baseline = (Get-Content $m -Raw | ConvertFrom-Json).'builtin-baseline'
+            if (-not $baseline) { continue }
+            git -C C:\vcpkg fetch --depth 1 origin $baseline
+            git -C C:\vcpkg cat-file -e "${baseline}:versions/baseline.json"
+            if ($LASTEXITCODE -ne 0) { throw "vcpkg baseline $baseline ($m) unreachable after fetch" }
+            Write-Host "vcpkg baseline $baseline reachable ($m)"
+          }
           vcpkg integrate install
 
       # WinHTTrack links src\$(Platform)\$(Configuration)\libhttrack.lib, so the
@@ -404,11 +408,13 @@ jobs:
           ACCEPTED: ${{ vars.SECURITY_ACCEPTED_CVES }}
         run: |
           $expectArg = @()
-          $baseline = (Get-Content httrack-windows/WinHTTrack/vcpkg.json -Raw | ConvertFrom-Json).'builtin-baseline'
+          # Cross-check against the ENGINE's pin: its tree is what the installer ships and
+          # is scanned first-wins below, so the GUI baseline would compare the wrong thing.
+          $baseline = (Get-Content httrack/src/vcpkg.json -Raw | ConvertFrom-Json).'builtin-baseline'
           if ($baseline) {
             $url = "https://raw.githubusercontent.com/microsoft/vcpkg/$baseline/versions/baseline.json"
             $expect = (Invoke-RestMethod $url).default.openssl.baseline
-            Write-Host "GUI pin resolves openssl to $expect"
+            Write-Host "engine pin resolves openssl to $expect"
             $expectArg = @('--expect-openssl', $expect)
           }
           # Engine tree first: its DLLs are the ones the installer ships.


### PR DESCRIPTION
The engine pinned its own `builtin-baseline` in xroche/httrack#643, closing the reproducibility gap from #642. That change reaches the GUI build immediately, since CI checks out the engine at master, and it exposes a hole: the fetch step only pulled the GUI manifest's baseline into the runner's frozen `C:\vcpkg`, while the engine build resolves against the engine's baseline, a commit newer than the runner image. That is the same unresolvable-baseline break the GUI build hit before its own fetch, and no GUI build has exercised the pinned engine yet, so this PR is also the canary that proves it resolves.

The fix loops the existing fetch over both manifests. It also repoints the CVE gate's `--expect-openssl` cross-check at the engine baseline, since the engine tree is what the installer ships and is scanned first-wins; comparing the resolved version to the GUI baseline compared an unrelated pin. Both resolve to OpenSSL 3.6.3 today, so nothing about what ships changes.