### PR TITLE
Extend our copyright year to 2026

### DIFF
--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 2014 Xavier Roche and other contributors
+Copyright (C) 2014-2026 Xavier Roche and other contributors
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 2014 Xavier Roche and other contributors
+Copyright (C) 2014-2026 Xavier Roche and other contributors
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/WinHTTrack/HTTrackInterface.c
+++ b/WinHTTrack/HTTrackInterface.c
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------ */
 /*
 HTTrack Website Copier, Offline Browser for Windows and Unix
-Copyright (C) 1998 Xavier Roche and other contributors
+Copyright (C) 1998-2026 Xavier Roche and other contributors
 
 SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
Extends the three of our own copyright notices that still ended before 2026 (CrashReport.cpp/.h at 2014, HTTrackInterface.c at 1998) to a range ending in 2026, each keeping its original start year. The other notices were already 2026.

Third-party copyrights are deliberately left alone: Gipsysoft in RasLoad, Microsoft in the MFC-derived headers (HtmlFrm.h, MainFrm.h, splitter.h, HtmlCtrl), and the GPL text in COPYING/gpl.txt. ASCII-only edits; the Latin-1 file's CRLF and high bytes are preserved.