### PR TITLE
Correctness cluster: crash unwind, reparse-safe delete, ShellExecute checks, language self-heal

### DIFF
--- a/WinHTTrack/DialogHtmlHelp.cpp
+++ b/WinHTTrack/DialogHtmlHelp.cpp
@@ -98,7 +98,7 @@ BOOL CDialogHtmlHelp::OnInitDialog()
     UpdateWindow();
   } else {
     EndDialog(IDCANCEL);
-    if (!ShellExecute(NULL,"open",home+strlen("file://"),"","",SW_RESTORE))
+    if (!ShellOpen(home+strlen("file://"), SW_RESTORE))
       AfxMessageBox(LANG(LANG_DIAL1));
   }
   return TRUE;  

--- a/WinHTTrack/DirTreeView.cpp
+++ b/WinHTTrack/DirTreeView.cpp
@@ -726,7 +726,8 @@ BOOL CDirTreeViewShellEx::InitInstance() {
 UINT CDirTreeViewShellEx( LPVOID pP ) {
   CWaitCursor wait;
   CString* File=(CString*) pP;
-  if (!ShellExecute(NULL,"open",*File,NULL,NULL,SW_SHOWNORMAL)) {
+  if (!ShellOpen(*File, SW_SHOWNORMAL)) {
+    AfxMessageBox("Cannot open " + *File);
   }
   delete File;
   return 0;

--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -151,7 +151,8 @@ void CFirstInfo::OnLButtonDown(UINT nFlags, CPoint point)
       this->ClientToScreen(&point);
       w->ScreenToClient(&point);
     if ((point.y>=100) && (point.y<=110) || (point.y<=80)) {
-      if (!ShellExecute(NULL,"open","http://www.httrack.com","","",SW_RESTORE)) {
+      if (!ShellOpen("http://www.httrack.com", SW_RESTORE)) {
+        AfxMessageBox("Cannot open a web browser for http://www.httrack.com");
       }
     }
     break;

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1738,6 +1738,10 @@ char *strdupt_utf8(const char *const s) {
   return utf8 != NULL ? utf8 : strdupt(s);
 }
 
+bool ShellOpen(LPCSTR file, int nShowCmd) {
+  return (INT_PTR) ShellExecute(NULL, "open", file, NULL, NULL, nShowCmd) > 32;
+}
+
 #if SHELL_MULTITHREAD
 
 static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtrs) {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -75,6 +75,7 @@ extern "C" {
 //#include "WizLinks.h"
 
 #include "inprogress.h"
+#include "CrashReport.h"
 
 #include "SYS\TIMEB.H"
 
@@ -441,7 +442,7 @@ int check_continue(char* pathlog) {
 	char catbuff[CATBUFF_SIZE];
 	char catbuff2[CATBUFF_SIZE];
 	char catbuff3[CATBUFF_SIZE];
-  char path_log[256];
+  char path_log[HTS_URLMAXSIZE*2];
   strcpybuff(path_log,pathlog);
   if (strlen(path_log)>0)
     if ((path_log[strlen(path_log)-1]!='/') && (path_log[strlen(path_log)-1]!='\\'))
@@ -1744,17 +1745,34 @@ bool ShellOpen(LPCSTR file, int nShowCmd) {
 
 #if SHELL_MULTITHREAD
 
+// EXCEPTION_CONTINUE_EXECUTION would restart the faulting instruction forever; unwind to the -100 path instead.
 static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtrs) {
-  return EXCEPTION_CONTINUE_EXECUTION;
-}                              
+  switch(dwExceptCode) {
+    case EXCEPTION_ACCESS_VIOLATION:
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+    case EXCEPTION_IN_PAGE_ERROR:
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+    case EXCEPTION_PRIV_INSTRUCTION:
+    case EXCEPTION_STACK_OVERFLOW:
+      // Handling it here bypasses the top-level filter, so report from inside the filter, before the unwind.
+      CrashReportLogException("Engine thread crashed");
+      return EXCEPTION_EXECUTE_HANDLER;
+    default:
+      return EXCEPTION_CONTINUE_SEARCH;
+  }
+}
 
 void __cdecl RunBackRobot(void* al_p) {
   int argc;
   char** argv;
 
-  while((!inprogress) && (!termine)) Sleep(10);
-  if (inprogress)
-    while ((!inprogress->m_hWnd) || (termine)) Sleep(10);   // attendre formulaire
+  /* Both spins are bounded only by 'termine', which no writer sets this early: keep the operator honest. */
+  while ((!inprogress) && (!termine)) Sleep(10);
+  if (inprogress) {
+    while ((!inprogress->m_hWnd) && (!termine)) Sleep(10);   // attendre formulaire
+  }
     //Sleep(100);
     
     Robot_params* al=(Robot_params*) al_p;
@@ -2200,7 +2218,8 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F20 /*"\" \nDuring:\n  ","\" \nDurant:\n  "*/));
       strcatbuff(end_mirror_msg,"\"");
-      strcatbuff(end_mirror_msg,ShellOptions->LINE_back);
+      /* Debug-only echo of the command line, and the only unbounded source here: cap it. */
+      strlncatbuff(end_mirror_msg,ShellOptions->LINE_back,sizeof(end_mirror_msg),2048);
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1748,6 +1748,9 @@ bool ShellOpen(LPCSTR file, int nShowCmd) {
 // EXCEPTION_CONTINUE_EXECUTION would restart the faulting instruction forever; unwind to the -100 path instead.
 static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtrs) {
   switch(dwExceptCode) {
+    case EXCEPTION_STACK_OVERFLOW:
+      // Symbol-walking here would re-fault on the exhausted stack; just unwind to -100.
+      return EXCEPTION_EXECUTE_HANDLER;
     case EXCEPTION_ACCESS_VIOLATION:
     case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
     case EXCEPTION_DATATYPE_MISALIGNMENT:
@@ -1755,8 +1758,7 @@ static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtr
     case EXCEPTION_IN_PAGE_ERROR:
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
     case EXCEPTION_PRIV_INSTRUCTION:
-    case EXCEPTION_STACK_OVERFLOW:
-      // Handling it here bypasses the top-level filter, so report from inside the filter, before the unwind.
+      // Handling it here bypasses the top-level filter, so report before the unwind.
       CrashReportLogException("Engine thread crashed");
       return EXCEPTION_EXECUTE_HANDLER;
     default:

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -113,6 +113,10 @@ inline bool StripTrailingSlash(char* s) {
   return false;
 }
 
+// Open a document, folder or URL through the shell, true on success.
+// ShellExecute() reports success as a pseudo-HINSTANCE > 32, so a bare !ShellExecute() never fires.
+bool ShellOpen(LPCSTR file, int nShowCmd);
+
 #ifndef HTS_DEF_FWSTRUCT_lien_back
 #define HTS_DEF_FWSTRUCT_lien_back
 typedef struct lien_back lien_back;

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -756,10 +756,22 @@ BOOL CWinHTTrackApp::RmDir(CString srcpath) {
 
   if (srcpath.GetLength()==0)
     return FALSE;
+
+  // A junction or symlink must be unlinked, never descended: its target is outside what the user confirmed.
+  const DWORD attr = GetFileAttributes(srcpath);
+  if (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_REPARSE_POINT)) {
+    if (!RemoveDirectory(srcpath)) {
+      AfxMessageBox("Error deleting "+srcpath);
+      return FALSE;
+    }
+    return TRUE;
+  }
+
   CString path=srcpath;
   WIN32_FIND_DATA find;
+  BOOL ok = TRUE;
   if (path.Right(1)!="\\")
-    path+="\\";  
+    path+="\\";
   HANDLE h = FindFirstFile(path+"*.*",&find);
   if (h != INVALID_HANDLE_VALUE) {
     do {
@@ -769,15 +781,17 @@ BOOL CWinHTTrackApp::RmDir(CString srcpath) {
         if (!(find.dwFileAttributes  & FILE_ATTRIBUTE_DIRECTORY )) {
           if (remove(path+find.cFileName)) {
             AfxMessageBox("Error deleting "+path+find.cFileName);
-            return FALSE;
+            ok = FALSE;
           }
         } else {
           if (!RmDir(path+find.cFileName))
-            return FALSE;
+            ok = FALSE;
         }
-    } while(FindNextFile(h,&find));
+    } while(ok && FindNextFile(h,&find));
     FindClose(h);
   }
+  if (!ok)
+    return FALSE;
   if (rmdir(srcpath)) {
     AfxMessageBox("Error deleting "+srcpath);
     return FALSE;

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -256,7 +256,8 @@ void Cabout::OnLButtonDown(UINT nFlags, CPoint point)
       this->ClientToScreen(&point);
       w->ScreenToClient(&point);
     if ((point.y>=100) && (point.y<=110) || (point.y<=80)) {
-      if (!ShellExecute(NULL,"open","http://www.httrack.com","","",SW_RESTORE)) {
+      if (!ShellOpen("http://www.httrack.com", SW_RESTORE)) {
+        AfxMessageBox("Cannot open a web browser for http://www.httrack.com");
       }
     }
     break;

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -301,16 +301,18 @@ void LANG_LOAD(char* limit_to) {
 
   /* Get only language name */
   if (limit_to) {
-    if (hashname)
+    if (strnotempty(hashname))
       strcpybuff(limit_to,hashname);
     else
       strcpybuff(limit_to,"???");
     return;
   }
 
-  /* Error */
-  if (!hashname)
+  /* LANGINTKEY() returns "" on a miss, so a stale registry index would otherwise exit(1) on every start. */
+  if (!strnotempty(hashname) && selected_lang != 0) {
+    LANG_T(0);
     return;
+  }
 
   // xxc TEST
   /*
@@ -664,7 +666,6 @@ void LANG_DELETE() {
 void LANG_INIT() {
   CWinApp* pApp = AfxGetApp();
   if (pApp) {
-    int test = pApp->GetProfileInt("Language","IntId",0);
     LANG_T(pApp->GetProfileInt("Language","IntId",0));
   }
 }
@@ -672,10 +673,11 @@ void LANG_INIT() {
 int LANG_T(int l) {
   if (l>=0) {
     QLANG_T(l);
+    LANG_LOAD(NULL);
+    /* Persist only what loaded: LANG_LOAD() falls back to 0 on a bad index, and that is what must be saved. */
     CWinApp* pApp = AfxGetApp();
     if (pApp)
-      pApp->WriteProfileInt("Language","IntId",l);
-    LANG_LOAD(NULL);
+      pApp->WriteProfileInt("Language","IntId",QLANG_T(-1));
   }
   return QLANG_T(-1);  // 0=default (english)
 }


### PR DESCRIPTION
Five defects that share no code but are all latent failures on error or edge paths CI never exercises.

The engine-thread exception filter returned `EXCEPTION_CONTINUE_EXECUTION`, restarting the faulting instruction forever, so an engine access violation spun a core with no UI and the crash report was never written. It now reports from inside the filter and unwinds to the existing `HTTRACK_result == -100` path. That change is why the buffer fix ships in the same commit: making the crash reachable turns `end_mirror_msg` from rarely-built into built on every crash, and its `strcatbuff` of the unbounded command line called `abort()` on a large project. The one unbounded source is capped, and `check_continue`'s `path_log[256]`, which aborted on a deep project path, is grown to match.

`RmDir` enumerated a junction or directory symlink as a directory and recursed into it, deleting the link target's contents outside what the confirmation dialog showed. It now detects a reparse point at entry and unlinks the link itself. The same rewrite closes a `FindFirstFile` handle that leaked on the error paths.

Every `ShellExecute` error check in the tree tested the returned handle as a boolean, but success is a value above 32, so all four checks were dead and a failure (a missing help file, for instance) did nothing visible. They now route through one `ShellOpen` helper that tests `> 32`.

A stale language index in the registry called `exit(1)` at startup and bricked the app, because the guard meant to catch it compared against `NULL` while the lookup returns an empty string. The guard is now live, self-heals to English, and the index is validated before it is persisted rather than after.

The two `RunBackRobot` spin loops are corrected defensively (`||` to `&&`, braces on the `if`); they are latent, not live, since nothing sets `termine` that early today, and the commit says so.

CI covers compilation. The crash-path unwind, the junction escape, the dialogs, and the self-heal are all VM-only and owed with the rest of the VM validation. The spec also suggests a CI negative-control for the language self-heal (plant a bad index, assert exit 0); I left that as a follow-up rather than redden shared CI with a half-tested registry probe.