### PR TITLE
Fix the Transfers-dialog use-after-free on the engine's socket array

### DIFF
--- a/WinHTTrack/InfoUrl.cpp
+++ b/WinHTTrack/InfoUrl.cpp
@@ -89,7 +89,6 @@ void CInfoUrl::StopTimer() {
   if (timer) {
     KillTimer(timer);
     timer=0;
-    StatsBufferback=NULL;
   }
 }
 
@@ -143,7 +142,7 @@ const char* ToStatus(int i) {
   }
 }
 
-void CInfoUrl::OnTimer(UINT_PTR nIDEvent) 
+void CInfoUrl::OnTimer(UINT_PTR nIDEvent)
 {
   static char old_info[8192]="";
   //
@@ -151,84 +150,81 @@ void CInfoUrl::OnTimer(UINT_PTR nIDEvent)
     EndDialog(IDOK);
     return;
   }
-  if (!StatsBufferback) return;
+  // Snapshot the engine-owned rows under the lock, then render outside it: reaching
+  // into the live back[] here was a use-after-free (unlocked, freed on engine exit).
+  // Single modal CInfoUrl at a time, so a static copy is safe and spares the stack.
+  static t_StatsBuffer rows[NStatsBuffer];
+  WHTT_LOCK();
+  if (termine) {
+    WHTT_UNLOCK();
+    EndDialog(IDOK);
+    return;
+  }
+  memcpy(rows,StatsBuffer,sizeof(rows));
+  WHTT_UNLOCK();
   //
-  lien_back* back=(lien_back*) StatsBufferback;
+  int cur=id;
+  if (cur<0 || cur>=NStatsBuffer) cur=0;
   //
   if (m_ctl_backlist.GetDroppedState()==0) {
     m_ctl_backlist.Clear();
     m_ctl_backlist.ResetContent();
     int i;
-    int back_max=StatsBufferback_max;
-    for(i=0;i<back_max;i++) {
-      if (termine) {
-        EndDialog(IDOK);
-        return;
-      }
-      if (back[i].status != -1) {
+    for(i=0;i<NStatsBuffer;i++) {
+      if (rows[i].etat[0]) {
         char st[HTS_URLMAXSIZE*4];
         sprintf(st,"%02d: ",i);
-        strncatbuff(st,back[i].url_adr,256);
-        strncatbuff(st,back[i].url_fil,256);
+        strncatbuff(st,rows[i].url_adr,256);
+        strncatbuff(st,rows[i].url_fil,256);
         m_ctl_backlist.AddString(st);
       }
     }
   }
   //
-  if (back) {
-    CInfoUrl box;
+  {
+    t_StatsBuffer* it=&rows[cur];
     char info[8192]; info[0]='\0';
     char total[256]; total[0]='\0';
     char info100[256]; info100[0]='\0';
     int offset=0;
-    if (back[id].status != -1) {        // utilisé
-      if (back[id].r.totalsize>0) {
-        sprintf(total,LLintP,(LLint)back[id].r.totalsize);
-        offset=(int) ((LONGLONG) ((LONGLONG) back[id].r.size*(LONGLONG) 100)/((LONGLONG) back[id].r.totalsize));
+    if (it->etat[0]) {        // ligne active
+      if (it->r_totalsize>0) {
+        sprintf(total,LLintP,(LLint)it->r_totalsize);
+        offset=(int) ((LONGLONG) ((LONGLONG) it->r_size*(LONGLONG) 100)/((LONGLONG) it->r_totalsize));
         sprintf(info100,"(%d%%)",offset);
       } else {
         sprintf(total,"unknown");
-        sprintf(info100,"");
+        info100[0]='\0';
       }
-      sprintf(info,"File: %s\r\nTotal length: %s\r\nBytes downloaded: " LLintP " %s\r\nCurrent state: %s",back[id].url_sav,total,back[id].r.size,info100,ToStatus(back[id].status));
+      sprintf(info,"File: %s\r\nTotal length: %s\r\nBytes downloaded: " LLintP " %s\r\nCurrent state: %s",it->url_sav,total,it->r_size,info100,ToStatus(it->status));
     }
     //
     if (strcmp(old_info,info)) {
       char moreinfo[8192]; moreinfo[0]='\0';
-      lien_back* backitem=&back[id];
-      if (backitem) {
-        if (back[id].status != -1) {        // utilisé
-          sprintf(moreinfo+strlen(moreinfo),"Host: %s\r\n",backitem->url_adr);
-          sprintf(moreinfo+strlen(moreinfo),"File: %s\r\n",backitem->url_fil);
-          sprintf(moreinfo+strlen(moreinfo),"Name: %s\r\n",backitem->url_sav);
-          if (backitem->location_buffer)
-            if (backitem->location_buffer[0])
-              sprintf(moreinfo+strlen(moreinfo),"MoveToLocation: %s\r\n",backitem->location_buffer);
-            //
-            sprintf(moreinfo+strlen(moreinfo),"ContentType: %s\r\n",backitem->r.contenttype);
-            //
-            sprintf(moreinfo+strlen(moreinfo),"StatusCode: %d (%s)\r\n",backitem->r.statuscode,ToStatuscode(backitem->r.statuscode));
-            sprintf(moreinfo+strlen(moreinfo),"InternalStatus: %d (%s)\r\n",backitem->status,ToStatus(backitem->status));
-            if (backitem->r.msg[0])
-              sprintf(moreinfo+strlen(moreinfo),"StatusMessage: %s\r\n",backitem->r.msg);
-            //
-            sprintf(moreinfo+strlen(moreinfo),"HTTP/1.1: %s\r\n",ToBool(backitem->r.req.http11));
-            sprintf(moreinfo+strlen(moreinfo),"ChunkMode: %s\r\n",ToBool(backitem->r.is_chunk));
-            if (backitem->is_chunk)
-              sprintf(moreinfo+strlen(moreinfo),"CurrentChunkSize: " LLintP "\r\n",backitem->chunk_size);
-            //
-            sprintf(moreinfo+strlen(moreinfo),"TestMode: %s\r\n",ToBool(backitem->testmode));
-            sprintf(moreinfo+strlen(moreinfo),"HeadRequest: %s\r\n",ToBool(backitem->head_request));
-            sprintf(moreinfo+strlen(moreinfo),"NotModified: %s\r\n",ToBool(backitem->r.notmodified));
-            //
-            sprintf(moreinfo+strlen(moreinfo),"WriteToDisk: %s\r\n",ToBool(backitem->r.is_write));
-            sprintf(moreinfo+strlen(moreinfo),"LocalFile: %s\r\n",ToBool(backitem->r.is_file));
-            //
-            sprintf(moreinfo+strlen(moreinfo),"Size: " LLintP "\r\n",backitem->r.size);
-            sprintf(moreinfo+strlen(moreinfo),"TotalSize: " LLintP "\r\n",backitem->r.totalsize);
-        } else
-          strcpybuff(moreinfo,"Transfer complete in this buffer, waiting for next file");
-      }
+      if (it->etat[0]) {        // ligne active
+        sprintf(moreinfo+strlen(moreinfo),"Host: %s\r\n",it->url_adr);
+        sprintf(moreinfo+strlen(moreinfo),"File: %s\r\n",it->url_fil);
+        sprintf(moreinfo+strlen(moreinfo),"Name: %s\r\n",it->url_sav);
+        if (it->location[0])
+          sprintf(moreinfo+strlen(moreinfo),"MoveToLocation: %s\r\n",it->location);
+        sprintf(moreinfo+strlen(moreinfo),"ContentType: %s\r\n",it->contenttype);
+        sprintf(moreinfo+strlen(moreinfo),"StatusCode: %d (%s)\r\n",it->statuscode,ToStatuscode(it->statuscode));
+        sprintf(moreinfo+strlen(moreinfo),"InternalStatus: %d (%s)\r\n",it->status,ToStatus(it->status));
+        if (it->msg[0])
+          sprintf(moreinfo+strlen(moreinfo),"StatusMessage: %s\r\n",it->msg);
+        sprintf(moreinfo+strlen(moreinfo),"HTTP/1.1: %s\r\n",ToBool(it->http11));
+        sprintf(moreinfo+strlen(moreinfo),"ChunkMode: %s\r\n",ToBool(it->is_chunk));
+        if (it->lien_chunk)
+          sprintf(moreinfo+strlen(moreinfo),"CurrentChunkSize: " LLintP "\r\n",it->chunk_size);
+        sprintf(moreinfo+strlen(moreinfo),"TestMode: %s\r\n",ToBool(it->testmode));
+        sprintf(moreinfo+strlen(moreinfo),"HeadRequest: %s\r\n",ToBool(it->head_request));
+        sprintf(moreinfo+strlen(moreinfo),"NotModified: %s\r\n",ToBool(it->notmodified));
+        sprintf(moreinfo+strlen(moreinfo),"WriteToDisk: %s\r\n",ToBool(it->is_write));
+        sprintf(moreinfo+strlen(moreinfo),"LocalFile: %s\r\n",ToBool(it->is_file));
+        sprintf(moreinfo+strlen(moreinfo),"Size: " LLintP "\r\n",it->r_size);
+        sprintf(moreinfo+strlen(moreinfo),"TotalSize: " LLintP "\r\n",it->r_totalsize);
+      } else
+        strcpybuff(moreinfo,"Transfer complete in this buffer, waiting for next file");
       //
       SetDlgItemTextUTF8(this, IDC_InfoUrl,info);
       SetDlgItemTextUTF8(this, IDC_Info100,info100);

--- a/WinHTTrack/InfoUrl.h
+++ b/WinHTTrack/InfoUrl.h
@@ -8,9 +8,6 @@
 //
 
 extern int termine;
-extern void* StatsBufferback;
-//extern lien_back* back;
-extern int StatsBufferback_max;
 
 /////////////////////////////////////////////////////////////////////////////
 // CInfoUrl dialog

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -181,8 +181,6 @@ Cinprogress* inprogress=NULL;
 
 // nbre de slides
 t_StatsBuffer StatsBuffer[NStatsBuffer];
-void* StatsBufferback=NULL;
-int StatsBufferback_max=0;
 InpInfo SInfo;
 
 #if USE_RAS
@@ -1315,8 +1313,6 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
         int l;            // idem
         int M=32;         // idem
         
-        StatsBufferback=(void*) back;
-        StatsBufferback_max=back_max;
         {
           int i;
           for(i=0;i<NStatsBuffer;i++) {
@@ -1399,6 +1395,27 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                   //
                   s[0]='\0';
                   strcpybuff(StatsBuffer[index].url_sav,back[i].url_sav);   // pour cancel
+                  strcpybuff(StatsBuffer[index].url_adr,back[i].url_adr);
+                  strcpybuff(StatsBuffer[index].url_fil,back[i].url_fil);
+                  StatsBuffer[index].location[0]='\0';
+                  strncatbuff(StatsBuffer[index].location,back[i].location_buffer,HTS_URLMAXSIZE*2-1);
+                  StatsBuffer[index].contenttype[0]='\0';
+                  strncatbuff(StatsBuffer[index].contenttype,back[i].r.contenttype,HTS_MIMETYPE_SIZE-1);
+                  StatsBuffer[index].msg[0]='\0';
+                  strncatbuff(StatsBuffer[index].msg,back[i].r.msg,79);
+                  StatsBuffer[index].status=back[i].status;
+                  StatsBuffer[index].r_size=back[i].r.size;
+                  StatsBuffer[index].r_totalsize=back[i].r.totalsize;
+                  StatsBuffer[index].statuscode=back[i].r.statuscode;
+                  StatsBuffer[index].http11=back[i].r.req.http11;
+                  StatsBuffer[index].is_chunk=back[i].r.is_chunk;
+                  StatsBuffer[index].lien_chunk=back[i].is_chunk;
+                  StatsBuffer[index].chunk_size=back[i].chunk_size;
+                  StatsBuffer[index].testmode=back[i].testmode;
+                  StatsBuffer[index].head_request=back[i].head_request;
+                  StatsBuffer[index].notmodified=back[i].r.notmodified;
+                  StatsBuffer[index].is_write=back[i].r.is_write;
+                  StatsBuffer[index].is_file=back[i].r.is_file;
                   if (strcmp(back[i].url_adr,"file://"))
                     strcatbuff(s,back[i].url_adr);
                   else

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -67,6 +67,23 @@ typedef struct t_StatsBuffer {
   int back;
   //
   int actived;    // pour disabled
+  // Transfers dialog (CInfoUrl) detail snapshot, filled under WHTT_LOCK on T2
+  int status;
+  LLint r_size;
+  LLint r_totalsize;
+  int statuscode;
+  int http11;
+  int is_chunk;      // htsblk r.is_chunk
+  int lien_chunk;    // lien_back.is_chunk (drives CurrentChunkSize)
+  LLint chunk_size;
+  int testmode;
+  int head_request;
+  int notmodified;
+  int is_write;
+  int is_file;
+  char contenttype[HTS_MIMETYPE_SIZE];
+  char msg[80];
+  char location[HTS_URLMAXSIZE * 2];
 } t_StatsBuffer;
 
 typedef struct InpInfo {

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -209,6 +209,9 @@ BOOL LaunchMirror();
 
 #define NStatsBuffer                    14
 
+// Defined in Shell.cpp; the Transfers dialog snapshots it under WHTT_LOCK.
+extern t_StatsBuffer StatsBuffer[NStatsBuffer];
+
 /* Class */
 class CShellOptions {
 public:

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -70,7 +70,6 @@ extern CWizTab* this_intCWizTab;
 // Pour la fin
 char end_mirror_msg[8192]="";
 
-extern t_StatsBuffer StatsBuffer[NStatsBuffer];
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -801,7 +801,7 @@ void Cinprogress::StatsBuffer_info(int id) {
     if (SInfo.stat_time>0) {
       if (StatsBuffer[id].etat[0]) {
         CInfoUrl box;
-        box.id=StatsBuffer[id].back;
+        box.id=id;
         _Cinprogress_inst=&box;
         WHTT_UNLOCK();
         {


### PR DESCRIPTION
The Transfers dialog read the engine's live socket array directly, with no lock, on a 100 ms timer. `CInfoUrl::OnTimer` (UI thread) dereferenced `StatsBufferback`, a raw pointer into the engine thread's `lien_back back[]`, and its count from a second unsynchronised global. Three ways to fail: a string read while the engine rewrites that slot in place, a stale base paired with a fresh count, and a use-after-free once `hts_main2` frees the array at the end of a mirror. The `if (termine)` guards there are themselves unsynchronised and order nothing.

The fix follows the pattern the code already uses correctly for the main progress page. The engine thread, which is the only thread that may touch `back[]`, fills the fields the dialog needs into the existing locked `StatsBuffer` snapshot. `OnTimer` copies that snapshot under `WHTT_LOCK()` into dialog-owned storage and then renders from the copy with the lock released. `StatsBufferback` and its extern declarations are gone.

Deadlock freedom: there is one lock (`WhttMutex`), so no ordering cycle exists, and `OnTimer` now holds it across a single `memcpy` and nothing else. No GUI call, no engine call, no allocation happens under the lock, so the UI thread never blocks the engine while holding it. This is strictly less hold time than the existing progress refresh, which already holds the same lock across dozens of GUI calls.

Behavior change: the dialog lists at most the snapshot's rows (the same cap the main page uses) and the data is up to 100 ms staler, against a few kilobytes more static storage.

This is the one fix in this batch that CI cannot validate. It compiles and links, and `--selftest` passes, but the race and the use-after-free only exist with a live multi-socket mirror, the Transfers dialog open, and a cancel mid-transfer. I claim no runtime validation; that is owed on the VM before this is trusted. It is also finding 1 of the audit's concurrency cluster; findings 2, 3 and 5 remain open.