### PR TITLE
Stop conv_printf from destroying DBCS trail bytes

### DIFF
--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -622,6 +622,12 @@ void conv_printf(char* from,char* to) {
   int i=0,j=0,len;
   len = (int) strlen(from);
   while(i<len) {
+    /* A DBCS trail byte can be 0x5C; copy the pair before it is mistaken for an escape. */
+    if (IsDBCSLeadByteEx(CP_ACP,(unsigned char)from[i]) && i+1<len) {
+      to[j++]=from[i++];
+      to[j++]=from[i++];
+      continue;
+    }
     switch(from[i]) {
     case '\\': 
       i++;


### PR DESCRIPTION
`conv_printf` scans language-file text byte by byte for `\` (0x5C) to unescape `\n`/`\t`/`\\`, but 0x5C is also a legal DBCS trail byte. On a Shift-JIS or Big5 language file the second byte of a character gets mistaken for an escape, corrupting the text even on correctly-localized Windows. Measured against the shipped tables: 4 characters in `Japanese.txt` (能×2, 十, 表) and 14 in `Chinese-BIG5.txt` (許×14) are destroyed at load; single-byte codepages are unaffected.

The fix copies a lead+trail pair through untouched before the escape scan can see the trail byte, using `IsDBCSLeadByteEx(CP_ACP, ...)`. CP_ACP is the right codepage because `NewLangCP` is always `CP_THREAD_ACP`, so these strings are rendered through the `...A` ANSI path — parsing them in the codepage they're rendered in is the only self-consistent choice, and it lines up with the shipped tables (ACP 932 → Shift-JIS, 950 → Big5). On a single-byte ACP the guard is a no-op.

Not CI-verifiable beyond compilation: `--selftest` loads the ISO-8859-1 English table, which only exercises the no-op path. The garbled-to-correct rendering needs a Japanese or Traditional-Chinese-locale Windows VM.