### PR TITLE
Bound the edit-control inputs that overflow fixed buffers

### DIFF
--- a/WinHTTrack/AddFilter.cpp
+++ b/WinHTTrack/AddFilter.cpp
@@ -47,6 +47,7 @@ void CAddFilter::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_AFext, m_afquery);
 	DDX_CBIndex(pDX, IDC_AFtype, m_aftype);
 	//}}AFX_DATA_MAP
+  DDV_MaxChars(pDX, m_afquery, 1024);
   m_ctl_ok.ModifyStyle(0,WS_DISABLED);
 }
 
@@ -68,6 +69,7 @@ END_MESSAGE_MAP()
 BOOL CAddFilter::OnInitDialog() 
 {
 	CDialog::OnInitDialog();
+  m_ctl_afext.SetLimitText(1024);   // the filter builder works in fixed buffers
   SetIcon(httrack_icon,false);
   SetIcon(httrack_icon,true);  
   EnableToolTips(true);     // TOOL TIPS	

--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -52,6 +52,7 @@ void CInsertUrl::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_urlpass, m_urlpass);
 	DDX_Text(pDX, IDC_urladr, m_urladr);
 	//}}AFX_DATA_MAP
+  DDV_MaxChars(pDX, m_urladr, 2000);
 }
 
 
@@ -71,6 +72,7 @@ END_MESSAGE_MAP()
 BOOL CInsertUrl::OnInitDialog() 
 {
 	CDialog::OnInitDialog();
+  GetDlgItem(IDC_urladr)->SendMessage(EM_SETLIMITTEXT, 2000, 0);
   SetIcon(httrack_icon,false);
   SetIcon(httrack_icon,true);
   EnableToolTips(true);     // TOOL TIPS
@@ -184,9 +186,11 @@ UINT RunBackCatchServer( LPVOID pP ) {
       }
       // former URL!
       {
-        char finalurl[HTS_URLMAXSIZE*2];
+        char finalurl[HTS_URLMAXSIZE*4+16];
         inplace_escape_check_url(dest, sizeof(dest));
-        sprintf(finalurl,"%s" POSTTOK "file:%s",url,dest);
+        /* Both sources are HTS_URLMAXSIZE*2 and the token is 11 bytes; snprintf is the belt. */
+        _snprintf(finalurl,sizeof(finalurl)-1,"%s" POSTTOK "file:%s",url,dest);
+        finalurl[sizeof(finalurl)-1]='\0';
         SetDlgItemTextCP(_this, IDC_urladr,finalurl);
       }
     }

--- a/WinHTTrack/Iplog.cpp
+++ b/WinHTTrack/Iplog.cpp
@@ -122,9 +122,11 @@ void Ciplog::AffLogRefresh() {
     if (!feof(fp)) {
       char* a=dat;
       char* startline=dat;
+      // 'n' counts bytes read; the newline arm writes 2 per 1, so bound the write too.
+      char* const amax = dat + sizeof(dat) - 3;
       int n=0;
       int c;
-      while ( (!feof(fp)) && (n<HIGH_MARK) ) {
+      while ( (!feof(fp)) && (n<HIGH_MARK) && (a<amax) ) {
         c = fgetc(fp);
         n++;
         if ((c>0) && (c!=EOF)) {

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -65,7 +65,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab7 message handlers
 
-void NewFilter(int i,char* s) {  // 0: forbid 1: accept
+static void NewFilter(int i,char* s,size_t ssize) {  // 0: forbid 1: accept
   CAddFilter AddF;
   AddF.type=i;
   if (AddF.type==0)
@@ -73,7 +73,7 @@ void NewFilter(int i,char* s) {  // 0: forbid 1: accept
   else
     AddF.m_addtype=LANG(LANG_B21); // "Links following this rule will be accepted:";
   if (AddF.DoModal()==IDOK) {
-    char query[2048],t[256],as[256];
+    char query[2048],t[2048],as[2100];
     char* q;
 
     // error
@@ -81,16 +81,16 @@ void NewFilter(int i,char* s) {  // 0: forbid 1: accept
       return;
     }
 
-    strcpybuff(s,"");
+    strlcpybuff(s,"",ssize);
     strcpybuff(query,AddF.m_afquery);
     q=query;
     
     if (AddF.m_aftype==10) {
       if (i==0)
-        strcpybuff(s,"-");
+        strlcpybuff(s,"-",ssize);
       else
-        strcpybuff(s,"+");
-      strcatbuff(s,"*");
+        strlcpybuff(s,"+",ssize);
+      strlcatbuff(s,"*",ssize);
     } else {
       while(strlen(q)>0) {
         while ((*q==' ') || (*q==',')) q++;
@@ -105,11 +105,11 @@ void NewFilter(int i,char* s) {  // 0: forbid 1: accept
           } else if (b) a=b;
           
           if (a) {
-            strcpybuff (t,"");
-            strncat(t,q,a-q);
+            t[0]='\0';
+            strlncatbuff(t,q,sizeof(t),a-q);
             q=a+1;
           } else {
-            strcpybuff(t,q);
+            strlcpybuff(t,q,sizeof(t));
             strcpybuff(q,"");
           }
         }
@@ -149,26 +149,29 @@ void NewFilter(int i,char* s) {  // 0: forbid 1: accept
             break;
           }
           if (strlen(as)>0) {
+            /* Stop at capacity rather than abort: strlcatbuff() does not truncate. */
+            if (strlen(s) + strlen(as) + 4 >= ssize)
+              break;
             if (i==0)
-              strcatbuff(s,"-");
+              strlcatbuff(s,"-",ssize);
             else
-              strcatbuff(s,"+");
-            strcatbuff(s,as);
-            strcatbuff(s,"\x0d\x0a");
+              strlcatbuff(s,"+",ssize);
+            strlcatbuff(s,as,ssize);
+            strlcatbuff(s,"\x0d\x0a",ssize);
           }
         }
       }
       
     }
 
-  } else strcpybuff(s,"");
+  } else strlcpybuff(s,"",ssize);
 }
 
 
 void COptionTab7::OnAdd1() 
 {
   char s[1024]; s[0]='\0';
-  NewFilter(0,s);
+  NewFilter(0,s,sizeof(s));
   if (strlen(s)>0) {
     char tempo[HTS_URLMAXSIZE*16];
     {
@@ -192,7 +195,7 @@ void COptionTab7::OnAdd1()
 void COptionTab7::OnAdd2() 
 {
   char s[1024]; s[0]='\0';
-  NewFilter(1,s);
+  NewFilter(1,s,sizeof(s));
   if (strlen(s)>0) {
     char tempo[HTS_URLMAXSIZE*16];
     {

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -100,6 +100,7 @@ void Wid1::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_INFOMAIN, m_infomain);
 	DDX_Text(pDX, IDC_filelist, m_filelist);
 	//}}AFX_DATA_MAP
+  DDV_MaxChars(pDX, m_urls, 32000);
 }
 
 //IMPLEMENT_DYNAMIC(Wid1, CPropertyPage)
@@ -141,6 +142,9 @@ END_MESSAGE_MAP()
 
 BOOL Wid1::OnInitDialog( ) {
   CPropertyPage::OnInitDialog();
+  // The URL list has no CEdit member; bound it by handle.
+  GetDlgItem(IDC_URL)->SendMessage(EM_SETLIMITTEXT, 32000, 0);
+  GetDlgItem(IDC_filelist)->SendMessage(EM_SETLIMITTEXT, 2000, 0);
   EnableToolTips(true);     // TOOL TIPS
 
   // inits après affichage
@@ -253,12 +257,15 @@ void Wid1::CleanUrls()
   // TODO: Add your control notification handler code here
   
   GetDlgItemText(IDC_URL,st);
-  tempo=(char*) malloc(st.GetLength()+1);
-  ch=(char*) malloc(st.GetLength()+1);
-  str=(char*) malloc(st.GetLength()*2+8192);
-  tempo[0]=ch[0]=str[0]='\0';
+  /* Each token can gain "http://" and a CRLF, so a 1-char token emits 10 bytes: budget per input byte, not per token. */
+  const size_t inlen = (size_t) st.GetLength();
+  const size_t strsize = inlen*10 + 16;
+  tempo=(char*) malloc(inlen+1);
+  ch=(char*) malloc(inlen+1);
+  str=(char*) malloc(strsize);
   if ( (tempo) && (ch) && (str) ) {
-    strcpybuff(tempo,st);
+    tempo[0]=ch[0]=str[0]='\0';
+    strlcpybuff(tempo,st,inlen+1);
     int i;
     for(i=0;i < (int) strlen(tempo);i++)  {
       if(tempo[i]==10) tempo[i]=' ';
@@ -286,10 +293,10 @@ void Wid1::CleanUrls()
           */
           // recopier adresse
           if (strstr(ch,":/")==NULL) {
-            strcatbuff(str,"http://");
+            strlcatbuff(str,"http://",strsize);
           }
-          strcatbuff(str,ch);
-          strcatbuff(str,"\x0d\x0a");
+          strlcatbuff(str,ch,strsize);
+          strlcatbuff(str,"\x0d\x0a",strsize);
         }
         j=0;
       } else ch[j++]=tempo[i];


### PR DESCRIPTION
Five related fixes for buffers that a user can overflow by pasting a long value into a dialog field. None needs a network peer; the trigger in each case is ordinary text entry.

`NewFilter` (OptionTab7) built a scan rule in a `char[256]` from an uncapped filter box. A pasted URL of a couple of kilobytes smashed the frame through a raw `strncat`, and `NewFilter` took its output buffer as a bare `char*`, so the engine's `strcatbuff` macros silently degraded to unbounded `strcat` on it. The function now takes its buffer size, the working buffers are large enough for the real worst case, the token copies are length-bounded, and the accumulation stops at capacity instead of aborting.

`CleanUrls` (Wid1) sized its output at `len*2+8192`, but a one-character token emits `http://` plus a CRLF, so short tokens can exceed that. It now budgets per input byte and, while there, moves the buffer initialisation inside the null-check that previously ran after three dereferences.

`InsertUrl` formatted a browser-supplied URL and a path into a buffer half the size of the two sources; it now sizes for both and formats with `_snprintf`. `Iplog`'s log viewer bounded the bytes it read but not the pointer it wrote, and its newline arm emits two bytes per one consumed, so a file of one-character lines overran the stack buffer; the write pointer is now bounded too.

Underneath all of these, no edit control in the tree had a length limit, so every fixed buffer downstream was an implicit and inconsistent contract. The controls feeding these paths now cap their input (`DDV_MaxChars` on the bound member, `EM_SETLIMITTEXT` on the handle for the list controls that have no member).

CI covers compilation on both arches. The runtime proof that each buffer now holds its worst-case input needs a VM with page-heap enabled and the actual paste, which is owed with the other VM validation before tagging.