### PR TITLE
Convert C/C++ sources from ISO-8859-1 to UTF-8

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -26,9 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Byte-exact on purpose. The sources are ISO-8859-1 (accented French
-      # comments), and grep-family tools treat them as binary and silently match
-      # nothing, so a shell-based guard here would never fire.
+      # Byte-exact on purpose: sources are UTF-8, the .rc/tooling inputs stay
+      # Latin-1, and a shell guard can't tell them apart. Python decodes strictly.
       - name: Encoding and line endings
         run: |
           python3 - <<'EOF'
@@ -39,17 +38,24 @@ jobs:
                                    capture_output=True, text=True, check=True).stdout
               return [p for p in out.splitlines() if p]
 
+          SOURCE = tracked('*.cpp', '*.h', '*.c')
           LF_ONLY = tracked('*.cpp', '*.h')
           CRLF_ONLY = tracked('*.rc', '*.rc2', '*.def', '*.idl', '*.rgs', '*.sln',
                               '*.vcproj', '*.vcxproj', '*.props', '*.manifest',
                               '*.dsp', '*.dsw', '*.iss')
           bad = []
 
-          # A UTF-8-assuming editor rewrites the Latin-1 bytes to U+FFFD and
-          # destroys the text. That is silent in review; fail loudly instead.
-          for p in LF_ONLY + CRLF_ONLY:
+          # Sources are UTF-8: a Latin-1 regression (a raw 0xe9) fails this decode.
+          for p in SOURCE:
+              try:
+                  open(p, 'rb').read().decode('utf-8')
+              except UnicodeDecodeError as e:
+                  bad.append(f'{p}: not valid UTF-8 ({e})')
+
+          # U+FFFD is valid UTF-8 but means a tool mangled the text; fail loudly.
+          for p in SOURCE + CRLF_ONLY:
               if b'\xef\xbf\xbd' in open(p, 'rb').read():
-                  bad.append(f'{p}: contains U+FFFD; a UTF-8 tool mangled the Latin-1 text')
+                  bad.append(f'{p}: contains U+FFFD; a UTF-8 tool mangled the text')
 
           for p in LF_ONLY:
               if b'\r' in open(p, 'rb').read():
@@ -70,7 +76,7 @@ jobs:
           if bad:
               print('\n'.join(bad))
               sys.exit(1)
-          print(f'OK: {len(LF_ONLY)} LF sources, {len(CRLF_ONLY)} CRLF tooling files, no mojibake.')
+          print(f'OK: {len(SOURCE)} UTF-8 sources, {len(CRLF_ONLY)} Latin-1 CRLF tooling files.')
           EOF
 
   build:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0601;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- UTF-8 sources; ANSI build keeps the system execution charset (no non-ASCII narrow literals). -->
+      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/WinHTTrack/AddFilter.cpp
+++ b/WinHTTrack/AddFilter.cpp
@@ -100,12 +100,12 @@ BOOL CAddFilter::OnInitDialog()
   SetIcon(httrack_icon,true);  
   EnableToolTips(true);     // TOOL TIPS	
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
     SetWindowTextCP(this, LANG(LANG_B5) /*"Ajouter un filtre"*/);
-    SetDlgItemTextCP(this, IDC_STATIC_rule,LANG(LANG_B6) /*"Choisir une règle:"*/);
-    SetDlgItemTextCP(this, IDC_affkeyword,LANG(LANG_B7) /*"Entrer un mot clé:"*/);
+    SetDlgItemTextCP(this, IDC_STATIC_rule,LANG(LANG_B6) /*"Choisir une rÃ¨gle:"*/);
+    SetDlgItemTextCP(this, IDC_affkeyword,LANG(LANG_B7) /*"Entrer un mot clÃ©:"*/);
     SetDlgItemTextCP(this, IDCANCEL,LANG(LANG_CANCEL) /*"Annuler"*/);
     SetDlgItemTextCP(this, IDOK,LANG(LANG_B8) /*"Ajouter"*/);
     SetCombo(this,IDC_AFtype,LISTDEF_1);
@@ -122,7 +122,7 @@ void CAddFilter::OnSelchangeAFtype()
   strcpybuff(hlp,LANG(LANG_B22)); //  "Example: ");
   r=m_ctl_aftype.GetCurSel();
   switch(r) {
-  case CB_ERR : break;  // pas de sélection
+  case CB_ERR : break;  // pas de sÃ©lection
   case 0:
     strcatbuff(hlp,LANG(LANG_B23)); // "gif\x0d\x0aWill detect all gif files (or GIF files)");
     break;
@@ -236,10 +236,10 @@ BOOL CAddFilter::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
 const char* CAddFilter::GetTip(int ID)
 {
   switch(ID) {
-    case IDC_AFtype: return LANG(LANG_B1); /*"Select a rule for the filter","Choisissez une règle pour le filtre");*/ break;
-    case IDC_AFext:  return LANG(LANG_B2); /*"Enter here keywords for the filter","Entrez ici un mot clé pour le filtre");*/ break;
+    case IDC_AFtype: return LANG(LANG_B1); /*"Select a rule for the filter","Choisissez une rÃ¨gle pour le filtre");*/ break;
+    case IDC_AFext:  return LANG(LANG_B2); /*"Enter here keywords for the filter","Entrez ici un mot clÃ© pour le filtre");*/ break;
     case IDCANCEL:   return LANG(LANG_B3); /*"Cancel","Annuler");*/ break;
-    case IDOK:       return LANG(LANG_B4); /*"Add this filter","Ajouter cette règle");*/ break;
+    case IDOK:       return LANG(LANG_B4); /*"Add this filter","Ajouter cette rÃ¨gle");*/ break;
     //case : return ""; break;
   }
   return "";

--- a/WinHTTrack/BuildOptions.cpp
+++ b/WinHTTrack/BuildOptions.cpp
@@ -93,8 +93,8 @@ BOOL CBuildOptions::OnInitDialog()
 {
 	CDialog::OnInitDialog();
 	
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this, LANG(LANG_Q1)); // struct
     SetDlgItemTextCP(this, IDOK,LANG(LANG_OK ));
     SetDlgItemTextCP(this, IDC_STATIC_options,LANG_O2);

--- a/WinHTTrack/CatchUrl.cpp
+++ b/WinHTTrack/CatchUrl.cpp
@@ -127,8 +127,8 @@ BOOL CCatchUrl::OnInitDialog()
 	CDialog::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this, LANG(LANG_V1));
     SetDlgItemTextCP(this, IDC_STATIC_info,LANG_V2);
     SetDlgItemTextCP(this, IDC_STATIC_info2,LANG_V3);

--- a/WinHTTrack/DialogContainer.h
+++ b/WinHTTrack/DialogContainer.h
@@ -33,7 +33,7 @@ Please visit our Website: http://www.httrack.com
 // DialogContainer.h : header file
 //
 
-// Includes pour objet encapsulé
+// Includes pour objet encapsulÃ©
 #include "WizTab.h"
 
 /////////////////////////////////////////////////////////////////////////////

--- a/WinHTTrack/DialogHtmlHelp.cpp
+++ b/WinHTTrack/DialogHtmlHelp.cpp
@@ -110,7 +110,7 @@ BOOL CDialogHtmlHelp::OnInitDialog()
     strcatbuff(home,"index.html");
   }
 
-  // créer
+  // crÃ©er
   if (m_page.CreateFromStatic(IDC_HTMLVIEW, this)) {
     m_page.SetToolBar(false);
     m_page.SetMenuBar(false);
@@ -271,7 +271,7 @@ const char* CDialogHtmlHelp::GetTip(int ID)
 {
   switch(ID) {
     case IDCANCEL:   return LANG(LANG_B3); /*"Cancel","Annuler");*/ break;
-    case IDOK:       return LANG(LANG_B4); /*"Add this filter","Ajouter cette règle");*/ break;
+    case IDOK:       return LANG(LANG_B4); /*"Add this filter","Ajouter cette rÃ¨gle");*/ break;
   }
   return "";
 }

--- a/WinHTTrack/DirTreeView.cpp
+++ b/WinHTTrack/DirTreeView.cpp
@@ -180,7 +180,7 @@ void CDirTreeView::RefreshTree() {
   BuildTrackHandles();
 }
 
-/* remise à zéro */
+/* remise Ã  zÃ©ro */
 void CDirTreeView::ResetTree() {
   if (!GetTreeCtrl()) return;   /* error */
   RefreshTree();
@@ -259,7 +259,7 @@ void CDirTreeView::OnDblclk(NMHDR* pNMHDR, LRESULT* pResult)
               //}
             }
           } else {
-            /* Lancer ShellEx en arrière plan */
+            /* Lancer ShellEx en arriÃ¨re plan */
             AfxBeginThread(CDirTreeViewShellEx,new CString(name));
           }
         }
@@ -411,7 +411,7 @@ HTREEITEM CDirTreeView::GetPathItem(CString path,BOOL open,BOOL nofail,BOOL nohi
 BOOL CDirTreeView::EnsureVisible(CString path) {
   if (!GetTreeCtrl()) return FALSE;   /* error */
 #if 0
-  /* Lancer refresh en arrière plan */
+  /* Lancer refresh en arriÃ¨re plan */
   refreshPath=path;
   StopTimer();
   AfxBeginThread(CDirTreeViewRefresh,this);
@@ -468,7 +468,7 @@ BOOL CDirTreeView::RefreshDir(HTREEITEM position,BOOL nohide) {
     if (!nohide)
       tree.ModifyStyle(WS_VISIBLE,0);
 
-    { // backuper éléments visibles
+    { // backuper Ã©lÃ©ments visibles
       HTREEITEM it=tree.GetChildItem(position);
       int backup_visibles_count=0;
       while(it) {
@@ -530,7 +530,7 @@ BOOL CDirTreeView::RefreshDir(HTREEITEM position,BOOL nohide) {
         h = FindFirstFile(path+"*.*",&find);
     }
 
-    // restaurer éléments visibles
+    // restaurer Ã©lÃ©ments visibles
     RestoreVisibles(position,backup_visibles);
 
     // liste visible
@@ -552,12 +552,12 @@ void CDirTreeView::RestoreVisibles(HTREEITEM position,CString& backup_visibles) 
   if (!tree) return;   /* error */
 
   if (backup_visibles.GetLength()) {
-    // réouvrir les éléments visibles
+    // rÃ©ouvrir les Ã©lÃ©ments visibles
     HTREEITEM it=tree.GetChildItem(position);
     while(it) {
       if (backup_visibles.Find("\n"+GetItemPath(it)+"\n")>=0) {
         tree.Expand(it,TVE_EXPAND);
-        RefreshDir(it,TRUE);       /* car appelé par RefreshDir lui même */
+        RefreshDir(it,TRUE);       /* car appelÃ© par RefreshDir lui mÃªme */
         RestoreVisibles(it,backup_visibles);
       }
       it=tree.GetNextSiblingItem(it);
@@ -597,7 +597,7 @@ void CDirTreeView::BuildTrackHandles()
 {
   if (!GetTreeCtrl()) return;   /* error */
   DestroyTrackHandles();
-  /* Lecture éléments du root visibles (non, c'est pas récursif vu que ce sont les élts visibles) */
+  /* Lecture Ã©lÃ©ments du root visibles (non, c'est pas rÃ©cursif vu que ce sont les Ã©lts visibles) */
   CTreeCtrl& it=GetTreeCtrl();
   HTREEITEM pos=it.GetFirstVisibleItem();
   while(pos) {
@@ -605,7 +605,7 @@ void CDirTreeView::BuildTrackHandles()
     CFileStatus status;
     if (it.ItemHasChildren(pos)) {        /* surveiller si enfants */
       if (it.GetItemState(pos,TVIF_STATE) & TVIS_EXPANDED) {    /* si ouvert */
-        if (CFile::GetStatus(path.Left(path.GetLength()-1),status)) {   // répertoire (note: path sans le / final)
+        if (CFile::GetStatus(path.Left(path.GetLength()-1),status)) {   // rÃ©pertoire (note: path sans le / final)
           if (status.m_attribute & 0x10 ) {       /* directory = 0x10 */
             whandle[count_whandle]=FindFirstChangeNotification(path,FALSE,FILE_NOTIFY_CHANGE_FILE_NAME|FILE_NOTIFY_CHANGE_DIR_NAME);
             if (whandle[count_whandle] != INVALID_HANDLE_VALUE) {
@@ -628,7 +628,7 @@ void CDirTreeView::DoTrackHandles()
 
   if (count_whandle) {
     int r=(WaitForMultipleObjects(count_whandle,whandle,FALSE,0)-WAIT_OBJECT_0);
-    if ( (r>=0) && (r<count_whandle) ) {      // un item a changé
+    if ( (r>=0) && (r<count_whandle) ) {      // un item a changÃ©
       DestroyTrackHandles();
       HTREEITEM pos=pos_whandle[r];
       RefreshPos(pos);

--- a/WinHTTrack/EasyDropTarget.cpp
+++ b/WinHTTrack/EasyDropTarget.cpp
@@ -264,7 +264,7 @@ CString CEasyDropTarget::DoImportFile(HDROP hDropInfo)
     int size;
     size=DragQueryFile(hDropInfo,i,NULL,0);    // buffer size
     if (size>0) {
-      size+=16;    // marge de sécurité
+      size+=16;    // marge de sÃ©curitÃ©
       buff=(char*) calloc(size,1);
       if (buff) {
         if (DragQueryFile(hDropInfo,i,buff,size)>0) {    // ok copied

--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -98,7 +98,7 @@ BOOL CFirstInfo::OnSetActive( ) {
 
 BOOL CFirstInfo::OnQueryCancel( ) {
   //  if (AfxMessageBox(LANG(LANG_J1),MB_OKCANCEL)==IDOK) {
-  /* Envoyer un WM_CLOSE à notre fenêtre principale */
+  /* Envoyer un WM_CLOSE Ã  notre fenÃªtre principale */
   GetMainWindow()->SendMessage(WM_CLOSE,0,0);
   //  }
   return FALSE;
@@ -116,8 +116,8 @@ BOOL CFirstInfo::OnInitDialog()
   wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1; 
   m_splash.SetWindowPlacement(&wp);
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemText(,"");
     
     SetDlgItemTextCP(this,IDC_STATIC_welcome, LANG_Y1);

--- a/WinHTTrack/HTTrackInterface.c
+++ b/WinHTTrack/HTTrackInterface.c
@@ -44,7 +44,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsopt.h"
 #include "HTTrackInterface.h"
 
-// Lecture d'une ligne (peut être unicode à priori)
+// Lecture d'une ligne (peut Ãªtre unicode Ã  priori)
 int linput(FILE* fp,char* s,int max) {
   int c;
   int j=0;
@@ -54,7 +54,7 @@ int linput(FILE* fp,char* s,int max) {
       switch(c) {
         case 13: break;  // sauter CR
         case 10: c=-1; break;
-        case 9: case 12: break;  // sauter ces caractères
+        case 9: case 12: break;  // sauter ces caractÃ¨res
         default: s[j++]=(char) c; break;
       }
     }
@@ -74,7 +74,7 @@ int linput_trim(FILE* fp,char* s,int max) {
       // sauter espaces et tabs en fin
       while( (rlen>0) && ((ls[max(rlen-1,0)]==' ') || (ls[max(rlen-1,0)]=='\t')) )
         ls[--rlen]='\0';
-      // sauter espaces en début
+      // sauter espaces en dÃ©but
       a=ls;
       while((rlen>0) && ((*a==' ') || (*a=='\t'))) {
         a++;
@@ -106,7 +106,7 @@ int linput_cpp(FILE* fp,char* s,int max) {
   return rlen;
 }
 
-// idem avec les car spéciaux
+// idem avec les car spÃ©ciaux
 void rawlinput(FILE* fp,char* s,int max) {
   int c;
   int j=0;

--- a/WinHTTrack/InfoUrl.cpp
+++ b/WinHTTrack/InfoUrl.cpp
@@ -92,8 +92,8 @@ BOOL CInfoUrl::OnInitDialog()
   SetIcon(httrack_icon,true);  
   SetForegroundWindow();   // yop en premier plan!
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this, LANG_X1);
     SetDlgItemTextCP(this, IDC_Freeze,LANG_X2);
     SetDlgItemTextCP(this, IDC_STATIC_moreinfos,LANG_X3);

--- a/WinHTTrack/Infoend.cpp
+++ b/WinHTTrack/Infoend.cpp
@@ -71,7 +71,7 @@ extern CSplitterFrame* this_CSplitterFrame;
 extern CWizTab* this_CWizTab;
 extern CWizTab* this_intCWizTab2;
 
-/* Objet lui même */
+/* Objet lui mÃªme */
 Cinfoend* this_Cinfoend=NULL;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -127,8 +127,8 @@ BOOL Cinfoend::OnInitDialog()
   EnableToolTips(true);     // TOOL TIPS
   //SetForegroundWindow();   // yop en premier plan!
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
     //SetWindowTextCP(this, LANG(LANG_D6) /*"Fin du miroir"*/);
     SetDlgItemTextCP(this, IDlog,LANG(LANG_D7) /*"Voir fichier d'audit"*/);
@@ -156,7 +156,7 @@ void Cinfoend::Onlog()
   if (strlen(pathlog)>0)
   if ((pathlog[strlen(pathlog)-1]!='/') && (pathlog[strlen(pathlog)-1]!='\\'))
     strcatbuff(pathlog,"/");
-  // fichier log existe ou on est télécommandé par un !
+  // fichier log existe ou on est tÃ©lÃ©commandÃ© par un !
   if ( (fexist(fconcat(catbuff,sizeof(catbuff),pathlog,"hts-err.txt")))
     || (fexist(fconcat(catbuff,sizeof(catbuff),pathlog,"hts-log.txt"))) ) {
     strcpybuff(form.pathlog,pathlog);
@@ -271,14 +271,14 @@ void Cinfoend::OnBye()
 
 BOOL Cinfoend::OnQueryCancel( ) {
   //if (AfxMessageBox(LANG(LANG_J1),MB_OKCANCEL)==IDOK) {
-  /* Envoyer un WM_CLOSE à notre fenêtre principale */
+  /* Envoyer un WM_CLOSE Ã  notre fenÃªtre principale */
   GetMainWindow()->SendMessage(WM_CLOSE,0,0);
   //}
   return FALSE;
 }
 
 BOOL Cinfoend::OnSetActive( ) {
-  // détruire ICI sinon crash!!!!
+  // dÃ©truire ICI sinon crash!!!!
   WHTT_LOCATION("Infoend");
   if (this_intCWizTab2) {
     this_intCWizTab2->DestroyWindow();

--- a/WinHTTrack/InsertUrl.cpp
+++ b/WinHTTrack/InsertUrl.cpp
@@ -104,7 +104,7 @@ BOOL CInsertUrl::OnInitDialog()
   EnableToolTips(true);     // TOOL TIPS
   SetForegroundWindow();   // yop en premier plan!
 	
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this,  LANG(LANG_T1));
     SetDlgItemTextCP(this, IDC_STATIC_adr,LANG(LANG_T2));
     SetDlgItemTextCP(this, IDC_STATIC_auth,LANG(LANG_T4));
@@ -242,7 +242,7 @@ UINT RunBackCatchServer( LPVOID pP ) {
 
 void CInsertUrl::Oncapt() 
 {
-  // Demander un port d'écoute
+  // Demander un port d'Ã©coute
   adr_prox[0]='\0';
   port_prox=0;
   soc=catch_url_init_std(&port_prox,adr_prox);

--- a/WinHTTrack/InsertUrl.h
+++ b/WinHTTrack/InsertUrl.h
@@ -33,8 +33,8 @@ Please visit our Website: http://www.httrack.com
 // InsertUrl.h : header file
 //
 
-// Attention, définition existante également dans htslib.h
-// (à modifier avec celle-ci)
+// Attention, dÃ©finition existante Ã©galement dans htslib.h
+// (Ã  modifier avec celle-ci)
 #define POSTTOK "?>post"
 
 /* Externe C */

--- a/WinHTTrack/Iplog.cpp
+++ b/WinHTTrack/Iplog.cpp
@@ -161,12 +161,12 @@ void Ciplog::AffLogRefresh() {
           case 10: {
             *a='\0';
             if (filter & 1) {
-              if (strstr(startline,"Debug:")) {       // éliminer débug
+              if (strstr(startline,"Debug:")) {       // Ã©liminer dÃ©bug
                 a=startline;
               }
             }
             if (filter & 2) {
-              if (strstr(startline,"Info:")) {       // éliminer info
+              if (strstr(startline,"Info:")) {       // Ã©liminer info
                 a=startline;
               }
             }
@@ -190,7 +190,7 @@ void Ciplog::AffLogRefresh() {
       *a='\0';
     }
     if (strlen(dat)>0) {
-      // avant d'écrire on sauvegarde la position (bah oui.. c chiant)
+      // avant d'Ã©crire on sauvegarde la position (bah oui.. c chiant)
       txt += dat;
       int lh = m_ctl_iplog.GetScrollPos(SB_HORZ);
       int lv = m_ctl_iplog.GetScrollPos(SB_VERT);
@@ -230,8 +230,8 @@ BOOL Ciplog::OnInitDialog()
   ///m_ctl_iplog.ModifyStyleEx(0,WS_EX_CLIENTEDGE|WS_EX_DLGMODALFRAME);
   //m_ctl_iplog.SetReadOnly(FALSE);     // en blanc
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
     SetDlgItemTextCP(this, IDC_STATIC_type,LANG(LANG_E4)); // "Type d'infos:");
     SetDlgItemTextCP(this, IDC_logtype,LANG(LANG_E5)); // "Erreurs");
@@ -241,7 +241,7 @@ BOOL Ciplog::OnInitDialog()
     SetCombo(this,IDC_HIDEINFO,LISTDEF_2);
   }
 
-  // démarrer timer
+  // dÃ©marrer timer
   StartTimer();
 
 	return TRUE;  // return TRUE unless you set the focus to a control
@@ -377,7 +377,7 @@ void Ciplog::OnSelchangeHideinfo()
 {
   int r=m_ctl_hideinfo.GetCurSel();
   switch(r) {
-  case CB_ERR : break;  // pas de sélection
+  case CB_ERR : break;  // pas de sÃ©lection
   default:
     type_filter=r;
   break;

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -79,7 +79,7 @@ CMainTab::~CMainTab()
 void CMainTab::AddControlPages()
 {
   m_hIcon = httrack_icon;
-  m_psh.dwFlags |= PSP_USEHICON;  // utiliser icône
+  m_psh.dwFlags |= PSP_USEHICON;  // utiliser icÃ´ne
   m_psh.dwFlags &= ~PSH_HASHELP;  // pas de bouton help
   m_psh.hIcon = m_hIcon;
   //m_psh.pszIcon = "test";
@@ -154,17 +154,17 @@ BOOL CMainTab::OnInitDialog()
     }
   }
 */  
-  // Chargement des préférences
+  // Chargement des prÃ©fÃ©rences
   LoadPrefs();
   
-  // Appliquer préférences
+  // Appliquer prÃ©fÃ©rences
   Apply();
   
   int r = CPropertySheet::OnInitDialog();
   //SetActivePage(GetPageCount()-1);
   SetActivePage(0);
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   return r;
 }
 HCURSOR CMainTab::OnQueryDragIcon()
@@ -183,7 +183,7 @@ void CMainTab::OnSysCommand(UINT nID, LPARAM lParam)
 {
   /*if ((nID & 0xFFF0) == IDM_ABOUTBOX)
   {
-    SetActivePage(GetPageCount()-1);    // Afficher informations sur le programme et affichant la dernière page des control TAB
+    SetActivePage(GetPageCount()-1);    // Afficher informations sur le programme et affichant la derniÃ¨re page des control TAB
  	}
   else
   {
@@ -193,7 +193,7 @@ void CMainTab::OnSysCommand(UINT nID, LPARAM lParam)
   */
 }
 
-// L'utilisateur a appuyé sur "Apply"
+// L'utilisateur a appuyÃ© sur "Apply"
 void CMainTab::OnApplyNow()
 {
   EnableWindow(false);
@@ -202,15 +202,15 @@ void CMainTab::OnApplyNow()
   EnableWindow(true);
 }
 
-// Sauver et appliquer les préférences
+// Sauver et appliquer les prÃ©fÃ©rences
 void CMainTab::ApplyAndSave() {
   CWaitCursor wait;      // Afficher curseur sablier
-  bool err=false;  // Erreur lors de l'écriture des paramètres
+  bool err=false;  // Erreur lors de l'Ã©criture des paramÃ¨tres
   
-  // Appliquer les préférences
+  // Appliquer les prÃ©fÃ©rences
   Apply();
   
-  // Sauver préférences
+  // Sauver prÃ©fÃ©rences
   CWinApp* pApp = AfxGetApp();
   //if (!pApp->WriteProfileInt("Driver", "DriverId",numero_driver))          // No du driver
   //  err=true;
@@ -219,12 +219,12 @@ void CMainTab::ApplyAndSave() {
     AfxMessageBox(LANG(LANG_DIAL2));
 }
 
-// Appliquer préférences
+// Appliquer prÃ©fÃ©rences
 void CMainTab::Apply() {
-  // Appliquer préférences
+  // Appliquer prÃ©fÃ©rences
 }
 
-// Chargement des préférences
+// Chargement des prÃ©fÃ©rences
 void CMainTab::LoadPrefs() {
   CWinApp* pApp = AfxGetApp();
   //n = pApp->GetProfileInt("Driver", "DriverId",0);   // No du driver
@@ -272,11 +272,11 @@ BOOL CMainTab::OnHelpInfo(HELPINFO* dummy)
 /*
 // Capturer OK et Cancel
 void CMainTab::OnOK( ) {
-  // Sauver et appliquer préférences
+  // Sauver et appliquer prÃ©fÃ©rences
   ApplyAndSave();
 }
 void CMainTab::OnCancel( ) {
-  // Recharger préférences
+  // Recharger prÃ©fÃ©rences
   LoadPrefs();
 }
 */

--- a/WinHTTrack/MainTab.h
+++ b/WinHTTrack/MainTab.h
@@ -29,7 +29,7 @@ Please visit our Website: http://www.httrack.com
 
 // Tab Control Principal
 
-// En-tête pour l'affichage des tabs
+// En-tÃªte pour l'affichage des tabs
 #include "OptionTab1.h"
 #include "OptionTab2.h"
 #include "OptionTab3.h"
@@ -58,7 +58,7 @@ protected:
   
   // Attributes
 public:
-  // Déclaration des classes-dialog pour les différents Tab Control
+  // DÃ©claration des classes-dialog pour les diffÃ©rents Tab Control
   COptionTab1        m_option1;
   COptionTab2        m_option2;
   COptionTab3        m_option3;

--- a/WinHTTrack/MemRegister.cpp
+++ b/WinHTTrack/MemRegister.cpp
@@ -24,8 +24,8 @@ would dishonor our work and waste the many hours we have spent on it.
 
 Please visit our Website: http://www.httrack.com
 */
-// Classe de sauvegarde de clés (identifiées par leur nom)
-// à la manière de la base de registre (mais en plus basique)
+// Classe de sauvegarde de clÃ©s (identifiÃ©es par leur nom)
+// Ã  la maniÃ¨re de la base de registre (mais en plus basique)
 
 #include "stdafx.h"
 #include "MemRegister.h"

--- a/WinHTTrack/MemRegister.h
+++ b/WinHTTrack/MemRegister.h
@@ -24,8 +24,8 @@ would dishonor our work and waste the many hours we have spent on it.
 
 Please visit our Website: http://www.httrack.com
 */
-// Classe de sauvegarde de clés (identifiées par leur nom)
-// à la manière de la base de registre (mais en plus basique)
+// Classe de sauvegarde de clÃ©s (identifiÃ©es par leur nom)
+// Ã  la maniÃ¨re de la base de registre (mais en plus basique)
 
 #if !defined(MEMREGISTER_LIB_JHGFHIV25489654156HJRZDSCIOUJ5648654651)
 #define MEMREGISTER_LIB_JHGFHIV25489654156HJRZDSCIOUJ5648654651

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -75,7 +75,7 @@ extern Wid1* dialog1;
 /* shellapp */
 extern CShellApp* CShellApp_app;
 
-/* création structure */
+/* crÃ©ation structure */
 extern "C" HTSEXT_API int structcheck(const char* s);
 
 
@@ -187,7 +187,7 @@ LRESULT CNewProj::OnWizardNext() {
   st.TrimLeft();
   st.TrimRight();
   strcpybuff(tempo,st);
-  // caractères interdits
+  // caractÃ¨res interdits
   {
     int i;
     char* a=NULL;
@@ -199,7 +199,7 @@ LRESULT CNewProj::OnWizardNext() {
   //while(a=strchr(tempo,' ')) *a='_';      // PAS de _
   SetDlgItemTextCP(this, IDC_projname,tempo);
 
-  // Modifié et sauvable
+  // ModifiÃ© et sauvable
   GetDlgItemText(IDC_projpath,stp);
   if (stp.GetLength() > MAX_PATH) {
     return -1;
@@ -265,8 +265,8 @@ BOOL CNewProj::OnInitDialog()
   // disabled
   OnChangeprojname();
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this,  LANG(LANG_S10));
     // SetDlgItemTextCP(this, IDOK,LANG(LANG_NEXT )); // "SUIVANT ->");
     // SetDlgItemTextCP(this, IDCANCEL,LANG(LANG_QUIT));  // exit 
@@ -478,8 +478,8 @@ void CNewProj::Changeprojname(CString stl) {
       strcatbuff(tempo,"/");
       strcatbuff(tempo,stl);
       strcatbuff(tempo,"/");
-      if (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))     // un cache est présent
-        && fsize(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))>0) {   // taille log contrôle>0
+      if (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))     // un cache est prÃ©sent
+        && fsize(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))>0) {   // taille log contrÃ´le>0
         CString strSection       = "OptionsValues";
         CString st  = MyGetProfileString(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"),strSection,"CurrentUrl");
         CString st2 = MyGetProfileString(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"),strSection,"Category");
@@ -621,7 +621,7 @@ BOOL CNewProj::OnKillActive( ) {
 
   UpdateData(TRUE);         // DoDataExchange
 
-  // créer structure
+  // crÃ©er structure
   {
     char dest[HTS_URLMAXSIZE*2];
     int i=0;
@@ -648,7 +648,7 @@ BOOL CNewProj::OnKillActive( ) {
   //a.Format("t=%dms", (int)l_dir);
   //(void) AfxMessageBox(a, MB_OK);
 
-  // charger préfs
+  // charger prÃ©fs
   dialog1->OnChangepathlog();
 
   return 1;

--- a/WinHTTrack/OptionTab1.cpp
+++ b/WinHTTrack/OptionTab1.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab1, CPropertyPage)
 COptionTab1::COptionTab1() : CPropertyPage(COptionTab1::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT1); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -95,7 +95,7 @@ BOOL COptionTab1::OnInitDialog()
   CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 	
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_parseall) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_link)     ->ModifyStyle(0,WS_DISABLED);
@@ -114,11 +114,11 @@ BOOL COptionTab1::OnInitDialog()
     GetDlgItem(IDC_keepqueryorder)->ModifyStyle(WS_DISABLED,0);
   }
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
-    //SetWindowTextCP(this, LANG(LANG_I30)); // "Options (les champs laissés vides seront fixés sur les valeurs par défaut)");
-    SetDlgItemTextCP(this, IDC_link,LANG(LANG_I31)); // "Capturer les fichiers non html proches (ex: fichiers ZIP situés à l'extérieur)");
-    SetDlgItemTextCP(this, IDC_testall,LANG(LANG_I32)); // "Tester tous les liens (même ceux interdits)");
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
+    //SetWindowTextCP(this, LANG(LANG_I30)); // "Options (les champs laissÃ©s vides seront fixÃ©s sur les valeurs par dÃ©faut)");
+    SetDlgItemTextCP(this, IDC_link,LANG(LANG_I31)); // "Capturer les fichiers non html proches (ex: fichiers ZIP situÃ©s Ã  l'extÃ©rieur)");
+    SetDlgItemTextCP(this, IDC_testall,LANG(LANG_I32)); // "Tester tous les liens (mÃªme ceux interdits)");
     SetDlgItemTextCP(this, IDC_parseall,LANG(LANG_I32b));
     SetDlgItemTextCP(this, IDC_htmlfirst,LANG(LANG_I32c));
     SetDlgItemTextCP(this, IDC_keepwww,LANG(LANG_KEEPWWW));
@@ -168,7 +168,7 @@ BOOL COptionTab1::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
 const char* COptionTab1::GetTip(int ID)
 {
   switch(ID) {
-    case IDC_link:    return LANG(LANG_I1); break; // "Get files even in foreign addresses","Récupérer les fichiers même sur les liens extérieurs"); break;
+    case IDC_link:    return LANG(LANG_I1); break; // "Get files even in foreign addresses","RÃ©cupÃ©rer les fichiers mÃªme sur les liens extÃ©rieurs"); break;
     case IDC_testall: return LANG(LANG_I2); break; // "Test all links in pages","Tester tous les liens dans les pages"); break;
     case IDC_parseall: return LANG(LANG_I2b); break;
     case IDC_htmlfirst: return LANG(LANG_I2c); break;

--- a/WinHTTrack/OptionTab10.cpp
+++ b/WinHTTrack/OptionTab10.cpp
@@ -59,7 +59,7 @@ IMPLEMENT_DYNCREATE(COptionTab10, CPropertyPage)
 COptionTab10::COptionTab10() : CPropertyPage(COptionTab10::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT10); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -136,13 +136,13 @@ BOOL COptionTab10::OnInitDialog()
     OnPwdhide();
   }
 
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_proxyconfigure,LANG(LANG_I47b)); // "Configurer"
     SetDlgItemTextCP(this, IDC_ftpprox,LANG(LANG_I47c));
     SetDlgItemTextCP(this, IDC_PWDHIDE,LANG_HIDEPWD);  /* Hide password */
   }  
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_prox           ) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_portprox       ) ->ModifyStyle(0,WS_DISABLED);

--- a/WinHTTrack/OptionTab11.cpp
+++ b/WinHTTrack/OptionTab11.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab11, CPropertyPage)
 COptionTab11::COptionTab11() : CPropertyPage(COptionTab11::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT11); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -113,7 +113,7 @@ BOOL COptionTab11::OnInitDialog()
 	
   EnableToolTips(true);     // TOOL TIPS
 
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_STATIC_asso,LANG_W1);
     SetDlgItemTextCP(this, IDC_STATIC_filetype,LANG_W2);
     SetDlgItemTextCP(this, IDC_STATIC_mime,LANG_W3);
@@ -121,7 +121,7 @@ BOOL COptionTab11::OnInitDialog()
 
   SetWindowTextCP(this, LANG_IOPT11);
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_ext1           ) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_ext2           ) ->ModifyStyle(0,WS_DISABLED);

--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab2, CPropertyPage)
 COptionTab2::COptionTab2() : CPropertyPage(COptionTab2::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT2); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -111,10 +111,10 @@ BOOL COptionTab2::OnInitDialog()
 	CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 	
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
-    SetDlgItemTextCP(this, IDC_STATIC_buildopt,LANG(LANG_I33)); // "Type de structure (manière dont les liens sont sauvés)");
+    SetDlgItemTextCP(this, IDC_STATIC_buildopt,LANG(LANG_I33)); // "Type de structure (maniÃ¨re dont les liens sont sauvÃ©s)");
     SetDlgItemTextCP(this, IDC_dos,LANG(LANG_I37)); // "Noms DOS");
     SetDlgItemTextCP(this, IDC_iso9660,LANG(LANG_I37b)); // "Noms DOS");
     SetDlgItemTextCP(this, IDC_errpage,LANG(LANG_I38)); // "Pas de page d'erreur");
@@ -126,7 +126,7 @@ BOOL COptionTab2::OnInitDialog()
     SetCombo(this,IDC_build,LISTDEF_3);
   }
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_build)   ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_buildopt)->ModifyStyle(0,WS_DISABLED);
@@ -193,10 +193,10 @@ const char* COptionTab2::GetTip(int ID)
 {
   switch(ID) {
     case IDC_build:   return LANG(LANG_I3); break; // "Choose local site structure","Choisir la structure de fichiers local"); break;
-    case IDC_buildopt:return LANG(LANG_I4); break; // "Set user-defined structure on disk","Définir la structure du site sur disque"); break;
-    case IDC_dos:     return LANG(LANG_I8); break; // "Generate ONLY 8-3 filenames","Générer uniquement des fichiers courts 8-3"); break;
-    case IDC_iso9660: return LANG(LANG_I8b); break; // "Generate ONLY ISO9660 filenames","Générer uniquement des fichiers courts 8-3"); break;
-    case IDC_errpage: return LANG(LANG_I9); break; // "Do not write html error pages","Ne pas générer les fichiers d'erreur html"); break;
+    case IDC_buildopt:return LANG(LANG_I4); break; // "Set user-defined structure on disk","DÃ©finir la structure du site sur disque"); break;
+    case IDC_dos:     return LANG(LANG_I8); break; // "Generate ONLY 8-3 filenames","GÃ©nÃ©rer uniquement des fichiers courts 8-3"); break;
+    case IDC_iso9660: return LANG(LANG_I8b); break; // "Generate ONLY ISO9660 filenames","GÃ©nÃ©rer uniquement des fichiers courts 8-3"); break;
+    case IDC_errpage: return LANG(LANG_I9); break; // "Do not write html error pages","Ne pas gÃ©nÃ©rer les fichiers d'erreur html"); break;
     case IDC_external: return LANG(LANG_I29); break; // extern
     case IDC_nopurge: return LANG(LANG_I1a); break; // erase old files
     case IDC_hidepwd: return LANG(LANG_I30); break;

--- a/WinHTTrack/OptionTab3.cpp
+++ b/WinHTTrack/OptionTab3.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab3, CPropertyPage)
 COptionTab3::COptionTab3() : CPropertyPage(COptionTab3::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT3); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -99,7 +99,7 @@ BOOL COptionTab3::OnInitDialog()
 	CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 	
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_Cache)   ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_filter)  ->ModifyStyle(0,WS_DISABLED);
@@ -126,8 +126,8 @@ BOOL COptionTab3::OnInitDialog()
     GetDlgItem(IDC_STATIC_stripquery)->ModifyStyle(WS_DISABLED,0);
   }
   
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_Cache,LANG(LANG_I34)); // "Utiliser un cache");
     SetDlgItemTextCP(this, IDC_STATIC_primf,LANG(LANG_I39)); // "Filtre primaire");
     SetDlgItemTextCP(this, IDC_STATIC_travel,LANG(LANG_I40)); // "Mode de parcours");
@@ -185,10 +185,10 @@ BOOL COptionTab3::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
 const char* COptionTab3::GetTip(int ID)
 {
   switch(ID) {
-    case IDC_Cache:   return LANG(LANG_I5); break; // "Use a cache for updates and retries","Utiliser un cache pour les mise à jour et reprises"); break;
-    case IDC_filter:  return LANG(LANG_I10); break; // "Select file types to be saved on disk","Sélection des types de fichier à sauver"); break;
-    case IDC_travel:  return LANG(LANG_I11); break; // "Select the travel direction in the site","Sélection de la direction du miroir"); break;
-    case IDC_travel2:  return LANG(LANG_I11b); break; // "Select the travel direction in the site","Sélection de la direction du miroir"); break;
+    case IDC_Cache:   return LANG(LANG_I5); break; // "Use a cache for updates and retries","Utiliser un cache pour les mise Ã  jour et reprises"); break;
+    case IDC_filter:  return LANG(LANG_I10); break; // "Select file types to be saved on disk","SÃ©lection des types de fichier Ã  sauver"); break;
+    case IDC_travel:  return LANG(LANG_I11); break; // "Select the travel direction in the site","SÃ©lection de la direction du miroir"); break;
+    case IDC_travel2:  return LANG(LANG_I11b); break; // "Select the travel direction in the site","SÃ©lection de la direction du miroir"); break;
     case IDC_travel3:  return LANG(LANG_I11c); break;
     case IDC_windebug: return LANG_I1h; break;
     case IDC_stripquery: return LANG(LANG_STRIPQUERYTIP); break;

--- a/WinHTTrack/OptionTab4.cpp
+++ b/WinHTTrack/OptionTab4.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab4, CPropertyPage)
 COptionTab4::COptionTab4() : CPropertyPage(COptionTab4::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT4); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -97,9 +97,9 @@ BOOL COptionTab4::OnInitDialog()
 	CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 	
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
-    SetDlgItemTextCP(this, IDC_STATIC_flowc,LANG(LANG_I41)); // "Contrôle du flux");
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
+    SetDlgItemTextCP(this, IDC_STATIC_flowc,LANG(LANG_I41)); // "ContrÃ´le du flux");
     SetDlgItemTextCP(this, IDC_STATIC_mc,LANG(LANG_I44)); // "N# connexions");
     SetDlgItemTextCP(this, IDC_remt,LANG(LANG_I45)); // "Abandon hote si erreur");
     SetDlgItemTextCP(this, IDC_STATIC_retr,LANG(LANG_I48)); // "Essais");
@@ -157,7 +157,7 @@ const char* COptionTab4::GetTip(int ID)
     case IDC_timeout: return LANG(LANG_I13); break; // "Maximum idle time for a file","Temps mort maximal pour un fichier"); break;
     case IDC_remt:    return LANG(LANG_I14); break; // "Cancel all links from a host if a timeout occurs","Annuler tous les liens sur un domaine en cas de temps mort"); break;
     case IDC_retry:   return LANG(LANG_I17); break; // "Maximum number of retries if a non-fatal error occurs","Nombre maximum d'essais en cas d'erreur non fatale"); break;
-    case IDC_rate:    return LANG(LANG_I15); break; // "Minimum transfer rate tolerated","Taux de transfert minimal toléré"); break;
+    case IDC_rate:    return LANG(LANG_I15); break; // "Minimum transfer rate tolerated","Taux de transfert minimal tolÃ©rÃ©"); break;
     case IDC_rems:    return LANG(LANG_I16); break; // "Cancel all links from a host if it is too slow","Annuler tous les liens sur un domaine en cas de transfert trop lent"); break;
     case IDC_ka:      return LANG(LANG_I47f); break;
     case IDC_pausefiles: return LANG(LANG_PAUSEFILESTIP); break;

--- a/WinHTTrack/OptionTab5.cpp
+++ b/WinHTTrack/OptionTab5.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab5, CPropertyPage)
 COptionTab5::COptionTab5() : CPropertyPage(COptionTab5::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT5); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -106,8 +106,8 @@ BOOL COptionTab5::OnInitDialog()
 	
   depth_status=-1;
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_STATIC_limits,LANG(LANG_I42)); // "Limites");
     SetDlgItemTextCP(this, IDC_STATIC_fillim,LANG(LANG_I49)); // "Limite en taille");
     SetDlgItemTextCP(this, IDC_STATIC_autre,LANG(LANG_I50)); // "Autres:");

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab6, CPropertyPage)
 COptionTab6::COptionTab6() : CPropertyPage(COptionTab6::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT6); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -91,9 +91,9 @@ BOOL COptionTab6::OnInitDialog()
 	CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 	
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
-    SetDlgItemTextCP(this, IDC_STATIC_browsid,LANG(LANG_I43)); // "Identité");
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
+    SetDlgItemTextCP(this, IDC_STATIC_browsid,LANG(LANG_I43)); // "IdentitÃ©");
     SetDlgItemTextCP(this, IDC_STATIC_footer,LANG(LANG_I43b));
     SetDlgItemTextCP(this, IDC_STATIC_accept_language,LANG(LANG_I43c));
     SetDlgItemTextCP(this, IDC_STATIC_other_headers,LANG(LANG_I43d));
@@ -143,7 +143,7 @@ BOOL COptionTab6::OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult )
 const char* COptionTab6::GetTip(int ID)
 {
   switch(ID) {
-    case IDC_user: return LANG(LANG_I23); break; // "Browser identity","Identité du browser"); break;
+    case IDC_user: return LANG(LANG_I23); break; // "Browser identity","IdentitÃ© du browser"); break;
     case IDC_footer: return LANG(LANG_I23b); break;
     case IDC_accept_language: return LANG(LANG_I23c); break;
     case IDC_other_headers: return LANG(LANG_I23d); break;

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -53,7 +53,7 @@ IMPLEMENT_DYNCREATE(COptionTab7, CPropertyPage)
 COptionTab7::COptionTab7() : CPropertyPage(COptionTab7::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT7); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -121,11 +121,11 @@ static void NewFilter(int i,char* s,size_t ssize) {  // 0: forbid 1: accept
       while(strlen(q)>0) {
         while ((*q==' ') || (*q==',')) q++;
         strcpybuff(t,"");
-        {  // prochain (séparé par des ,)
+        {  // prochain (sÃ©parÃ© par des ,)
           char *a,*b;
           a=strchr(q,' ');
           b=strchr(q,',');
-          if (a && b) {  // départager
+          if (a && b) {  // dÃ©partager
             if ( b < a)
               a=b;
           } else if (b) a=b;
@@ -247,7 +247,7 @@ BOOL COptionTab7::OnInitDialog()
 	CPropertyPage::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_ADD1) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_ADD2) ->ModifyStyle(0,WS_DISABLED);
@@ -262,8 +262,8 @@ BOOL COptionTab7::OnInitDialog()
     GetDlgItem(IDC_STATIC_tip) ->ModifyStyle(WS_DISABLED,0);
   }
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this, LANG(LANG_B9)); // "Filtres");
     SetDlgItemTextCP(this, IDC_STATIC_finfo,LANG(LANG_B10)); // "Vous pouvez exclure ou accepter plusieurs URLs ou liens, en utilisant les jokers\nVous pouvez utiliser les virgules ou les espaces entre les filtres\nExemple: +*.zip,-www.*.com,-www.*.edu/cgi-bin/*.cgi");
     SetDlgItemTextCP(this, IDC_ADD1,LANG(LANG_B11)); // "Exclure lien(s)..");

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab8, CPropertyPage)
 COptionTab8::COptionTab8() : CPropertyPage(COptionTab8::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT8); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -109,7 +109,7 @@ BOOL COptionTab8::OnInitDialog()
 	CDialog::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_cookies)          ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_checktype)        ->ModifyStyle(0,WS_DISABLED);
@@ -134,7 +134,7 @@ BOOL COptionTab8::OnInitDialog()
     GetDlgItem(IDC_STATIC_spider)    ->ModifyStyle(WS_DISABLED,0);
   }
 
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_robots,LANG(LANG_I55));
     SetDlgItemTextCP(this, IDC_cookies,LANG(LANG_I58));
     SetDlgItemTextCP(this, IDC_STATIC_checktype,LANG(LANG_I59));

--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -45,7 +45,7 @@ IMPLEMENT_DYNCREATE(COptionTab9, CPropertyPage)
 COptionTab9::COptionTab9() : CPropertyPage(COptionTab9::IDD)
 {
   // Patcher titre
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     m_psp.pszTitle=LANG(LANG_IOPT9); // titre
     m_psp.dwFlags|=PSP_USETITLE;
   }
@@ -95,7 +95,7 @@ BOOL COptionTab9::OnInitDialog()
 	CDialog::OnInitDialog();
   EnableToolTips(true);     // TOOL TIPS
 
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetDlgItemTextCP(this, IDC_index,LANG(LANG_I35)); // "Faire un index");
     SetDlgItemTextCP(this, IDC_index2,LANG(LANG_I35b));
     SetDlgItemTextCP(this, IDC_index_mail,LANG(LANG_I35c));
@@ -105,7 +105,7 @@ BOOL COptionTab9::OnInitDialog()
     SetCombo(this,IDC_logtype,LISTDEF_9);
   }  
 
-  // mode modif à la volée
+  // mode modif Ã  la volÃ©e
   if (modify==1) {
     GetDlgItem(IDC_norecatch)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_index)   ->ModifyStyle(0,WS_DISABLED);
@@ -169,10 +169,10 @@ const char* COptionTab9::GetTip(int ID)
 {
   switch(ID) {
     case IDC_norecatch: return LANG(LANG_I5b); break;
-    case IDC_index:   return LANG(LANG_I6); break; // "Create a start page","Générer une page de départ"); break;
-    case IDC_index2:   return LANG(LANG_I6b); break; // "Create a start page","Générer une page de départ"); break;
+    case IDC_index:   return LANG(LANG_I6); break; // "Create a start page","GÃ©nÃ©rer une page de dÃ©part"); break;
+    case IDC_index2:   return LANG(LANG_I6b); break; // "Create a start page","GÃ©nÃ©rer une page de dÃ©part"); break;
     case IDC_index_mail:return LANG(LANG_I6c); break;
-    case IDC_logf:    return LANG(LANG_I7); break; // "Create log files for error and info report","Générer des fichiers d'audit pour les erreurs et les messages"); break;
+    case IDC_logf:    return LANG(LANG_I7); break; // "Create log files for error and info report","GÃ©nÃ©rer des fichiers d'audit pour les erreurs et les messages"); break;
     case IDC_Cache2:  return LANG(LANG_I1e); break;
     case IDC_logtype: return LANG(LANG_I1f); break;
   }

--- a/WinHTTrack/ProxyId.cpp
+++ b/WinHTTrack/ProxyId.cpp
@@ -98,7 +98,7 @@ BOOL CProxyId::OnInitDialog()
   m_ctl_proxytype.AddString("HTTP (CONNECT tunnel)");
   m_ctl_proxytype.SetCurSel((m_proxytype >= 0 && m_proxytype < m_ctl_proxytype.GetCount()) ? m_proxytype : 0);
 	
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     SetWindowTextCP(this,  LANG(LANG_R1));
     SetDlgItemTextCP(this, IDC_STATIC_ptype,LANG(LANG_PROXYTYPE));
     SetDlgItemTextCP(this, IDC_STATIC_adr,LANG(LANG_R2));

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -119,7 +119,7 @@ extern "C" {
 //#define HTS_XGMETHOD 2    // 1: AfxBeginThread 2: _beginthread
 // --- --- --- --- Options --- --- --- ---
 //int INREDRAW_LOCKED=0;      // refresh graphique en cours
-//int INFILLMEM_LOCKED=0;     // refresh mémoire en cours
+//int INFILLMEM_LOCKED=0;     // refresh mÃ©moire en cours
 int HTTRACK_result=0;
 //
 CInfoUrl* _Cinprogress_inst=NULL;
@@ -145,13 +145,13 @@ httrackp *global_opt = NULL;
 // principal ---> robot & refresh data (thread 1)
 //           ---> refresh graphique    (thread 2)
 //           GO!> boucle gestion domodal() et boutons
-// arrêt: principal demande l'arrêt (termine_requested)
+// arrÃªt: principal demande l'arrÃªt (termine_requested)
 //        thread1 active termine et que thread2 ait fini de refresher
 //        thread2 se termine
-//        thread1 retourne 0 à hts_loop
+//        thread1 retourne 0 Ã  hts_loop
 //        le robot termine
 //        le thread1 active termine, termine le formulaire et se termine
-//        principal ayant quitté le formulaire affiche le message de fin
+//        principal ayant quittÃ© le formulaire affiche le message de fin
 
 
 // htslib.c
@@ -160,7 +160,7 @@ extern "C" {
   HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size);
 }
 
-// construction index général
+// construction index gÃ©nÃ©ral
 // void Build_TopIndex();
 
 void compute_options() ;
@@ -347,7 +347,7 @@ BOOL CShellApp::InitInstance()
   maintab = new CMainTab("WinHTTrack Website Copier");
   
   // PATCH-->
-  // éxécution..
+  // Ã©xÃ©cution..
   init_lance();
   
   delete maintab;
@@ -379,7 +379,7 @@ char* _SN(LLint n) {
   return str;
 }
 
-// t existe-t-il comme répertoire?
+// t existe-t-il comme rÃ©pertoire?
 int dir_check(char* t) {
   int dir;
   FILE* fp=fopen(t,"rb");
@@ -398,7 +398,7 @@ void check_temp(char* t,char* s) {
 
 // PATCH-->
 // Routines gestion dials
-// Patché pour 100% dials
+// PatchÃ© pour 100% dials
 
 
 void CShellApp::init_lance() {
@@ -454,7 +454,7 @@ int Save_current_profile(int ask) {
     winprofile+="winprofile.ini";
     Write_profile(winprofile,0);
     
-    // marquer document comme "sauvé"
+    // marquer document comme "sauvÃ©"
     if (this_CSplitterFrame)
       this_CSplitterFrame->SetSaved();
     
@@ -476,8 +476,8 @@ int check_continue(char* pathlog) {
       ||
       (fexist(fconcat(catbuff2,sizeof(catbuff2),path_log,"hts-cache/new.dat")))
       && (fexist(fconcat(catbuff3,sizeof(catbuff3),path_log,"hts-cache/new.ndx")))
-      ) {  // il existe déja un cache précédent.. renommer
-      //if (fexist(fconcat(path_log,"hts-cache/doit.log"))) {    // un cache est présent
+      ) {  // il existe dÃ©ja un cache prÃ©cÃ©dent.. renommer
+      //if (fexist(fconcat(path_log,"hts-cache/doit.log"))) {    // un cache est prÃ©sent
       return 1;
       //}
     }
@@ -486,7 +486,7 @@ int check_continue(char* pathlog) {
       ||
       (fexist(fconcat(catbuff2,sizeof(catbuff2),path_log,"hts-cache/old.dat")))
       && (fexist(fconcat(catbuff3,sizeof(catbuff3),path_log,"hts-cache/old.ndx")))
-      ) {  // il existe déja un ancien cache précédent.. renommer
+      ) {  // il existe dÃ©ja un ancien cache prÃ©cÃ©dent.. renommer
       return 1;
     }
     AfxMessageBox(LANG(LANG_F2 /*"There is no cache in the directory indicated\nWinHTTrack can not find any interrupted mirror!"*/),MB_OK+MB_ICONSTOP);
@@ -569,7 +569,7 @@ void compute_options() {
     ShellOptions->filelist = st;
   }
   
-  // stocker état et hh/mm/ss
+  // stocker Ã©tat et hh/mm/ss
   ShellOptions->hh = dialog2->m_hh;
   ShellOptions->mm = dialog2->m_mm;
   ShellOptions->ss = dialog2->m_ss;
@@ -608,7 +608,7 @@ void compute_options() {
     //ShellOptions->cache[0]='\0'; 
   }
   
-  // ne pas recharger fichiers déja pris mais effacés
+  // ne pas recharger fichiers dÃ©ja pris mais effacÃ©s
   if(maintab->m_option9.m_norecatch) ShellOptions->norecatch = "%n"; else ShellOptions->norecatch = "";
   
   // proxy
@@ -848,13 +848,13 @@ void compute_options() {
 
   /* autres options: RAS */
   if (dialog2->m_rasdisc)
-    disconnect=1;     /* déconnexion à la fin */
+    disconnect=1;     /* dÃ©connexion Ã  la fin */
   else
     disconnect=0;
 
   /* autres options: Shutdown */
   if (dialog2->m_rasshut)
-    shutdown_pc=1;     /* étendre à la fin */
+    shutdown_pc=1;     /* Ã©tendre Ã  la fin */
   else
     shutdown_pc=0;
 }
@@ -979,16 +979,16 @@ BOOL InitiateSystemShutdownExWithPriv(
 }
 
 
-// Les routines à définir:
-int __cdecl httrackengine_check(t_hts_callbackarg *carg, httrackp *opt, const char* adr,const char* fil,int status) {  // appelé par le wizard
+// Les routines Ã  dÃ©finir:
+int __cdecl httrackengine_check(t_hts_callbackarg *carg, httrackp *opt, const char* adr,const char* fil,int status) {  // appelÃ© par le wizard
   return -1;
 }
-int __cdecl httrackengine_check_mime(t_hts_callbackarg *carg, httrackp *opt, const char* adr,const char* fil,const char* mime,int status) {  // appelé par le wizard
+int __cdecl httrackengine_check_mime(t_hts_callbackarg *carg, httrackp *opt, const char* adr,const char* fil,const char* mime,int status) {  // appelÃ© par le wizard
   ATLTRACE(__FUNCTION__ " : check %s%s : <%s>\r\n", adr, fil, mime);
   return -1;
 }
 EXECUTION_STATE (WINAPI * SetThreadExecutionState_)(IN EXECUTION_STATE) = NULL;
-void __cdecl httrackengine_init(t_hts_callbackarg *carg) {    // appelé lors de l'init de HTTRACK, avant le début d'un miroir
+void __cdecl httrackengine_init(t_hts_callbackarg *carg) {    // appelÃ© lors de l'init de HTTRACK, avant le dÃ©but d'un miroir
   ATLTRACE(__FUNCTION__ " : init\r\n");
   // Finished
   PlaySound("MirrorStarted", NULL, SND_ASYNC | SND_NOWAIT | SND_APPLICATION);
@@ -1008,19 +1008,19 @@ void __cdecl httrackengine_init(t_hts_callbackarg *carg) {    // appelé lors de 
   httrackengine_loop(NULL, NULL, NULL, 0, 0, 0, 0, NULL, 0);  // init
   //printf("DEMARRAGE DU MIROIR DETECTE\n");  
 }
-void __cdecl httrackengine_uninit(t_hts_callbackarg *carg) {  // appelé en fin de miroir (peut être utile!!!)
+void __cdecl httrackengine_uninit(t_hts_callbackarg *carg) {  // appelÃ© en fin de miroir (peut Ãªtre utile!!!)
   ATLTRACE(__FUNCTION__ " : uninit\r\n");
   // Finished
   PlaySound("MirrorFinished", NULL, SND_ASYNC | SND_NOWAIT | SND_APPLICATION);
 
  // Disconnect RAS
 #if USE_RAS
-  if (LibRasUse) {        /* librairie RAS chargée */
-    if (disconnect) {     /* on doit déconnecter */
-      if (connected) {    /* on a initié une connexion */
+  if (LibRasUse) {        /* librairie RAS chargÃ©e */
+    if (disconnect) {     /* on doit dÃ©connecter */
+      if (connected) {    /* on a initiÃ© une connexion */
         if (conn)
           LibRas->RasHangUp(conn);
-      } else {            /* tout déconnecter */
+      } else {            /* tout dÃ©connecter */
         // On coupe tout (non, pas bourrin)
         DWORD size;
         RASCONN* adr;
@@ -1064,16 +1064,16 @@ void __cdecl httrackengine_uninit(t_hts_callbackarg *carg) {  // appelé en fin d
       );
   }
 }
-int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // appelé lors du démarrage du miroir (premières requètes)
+int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // appelÃ© lors du dÃ©marrage du miroir (premiÃ¨res requÃ¨tes)
   ATLTRACE(__FUNCTION__ " : starting\r\n");
 #if USE_RAS
   // connexion RAS
-  has_started=1;    // démarrage
+  has_started=1;    // dÃ©marrage
   connected=0;
   conn = NULL;
   memset(&SInfo, 0, sizeof(SInfo));
   if (LibRasUse) {
-    if (ShellOptions->_RasString.GetLength()>0) {    // sélection provider
+    if (ShellOptions->_RasString.GetLength()>0) {    // sÃ©lection provider
       if (!LibRas->RasDial(NULL,NULL,&ShellOptions->_dial,NULL,NULL,&conn)) {
         RASCONNSTATUS status;
         // RasGetConnectStatus can fail without touching rasconnstate: bail rather than poll on garbage.
@@ -1107,7 +1107,7 @@ int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // a
           }
         } while(connected==0);
       } else {
-        strcpybuff(connected_err,LANG(LANG_F3 /*"Could not connect to provider","Impossible d'établir la connexion"*/));
+        strcpybuff(connected_err,LANG(LANG_F3 /*"Could not connect to provider","Impossible d'Ã©tablir la connexion"*/));
         connected=-1;
         //termine=1;
       }
@@ -1123,7 +1123,7 @@ int __cdecl httrackengine_start(t_hts_callbackarg *carg, httrackp *opt) {   // a
   return 1;
 #endif
 }
-int  httrackengine_end(t_hts_callbackarg *carg, httrackp *opt) {     // appelé lors de la fin du miroir (plus de liens à charger)
+int  httrackengine_end(t_hts_callbackarg *carg, httrackp *opt) {     // appelÃ© lors de la fin du miroir (plus de liens Ã  charger)
   ATLTRACE(__FUNCTION__ " : end\r\n");
   WHTT_LOCK();
   termine=1;
@@ -1145,7 +1145,7 @@ int __cdecl httrackengine_htmlpostprocess(t_hts_callbackarg *carg, httrackp *opt
   //hts_free(old);
   return 1;
 }
-int __cdecl httrackengine_htmlcheck(t_hts_callbackarg *carg, httrackp *opt, char* html,int len,const char* url_address,const char* url_file) {    // appelé à chaque fois qu'un html doit être scanné (utile pour la prospection mais inutile ici)
+int __cdecl httrackengine_htmlcheck(t_hts_callbackarg *carg, httrackp *opt, char* html,int len,const char* url_address,const char* url_file) {    // appelÃ© Ã  chaque fois qu'un html doit Ãªtre scannÃ© (utile pour la prospection mais inutile ici)
   return 1;
 }
 int __cdecl httrackengine_chopt(t_hts_callbackarg *carg, httrackp *opt) {
@@ -1161,13 +1161,13 @@ void __cdecl httrackengine_filesave2(t_hts_callbackarg *carg, httrackp *opt, con
 // Le routine la plus utile sans doute: elle refresh les tableaux
 // C'est la 2e routine en thread qui assure le refresh graphique
 // (plus efficace)
-// -->C'est elle qui décide de tout arrêter si elle détecte in termine_request<--
+// -->C'est elle qui dÃ©cide de tout arrÃªter si elle dÃ©tecte in termine_request<--
 int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                                lien_back* back,int back_max,int back_index,
                                int lien_n,int lien_tot,
                                int stat_time,
-                               hts_stat_struct* stats) {    // appelé à chaque boucle de HTTrack
-  static char s[HTS_URLMAXSIZE*2]="";  // utilisé plus loin
+                               hts_stat_struct* stats) {    // appelÃ© Ã  chaque boucle de HTTrack
+  static char s[HTS_URLMAXSIZE*2]="";  // utilisÃ© plus loin
   int stat_written=-1;
   int stat_updated=-1;
   int stat_errors=-1;
@@ -1263,7 +1263,7 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
       // OPTI int rate;
       SInfo.ask_refresh=0;
       
-      // pour éviter temps cpu consommé trop grand
+      // pour Ã©viter temps cpu consommÃ© trop grand
       // Sleep(10);
       
       // initialiser ft
@@ -1300,7 +1300,7 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
       //
 #endif
       
-      // calculer heure si ce n'est déja fait
+      // calculer heure si ce n'est dÃ©ja fait
       if (stat_time<0)
         SInfo.stat_time=(int) (time_local()-SInfo.stat_timestart);
       
@@ -1310,7 +1310,7 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
       else
         rate=0;    // pas d'infos
       
-      // stocker infos: octets transférés, temps, etc.
+      // stocker infos: octets transfÃ©rÃ©s, temps, etc.
       if (stat_bytes>=0) SInfo.stat_bytes=stat_bytes;      // bytes
       if (stat_time>=0) SInfo.stat_time=stat_time;         // time
       if (lien_tot>=0) SInfo.lien_tot=lien_tot; // nb liens
@@ -1321,19 +1321,19 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
       if (SInfo.irate<0) SInfo.irate=SInfo.rate;
       if (nbk>=0) SInfo.stat_back=nbk;
       
-      // back: tableau de back_max éléments de cache
-      // back_max: nombre d'éléments ^^^^
-      // lien_tot: nombre total de liens traités pour le moment
-      // stat_bytes: octets sauvegardés
-      // stat_bytes_recv: octets téléchargés
-      // stat_time: temps en seconde depuis le début du miroir
-      // stat_nsocket: nombre de sockets connectées actuellement
-      // on peut en déduire rate=stat_bytes_recv/stat_time
+      // back: tableau de back_max Ã©lÃ©ments de cache
+      // back_max: nombre d'Ã©lÃ©ments ^^^^
+      // lien_tot: nombre total de liens traitÃ©s pour le moment
+      // stat_bytes: octets sauvegardÃ©s
+      // stat_bytes_recv: octets tÃ©lÃ©chargÃ©s
+      // stat_time: temps en seconde depuis le dÃ©but du miroir
+      // stat_nsocket: nombre de sockets connectÃ©es actuellement
+      // on peut en dÃ©duire rate=stat_bytes_recv/stat_time
       
       // printf("loop.. %d liens, %d octets, %d secondes, %d sockets, TAUX=%d\n",lien_tot,stat_bytes,stat_time,stat_nsocket,rate);
       
       // parcourir registre des liens
-      if (back_index>=0) {  // seulement si index passé
+      if (back_index>=0) {  // seulement si index passÃ©
         int j,k;
         int index=0;
         int ok=0;         // idem
@@ -1353,7 +1353,7 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
           }
         }
         for(k=0;k<2;k++) {    // 0: lien en cours 1: autres liens
-          for(j=0;(j<3) && (index<NStatsBuffer);j++) {  // passe de priorité
+          for(j=0;(j<3) && (index<NStatsBuffer);j++) {  // passe de prioritÃ©
             int _i;
             for(_i=0+k;(_i< max(back_max*k,1) ) && (index<NStatsBuffer);_i++) {  // no lien
               int i=(back_index+_i)%back_max;    // commencer par le "premier" (l'actuel)
@@ -1363,12 +1363,12 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                 switch(j) {
                 case 0:     // prioritaire
                   if ((back[i].status>0) && (back[i].status<99)) {
-                    strcpybuff(StatsBuffer[index].etat,LANG(LANG_F4 /*"receive","réception"*/)); ok=1;
+                    strcpybuff(StatsBuffer[index].etat,LANG(LANG_F4 /*"receive","rÃ©ception"*/)); ok=1;
                   }
                   break;
                 case 1:
                   if (back[i].status==99) {
-                    strcpybuff(StatsBuffer[index].etat,LANG(LANG_F5 /*"request","requète"*/)); ok=1;
+                    strcpybuff(StatsBuffer[index].etat,LANG(LANG_F5 /*"request","requÃ¨te"*/)); ok=1;
                   }
                   else if (back[i].status==STATUS_CONNECTING) {
                     strcpybuff(StatsBuffer[index].etat,LANG(LANG_F6 /*"connect","connexion"*/)); ok=1;
@@ -1397,9 +1397,9 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                   }
                   break;
                 default:
-                  if (back[i].status==0) {  // prêt
+                  if (back[i].status==0) {  // prÃªt
                     if ((back[i].r.statuscode==200)) {
-                      strcpybuff(StatsBuffer[index].etat,LANG(LANG_F8 /*"ready","prêt"*/)); ok=1;
+                      strcpybuff(StatsBuffer[index].etat,LANG(LANG_F8 /*"ready","prÃªt"*/)); ok=1;
                     }
                     else if ((back[i].r.statuscode>=100) && (back[i].r.statuscode<=599)) {
                       char tempo[256]; tempo[0]='\0';
@@ -1472,11 +1472,11 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                   
                   //if (back[i].url_fil[0]!='/') printf("/");
                   
-                  if (back[i].r.totalsize>0) {  // taille prédéfinie
+                  if (back[i].r.totalsize>0) {  // taille prÃ©dÃ©finie
                     StatsBuffer[index].sizetot=back[i].r.totalsize;
                     StatsBuffer[index].size=back[i].r.size;
-                  } else {  // pas de taille prédéfinie
-                    if (back[i].status==0) {  // prêt
+                  } else {  // pas de taille prÃ©dÃ©finie
+                    if (back[i].status==0) {  // prÃªt
                       StatsBuffer[index].sizetot=back[i].r.size;
                       StatsBuffer[index].size=back[i].r.size;
                     } else {
@@ -1497,7 +1497,7 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
 #else
     inprogress_refresh();  // tout de suite (non multithread)
 #endif
-    // INFILLMEM_LOCKED=0;    // délocker interface
+    // INFILLMEM_LOCKED=0;    // dÃ©locker interface
   }
   WHTT_UNLOCK();
   return (termine==0);
@@ -1523,7 +1523,7 @@ int inprogress_refresh() {
         if (!soft_term_requested) {
           if (!hts_setpause(global_opt, -1)) {
             if (!(parsing=hts_is_parsing(global_opt, -1)))
-              SetDlgItemTextCP(inprogress, IDC_inforun,LANG(LANG_F10 /*"Receiving files.","Réception des fichiers"*/)); 
+              SetDlgItemTextCP(inprogress, IDC_inforun,LANG(LANG_F10 /*"Receiving files.","RÃ©ception des fichiers"*/)); 
             else {
               switch(hts_is_testing(global_opt)) {
               case 0:
@@ -1684,7 +1684,7 @@ int inprogress_refresh() {
 #if USE_RAS
           if (!has_started)
 #endif
-            SetDlgItemTextCP(inprogress, IDC_nm0,LANG(LANG_F15 /*"Waiting for specific hour to start","Attente de l'heure programmée pour démarrer"*/));
+            SetDlgItemTextCP(inprogress, IDC_nm0,LANG(LANG_F15 /*"Waiting for specific hour to start","Attente de l'heure programmÃ©e pour dÃ©marrer"*/));
 #if USE_RAS
           else
             SetDlgItemTextCP(inprogress, IDC_nm0,LANG(LANG_F16 /*"Connecting to provider","Connexion au provider"*/));
@@ -1692,13 +1692,13 @@ int inprogress_refresh() {
           inprogress->m_sl0.SetRange(0,SInfo.ft);
           inprogress->m_sl0.SetPos(SInfo.ft-SInfo.stat_time);  // temps restant
           // SetDlgItemTextCP(inprogress, IDC_nm1,_SN(ft));
-          if (icn && (!this_CSplitterFrame->iconifie)) {  // minimisée mais pas en icone
+          if (icn && (!this_CSplitterFrame->iconifie)) {  // minimisÃ©e mais pas en icone
             sprintf(info,"[%d s]",SInfo.stat_time);
           } else {
             sprintf(info,LANG(LANG_F17 /*"Mirror waiting [%d seconds]","Miroir en attente [%d secondes]"*/),SInfo.stat_time);
           }
         } else {
-          if (icn) {  // minimisée
+          if (icn) {  // minimisÃ©e
             sprintf(info,"[%s]",(LPCTSTR)lnk);
           } else {
             char byteb[256];
@@ -1706,9 +1706,9 @@ int inprogress_refresh() {
             sprintf(info,LANG(LANG_F18),(LPCTSTR)lnk,byteb);
           }
         }
-        if (strcmp(info,last_info)) {       /* a changé */
+        if (strcmp(info,last_info)) {       /* a changÃ© */
           strcpybuff(last_info,info);           /* recopier */
-          if (this_CSplitterFrame->iconifie)  // minimisé icone
+          if (this_CSplitterFrame->iconifie)  // minimisÃ© icone
             this_CSplitterFrame->IconChange(last_info);
           else
             SetWindowTextCP(GetMainWindow(), last_info);
@@ -2094,7 +2094,7 @@ void lance(void) {
     args.Add(ShellOptions->stripquery);
   }
   
-  // mode spider, mettre après options
+  // mode spider, mettre aprÃ¨s options
   if (ShellOptions->choixdeb[0]=='!') {
     args.Add("--testlinks");
   } else if (ShellOptions->choixdeb[0]=='Y') {
@@ -2171,11 +2171,11 @@ void lance(void) {
         if ((path_log[strlen(path_log)-1]!='/') && (path_log[strlen(path_log)-1]!='\\'))
           strcatbuff(path_log,"/");
         
-        // on efface le doit.log, pour annuler les parametres anciens et en redéfinir de nouveaux
-        // c'est ici une logique qui diffère de la version en ligne de commande
+        // on efface le doit.log, pour annuler les parametres anciens et en redÃ©finir de nouveaux
+        // c'est ici une logique qui diffÃ¨re de la version en ligne de commande
         if (fexist(fconcat(catbuff,sizeof(catbuff),path_log,"hts-cache/new.zip"))
           || fexist(fconcat(catbuff2,sizeof(catbuff2),path_log,"hts-cache/new.ndx"))
-          ) {    // un cache est présent
+          ) {    // un cache est prÃ©sent
           if (fexist(fconcat(catbuff,sizeof(catbuff),path_log,"hts-cache/doit.log")))
             remove(fconcat(catbuff,sizeof(catbuff),path_log,"hts-cache/doit.log"));
           FILE* fp=fopen(fconcat(catbuff,sizeof(catbuff),path_log,"hts-cache/doit.log"),"wb");
@@ -2226,7 +2226,7 @@ void lance(void) {
     
     // non multithread
 #else
-#error "Non supporté"
+#error "Non supportÃ©"
 #endif
 
     /* Aborted mirror or finished? */
@@ -2253,7 +2253,7 @@ void lance(void) {
     //
     /* New pannel */
     if (result) {      // erreur?
-      strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
+      strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problÃ¨me est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
       if (result != -100) {
         strcatbuff(end_mirror_msg,hts_errmsg(global_opt));
@@ -2269,7 +2269,7 @@ void lance(void) {
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
     } else {
-      strcpybuff(end_mirror_msg,LANG(LANG_F22 /*"The mirror is finished.\nClick OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!","Le miroir est terminé\nCliquez sur OK pour quitter WinHTTrack\nVoir au besoin les fichiers d'audit pour vérifier que tout s'est bien passé\n\nMerci d'utiliser WinHTTrack!"*/));
+      strcpybuff(end_mirror_msg,LANG(LANG_F22 /*"The mirror is finished.\nClick OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!","Le miroir est terminÃ©\nCliquez sur OK pour quitter WinHTTrack\nVoir au besoin les fichiers d'audit pour vÃ©rifier que tout s'est bien passÃ©\n\nMerci d'utiliser WinHTTrack!"*/));
       //AfxMessageBox("The mirror is finished.\nClic OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!",MB_OK+MB_ICONINFORMATION);
       //        ShellExecute(0,"open",,"","",);
     }
@@ -2286,7 +2286,7 @@ void lance(void) {
         if (strlen(pathlog)>0)
           if ((pathlog[strlen(pathlog)-1]!='/') && (pathlog[strlen(pathlog)-1]!='\\'))
             strcatbuff(pathlog,"/");
-          // fichier log existe ou on est télécommandé par un !
+          // fichier log existe ou on est tÃ©lÃ©commandÃ© par un !
           if ( (fsize(fconcat(catbuff,sizeof(catbuff),pathlog,"hts-err.txt")))>0) {
             strcatbuff(end_mirror_msg,LANG(LANG_F23 /*"\n\nTip: Click [View log file] to see warning or error messages","\n\nConseil: [Voir fichiers log] pour voir les erreurs et messages"*/));
           }
@@ -2545,12 +2545,12 @@ CString MyGetProfileStringFile(FILE* fp,CString dummy,CString name,CString value
 }
 
 //
-// Get_profile et Write_profile eux mêmes
+// Get_profile et Write_profile eux mÃªmes
 //
-// path="" -> écrire dans la base (default)
-// path="<tmp>" -> écrire dans le fichier tempo commun
-// path="<mem>" -> écrire dans le buffer tempo commun
-// path="<null>" -> lire default (illégal en écriture)
+// path="" -> Ã©crire dans la base (default)
+// path="<tmp>" -> Ã©crire dans le fichier tempo commun
+// path="<mem>" -> Ã©crire dans le buffer tempo commun
+// path="<null>" -> lire default (illÃ©gal en Ã©criture)
 void Write_profile(CString path,int load_path) {
   CWaitCursor wait;
   CString strSection       = "OptionsValues";
@@ -2572,8 +2572,8 @@ void Write_profile(CString path,int load_path) {
       fclose(fp);
   }
   
-  //if (dialog3.m_hWnd == NULL) {    // pas initialisé
-  if (maintab->m_hWnd == NULL) {    // pas initialisé
+  //if (dialog3.m_hWnd == NULL) {    // pas initialisÃ©
+  if (maintab->m_hWnd == NULL) {    // pas initialisÃ©
     // checkboxes
     MyWriteProfileInt(path,strSection, "Near",maintab->m_option1.m_link);
     MyWriteProfileInt(path,strSection, "Test",maintab->m_option1.m_testall);
@@ -2838,7 +2838,7 @@ void Write_profile(CString path,int load_path) {
   }
   // liens, jokers etc. si mirror merge
   if (!(path.IsEmpty())) {
-    if (dialog1->m_hWnd == NULL) {    // pas initialisé
+    if (dialog1->m_hWnd == NULL) {    // pas initialisÃ©
       //MyWriteProfileString(path,strSection,"CurrentDepth",dialog1->m_depth);
       MyWriteProfileString(path,strSection,"CurrentUrl",dialog1->m_urls);
       if (dialog1->m_todo >= 0)
@@ -2877,13 +2877,13 @@ void Read_profile(CString path,int load_path) {
   CString strSection       = "OptionsValues";
   CString st;
   
-  // Vérification <tmp>
+  // VÃ©rification <tmp>
   if (path=="<tmp>") {     // fichier temporaire
     if (!tmpf)
       return;
     else
       fflush(tmpf);
-  } else if (path=="<null>") {     // options par défaut
+  } else if (path=="<null>") {     // options par dÃ©faut
     path="<mem>";
     tmpm.deleteAll();              // effacer
   } else {
@@ -3023,7 +3023,7 @@ void Read_profile(CString path,int load_path) {
   
   // liens, jokers etc. si mirror merge
   if (!(path.IsEmpty())) {
-    if (dialog1->m_hWnd == NULL) {    // pas initialisé
+    if (dialog1->m_hWnd == NULL) {    // pas initialisÃ©
       //dialog1->m_depth  = MyGetProfileString(path,strSection,"CurrentDepth");
       dialog1->m_urls     = MyGetProfileString(path,strSection,"CurrentUrl");
       dialog1->m_todo     = MyGetProfileInt(path,strSection,"CurrentAction",0);
@@ -3077,7 +3077,7 @@ void InitRAS() {
 #endif
 }
 
-// Reconstruire index général!
+// Reconstruire index gÃ©nÃ©ral!
 void Build_TopIndex(BOOL check_empty) {
   CWaitCursor wait;
 
@@ -3099,7 +3099,7 @@ void Build_TopIndex(BOOL check_empty) {
     // FILE* fpo=fopen(fconcat(path,"/index.html"),"wb");
     //if (fpo) {
     {
-      // verif_backblue(opt, path);    // générer gif
+      // verif_backblue(opt, path);    // gÃ©nÃ©rer gif
       //
       // Header
       //fprintf(fpo,toptemplate_header,
@@ -3138,7 +3138,7 @@ void Build_TopIndex(BOOL check_empty) {
                     }
                     
                     if ((fexist(iname)) || (fexist(iname2)) ) {
-                      // vérifier existence de .whtt
+                      // vÃ©rifier existence de .whtt
                       strcpybuff(iname,CShellApp_app->end_path);
                       strcatbuff(iname,find.cFileName);
                       strcatbuff(iname,".whtt");
@@ -3170,7 +3170,7 @@ void Build_TopIndex(BOOL check_empty) {
               CString str;
               str.Format(LANG_DELETEEMPTYCONF,(LPCTSTR)path);
               if (AfxMessageBox(str,MB_OKCANCEL)==IDOK) {
-                /* éliminer au besoin le .whtt */
+                /* Ã©liminer au besoin le .whtt */
                 DeleteFile(path+".whtt");
                 if (!RemoveEmptyDir(path))
                   AfxMessageBox(LANG_ERRORDEL);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -42,7 +42,7 @@ Please visit our Website: http://www.httrack.com
 #include "htsdefines.h"
 
 //
-// connecté via HTTrack? (défini dans projet)
+// connectÃ© via HTTrack? (dÃ©fini dans projet)
 #define USE_RAS 1
 //
 
@@ -204,7 +204,7 @@ void Build_TopIndex(BOOL check_empty=TRUE);
 
 void InitRAS();
 
-// Gestion répertoires
+// Gestion rÃ©pertoires
 int CheckDirInfo(CString path);
 BOOL RemoveEmptyDir(CString path);
 

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -173,7 +173,7 @@ BOOL Wid1::OnInitDialog( ) {
   GetDlgItem(IDC_filelist)->SendMessage(EM_SETLIMITTEXT, 2000, 0);
   EnableToolTips(true);     // TOOL TIPS
 
-  // inits après affichage
+  // inits aprÃ¨s affichage
   url_status=-1;
   filelist_status=-1;
   //prox_status=-1;
@@ -187,20 +187,20 @@ BOOL Wid1::OnInitDialog( ) {
   //OnSelchangedepth();  // update disabled/normal
   OnSelchangetodo();
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
     SetWindowTextCP(this,  LANG(LANG_G30)); // "Bienvenue dans WinHTTrack!");
     SetDlgItemTextCP(this, IDC_STATIC_action,LANG(LANG_G31)); // "Action:");
     //SetDlgItemTextCP(this, IDC_STATIC_filters,LANG(LANG_G33)); // "Filtres (refuser/accepter liens) :");
     SetDlgItemTextCP(this, IDC_STATIC_filters2,LANG(LANG_G41)); // "Options & prefs :");
     SetDlgItemTextCP(this, IDC_STATIC_paths,LANG(LANG_G34)); // "Chemins");
-    //SetDlgItemTextCP(this, IDC_regdef,LANG(LANG_G37)); // "Sauver préfs");
+    //SetDlgItemTextCP(this, IDC_regdef,LANG(LANG_G37)); // "Sauver prÃ©fs");
     //SetDlgItemTextCP(this, IDOK,LANG(LANG_NEXT )); // "SUIVANT ->");
     //SetDlgItemTextCP(this, IDC_avant,LANG(LANG_BACK));
     //SetDlgItemTextCP(this, IDCANCEL,LANG(LANG_QUIT));  // exit 
-    //SetDlgItemTextCP(this, IDfilter,LANG(LANG_G39)); // "Définir..");
-    SetDlgItemTextCP(this, ID_setopt,LANG(LANG_G40)); // "Définir les options..");
+    //SetDlgItemTextCP(this, IDfilter,LANG(LANG_G39)); // "DÃ©finir..");
+    SetDlgItemTextCP(this, ID_setopt,LANG(LANG_G40)); // "DÃ©finir les options..");
     //SetDlgItemTextCP(this, IDC_mirtitle2,LANG(LANG_G42)); // "Nom du projet");
     SetDlgItemTextCP(this, IDC_login2,LANG_G43);
     //SetDlgItemTextCP(this, IDC_urls,LANG_G44);
@@ -251,8 +251,8 @@ BOOL Wid1::OnInitDialog( ) {
   }
   // fichier ini  
 
-  //OnChangepathlog();  // update répertoire log
-  //OnChangepthmir();  // update répertoire miroir
+  //OnChangepathlog();  // update rÃ©pertoire log
+  //OnChangepthmir();  // update rÃ©pertoire miroir
 
   return TRUE;
 }
@@ -304,13 +304,13 @@ void Wid1::CleanUrls()
       if ((tempo[i]==' ') || (tempo[i]==0)) {
         ch[j++]='\0';
         if ((strlen(ch)>0) && ((int) strlen(ch)<HTS_URLMAXSIZE) ) {
-          // vérifier URL
+          // vÃ©rifier URL
           /*
           char adr[HTS_URLMAXSIZE*2],fil[HTS_URLMAXSIZE*2];
           adr[0]=fil[0]='\0';
           if (ident_url_absolute(ch,adr,fil)==-1) {
             htsblk r;
-            char loc[HTS_URLMAXSIZE*2]; loc[0]='\0';    // éventuelle nouvelle position
+            char loc[HTS_URLMAXSIZE*2]; loc[0]='\0';    // Ã©ventuelle nouvelle position
             r=http_test(ch,fil,loc);
             if (HTTP_IS_REDIRECT(r.statuscode)) {
               strcpybuff(ch,loc);
@@ -394,19 +394,19 @@ void Wid1::OnSelchangetodo()
     case 0:
       SetDlgItemTextCP(this, IDC_INFOMAIN,
       LANG(LANG_G2 /*"Mirror mode, fill the addresse(s) in the URL box.\x0d\x0aThe mirror will be saved in the location indicated below",
-      "Mode miroir, remplissez les addresse(s) dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvé à l'emplacement indiqué plus bas"*/)
+      "Mode miroir, remplissez les addresse(s) dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvÃ© Ã  l'emplacement indiquÃ© plus bas"*/)
       );
       break;
     case 1:
       SetDlgItemTextCP(this, IDC_INFOMAIN,
       LANG(LANG_G3 /* "Mirror mode with wizard (asks questions), fill the addresse(s) in the URL box.\x0d\x0aThe mirror will be saved in the location indicated below",
-      "Mode miroir semi automatique (pose des questions), remplissez les addresse(s) dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvé à l'emplacement indiqué plus bas"*/)
+      "Mode miroir semi automatique (pose des questions), remplissez les addresse(s) dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvÃ© Ã  l'emplacement indiquÃ© plus bas"*/)
       );
       break;
     case 2:
       SetDlgItemTextCP(this, IDC_INFOMAIN,
       LANG(LANG_G4 /* "Get files mode, fill the addresse(s) of the files in the URL box.\x0d\x0aThe mirror will be saved in the location indicated below",
-      "Mode téléchargement de fichier, remplissez les addresse(s) des fichiers dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvé à l'emplacement indiqué plus bas"*/)
+      "Mode tÃ©lÃ©chargement de fichier, remplissez les addresse(s) des fichiers dans la liste d'URLs.\x0d\x0aLe mirroir sera sauvÃ© Ã  l'emplacement indiquÃ© plus bas"*/)
       );
       SetDlgItemTextCP(this, IDC_depth,"");
       break;
@@ -419,7 +419,7 @@ void Wid1::OnSelchangetodo()
     case 4:
       SetDlgItemTextCP(this, IDC_INFOMAIN,
       LANG(LANG_G5 /* "Test links mode, fill the addresse(s) of the pages containing links to test in the URL box.\x0d\x0aThe log report will be saved in the location indicated below",
-      "Mode test de liens, remplissez les adresse(s) des pages contenant les liens à tester dans la liste d'URLs.\x0d\x0aLes fichiers d'audit seront sauvés à l'emplacement indiqué plus bas"*/)
+      "Mode test de liens, remplissez les adresse(s) des pages contenant les liens Ã  tester dans la liste d'URLs.\x0d\x0aLes fichiers d'audit seront sauvÃ©s Ã  l'emplacement indiquÃ© plus bas"*/)
       );
       SetDlgItemTextCP(this, IDC_depth,"");
       break;
@@ -427,12 +427,12 @@ void Wid1::OnSelchangetodo()
       if (r == LAST_ACTION )
         SetDlgItemTextCP(this, IDC_INFOMAIN,
         LANG(LANG_G6 /* "Update/Continue a mirror mode, check addresse(s) in the URL box, then click to the 'NEXT' button and check parameters.\x0d\x0aThe mirror will be saved in the location indicated below",
-        "Mode mise à jour/continuer un miroir, vérifiez les adresse(s) dans la liste d'URLs, puis cliquez sur le bouton 'NEXT' et vérifiez les paramètres.\x0d\x0aLe mirroir sera sauvé à l'emplacement indiqué plus bas"*/)
+        "Mode mise Ã  jour/continuer un miroir, vÃ©rifiez les adresse(s) dans la liste d'URLs, puis cliquez sur le bouton 'NEXT' et vÃ©rifiez les paramÃ¨tres.\x0d\x0aLe mirroir sera sauvÃ© Ã  l'emplacement indiquÃ© plus bas"*/)
         );
       else if (r == LAST_ACTION-1 )
         SetDlgItemTextCP(this, IDC_INFOMAIN,
         LANG(LANG_G6b /* "Update/Continue a mirror mode, check addresse(s) in the URL box, then click to the 'NEXT' button and check parameters.\x0d\x0aThe mirror will be saved in the location indicated below",
-        "Mode mise à jour/continuer un miroir, vérifiez les adresse(s) dans la liste d'URLs, puis cliquez sur le bouton 'NEXT' et vérifiez les paramètres.\x0d\x0aLe mirroir sera sauvé à l'emplacement indiqué plus bas"*/)
+        "Mode mise Ã  jour/continuer un miroir, vÃ©rifiez les adresse(s) dans la liste d'URLs, puis cliquez sur le bouton 'NEXT' et vÃ©rifiez les paramÃ¨tres.\x0d\x0aLe mirroir sera sauvÃ© Ã  l'emplacement indiquÃ© plus bas"*/)
         );
       break;
     }
@@ -459,8 +459,8 @@ void Wid1::AfterChangepathlog()
 
   strcpybuff(tempo,dialog0->GetPath());
   {
-    if (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))) {    // un cache est présent
-      if (fsize(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))>0) {   // taille log contrôle>0
+    if (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))) {    // un cache est prÃ©sent
+      if (fsize(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/winprofile.ini"))>0) {   // taille log contrÃ´le>0
         int i;
         for(i=0;i<(int) strlen(tempo);i++)
           if (tempo[i]=='/')
@@ -480,7 +480,7 @@ void Wid1::AfterChangepathlog()
             ||
             (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/new.dat")))
             && (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/new.ndx")))
-            ) {  // il existe déja un cache précédent.. renommer
+            ) {  // il existe dÃ©ja un cache prÃ©cÃ©dent.. renommer
             if (modify) {
               if (
                 (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-in_progress.lock")))
@@ -564,18 +564,18 @@ const char* Wid1::GetTip(int ID)
     case IDC_todo:  return LANG(LANG_G9); break; // "Choose an action","Choisissez une action"); break; 
     case IDC_depth: return LANG(LANG_G10); break; // "Maximum link depth to scan","Profondeur maximale"); break;
     case IDC_URL:   return LANG(LANG_G11); break; // "Enter addresses here","Entrez les adresses ici"); break;
-    //case IDC_urls:  return LANG(LANG_G12); break; // "Check spelling","Vérifier syntaxe"); break;
-    //case IDfilter:  return LANG(LANG_G13); break; // "Define additional filters","Définir les filtres supplémentaires"); break;
+    //case IDC_urls:  return LANG(LANG_G12); break; // "Check spelling","VÃ©rifier syntaxe"); break;
+    //case IDfilter:  return LANG(LANG_G13); break; // "Define additional filters","DÃ©finir les filtres supplÃ©mentaires"); break;
     //case IDC_pathlog:  return LANG(LANG_G16); break; // "Path","Chemin"); break;
     //case IDC_br2:      return LANG(LANG_G17); break; // "Select path","Choix du chemin"); break;
     //case IDC_pthmir:   return LANG(LANG_G18); break; // "Path","Chemin"); break;
     //case IDC_br1:      return LANG(LANG_G19); break; // "Select path","Choix du chemin"); break;
     case IDCANCEL:     return LANG(LANG_G20); break; // "Quit WinHTTrack","Quittter WinHTTrack"); break;
     case IDC_ipabout:  return LANG(LANG_G21); break; // "About WinHTTrack","A propos de WinHTTrack"); break;
-    case IDC_regdef:   return LANG(LANG_G22); break; // "Save preferences as default values","Sauver les réglages par défaut"); break;
+    case IDC_regdef:   return LANG(LANG_G22); break; // "Save preferences as default values","Sauver les rÃ©glages par dÃ©faut"); break;
     case IDOK:         return LANG(LANG_G23); break; // "Click to continue","Clic pour continuer"); break;
     case IDC_avant:     return LANG_TIPPREV; break;
-    case ID_setopt:    return LANG(LANG_G24); break; // "Click to define option","Clic pour définir les options"); break;
+    case ID_setopt:    return LANG(LANG_G24); break; // "Click to define option","Clic pour dÃ©finir les options"); break;
     case IDC_login2:   return LANG_G24b; break;
     case IDC_filelist: return LANG_G24c; break;
     //case : return ""; break;
@@ -596,12 +596,12 @@ void Wid1::OnDropFiles(HDROP hDropInfo)
   for(i=0;i<nf;i++) {
     char* buff;
     int size;
-    size=DragQueryFile(hDropInfo,i,NULL,0);    // taille buffer nécessaire
+    size=DragQueryFile(hDropInfo,i,NULL,0);    // taille buffer nÃ©cessaire
     if (size>0) {
-      size+=16;    // marge de sécurité
+      size+=16;    // marge de sÃ©curitÃ©
       buff=(char*) calloc(size,1);
       if (buff) {
-        if (DragQueryFile(hDropInfo,i,buff,size)>0) {    // ok copié
+        if (DragQueryFile(hDropInfo,i,buff,size)>0) {    // ok copiÃ©
           AfxMessageBox(buff,MB_OKCANCEL+MB_ICONQUESTION);
         }
         free(buff);
@@ -630,7 +630,7 @@ int Wid1::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
 CString Wid1::TextToUrl(CString st,CLIPFORMAT cfFormat) {
   // yop
-  // on va convertir les chaines à la suite
+  // on va convertir les chaines Ã  la suite
   CString res;
   if (cfFormat==CF_TEXT) {
     char *buff, *last;
@@ -719,7 +719,7 @@ BOOL Wid1::OnHelpInfo(HELPINFO* dummy)
 
 void Wid1::OnLoadprofile() {
   static char BASED_CODE szFilter[256];
-  strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","Réglages de WinHTTrack (*.opt)|*.opt||"*/));
+  strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","RÃ©glages de WinHTTrack (*.opt)|*.opt||"*/));
   CFileDialog* dial = new CFileDialog(true,"opt",NULL,OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,szFilter);
   if (dial->DoModal() == IDOK) {
     CString st=dial->GetPathName();
@@ -735,7 +735,7 @@ void Wid1::OnLoadprofile() {
 
 void Wid1::OnSaveprofile() {
   static char BASED_CODE szFilter[256];
-  strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","Réglages de WinHTTrack (*.opt)|*.opt||"*/));
+  strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","RÃ©glages de WinHTTrack (*.opt)|*.opt||"*/));
   CFileDialog* dial = new CFileDialog(false,"opt",NULL,OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,szFilter);
   if (dial->DoModal() == IDOK) {
     CString st=dial->GetPathName();

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -935,8 +935,8 @@ void CWinHTTrackApp::FwOnViewTransfers() {
 
 CDocument* CWinHTTrackApp::OpenDocumentFile( LPCTSTR lpszFileName)
 {
-  // Eviter deux fenêtres (un seul document)
-  // Le CMultui..->CSingleDoc.. est trop complexe à changer (à cause du splitter-wnd)
+  // Eviter deux fenÃªtres (un seul document)
+  // Le CMultui..->CSingleDoc.. est trop complexe Ã  changer (Ã  cause du splitter-wnd)
   int count=1;
 
   { /* Check if a document exists, and if exists if empty or not, and if name is different */
@@ -979,7 +979,7 @@ CDocument* CWinHTTrackApp::OpenDocumentFile( LPCTSTR lpszFileName)
 
   // Ouvrir nouveau?
   //if (count)
-  //  return;       // ne rien faire, car limité à 1 document
+  //  return;       // ne rien faire, car limitÃ© Ã  1 document
   //count++;
 
   /* Ouvrir */
@@ -1016,7 +1016,7 @@ void CWinHTTrackApp::NewTabs() {
 
 void CWinHTTrackApp::DeleteTabs() {
   if (m_tab0)
-  if (m_tab0->GetSafeHwnd())       /* a déja été détruit par CWinApp */
+  if (m_tab0->GetSafeHwnd())       /* a dÃ©ja Ã©tÃ© dÃ©truit par CWinApp */
     delete m_tab0;
   if (m_tab1)
   if (m_tab1->GetSafeHwnd())

--- a/WinHTTrack/WinHTTrack.h
+++ b/WinHTTrack/WinHTTrack.h
@@ -46,7 +46,7 @@ Please visit our Website: http://www.httrack.com
 // See WinHTTrack.cpp for the implementation of this class
 //
 
-// En-tête pour l'affichage des tabs
+// En-tÃªte pour l'affichage des tabs
 #include "NewProj.h"
 #include "Wid1.h"
 #include "trans.h"
@@ -60,7 +60,7 @@ class CWinHTTrackApp : public CWinApp
 public:
 	CWinHTTrackApp();
 	~CWinHTTrackApp();
-  void NewTabs();       /* recréer control tabs */
+  void NewTabs();       /* recrÃ©er control tabs */
   //
   CFirstInfo*        m_tab0;
   CNewProj*          m_tab1;

--- a/WinHTTrack/WinHTTrackDoc.cpp
+++ b/WinHTTrack/WinHTTrackDoc.cpp
@@ -176,7 +176,7 @@ BOOL CWinHTTrackDoc::OnOpenDocument(LPCTSTR lpszPathName)
   if (CFile::GetStatus(lpszPathName,status)) {
     CString PathName=lpszPathName;
 
-    /* si répertoire, convertir d'abord en .whtt */
+    /* si rÃ©pertoire, convertir d'abord en .whtt */
     if (status.m_attribute & 0x10 ) {       /* directory = 0x10 */
       PathName+=".whtt";
     }

--- a/WinHTTrack/WizLinks.cpp
+++ b/WinHTTrack/WizLinks.cpp
@@ -90,13 +90,13 @@ BOOL WizLinks::OnInitDialog()
   tm=SetTimer(WM_TIMER,1000,NULL);
   SetForegroundWindow();   // yop en premier plan!
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
-    SetWindowTextCP(this, LANG(LANG_M1)); // "Un lien a été détecté");
-    SetDlgItemTextCP(this, IDC_STATIC_rule,LANG(LANG_M2)); // "Choisir une règle:");
+    SetWindowTextCP(this, LANG(LANG_M1)); // "Un lien a Ã©tÃ© dÃ©tectÃ©");
+    SetDlgItemTextCP(this, IDC_STATIC_rule,LANG(LANG_M2)); // "Choisir une rÃ¨gle:");
     SetDlgItemTextCP(this, IDC_ch1,LANG(LANG_M3)); // "Ignorer ce lien");
-    SetDlgItemTextCP(this, IDC_ch2,LANG(LANG_M4)); // "Ignorer répertoire");
+    SetDlgItemTextCP(this, IDC_ch2,LANG(LANG_M4)); // "Ignorer rÃ©pertoire");
     SetDlgItemTextCP(this, IDC_ch3,LANG(LANG_M5)); // "Ignorer domaine");
     SetDlgItemTextCP(this, IDC_ch4,LANG(LANG_M6)); // "Prendre cette page uniquement");
     SetDlgItemTextCP(this, IDC_ch5,LANG(LANG_M7)); // "Miroir du site");

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -109,7 +109,7 @@ void CWizTab::DoInits() {
   } else {
     m_tabprogress=this_app->m_tabprogress;
   }
-  // Lecture du profile par défaut
+  // Lecture du profile par dÃ©faut
   maintab = new CMainTab("WinHTTrack");
   //if (!is_inProgress)   // sinon buggue
   Read_profile("",0);
@@ -128,12 +128,12 @@ void CWizTab::ClearInits() {
 void CWizTab::AddControlPages()
 {
   m_hIcon = httrack_icon;
-  m_psh.dwFlags |= PSP_USEHICON;  // utiliser icône
+  m_psh.dwFlags |= PSP_USEHICON;  // utiliser icÃ´ne
   m_psh.dwFlags &= ~PSH_HASHELP;  // pas de bouton help
   m_psh.hIcon = m_hIcon;
   //m_psh.pszIcon = "test";
 
-  // objet lui même
+  // objet lui mÃªme
   if (!is_inProgress)
     this_intCWizTab=this;
   else
@@ -155,7 +155,7 @@ void CWizTab::AddControlPages()
     AddPage(m_tab3);
   }
 
-  /* uniquement pour calibrer la page, retiré lors de initdialog */
+  /* uniquement pour calibrer la page, retirÃ© lors de initdialog */
   if (is_inProgress)
     AddPage(m_tabprogress);
 
@@ -242,11 +242,11 @@ BOOL CWizTab::OnInitDialog()
     }
   }
 */  
-  // Chargement des préférences
+  // Chargement des prÃ©fÃ©rences
   if (!is_inProgress)
     LoadPrefs();
   
-  // Appliquer préférences
+  // Appliquer prÃ©fÃ©rences
   Apply();
   
   int r = CPropertySheet::OnInitDialog();
@@ -260,7 +260,7 @@ BOOL CWizTab::OnInitDialog()
   return r;
 }
 
-// L'utilisateur a appuyé sur "Apply"
+// L'utilisateur a appuyÃ© sur "Apply"
 void CWizTab::OnApplyNow()
 {
   EnableWindow(false);
@@ -269,27 +269,27 @@ void CWizTab::OnApplyNow()
   EnableWindow(true);
 }
 
-// Sauver et appliquer les préférences
+// Sauver et appliquer les prÃ©fÃ©rences
 void CWizTab::ApplyAndSave() {
   CWaitCursor wait;      // Afficher curseur sablier
-  bool err=false;  // Erreur lors de l'écriture des paramètres
+  bool err=false;  // Erreur lors de l'Ã©criture des paramÃ¨tres
   
-  // Appliquer les préférences
+  // Appliquer les prÃ©fÃ©rences
   Apply();
   
-  // Sauver préférences
+  // Sauver prÃ©fÃ©rences
   CWinApp* pApp = AfxGetApp();
  
   if (err)
     AfxMessageBox(LANG(LANG_DIAL2));
 }
 
-// Appliquer préférences
+// Appliquer prÃ©fÃ©rences
 void CWizTab::Apply() {
-  // Appliquer préférences
+  // Appliquer prÃ©fÃ©rences
 }
 
-// Chargement des préférences
+// Chargement des prÃ©fÃ©rences
 void CWizTab::LoadPrefs() {
   CWinApp* pApp = AfxGetApp();
   //n = pApp->GetProfileInt("Driver", "DriverId",0);   // No du driver
@@ -317,11 +317,11 @@ BOOL CWizTab::OnHelpInfo(HELPINFO* dummy)
 /*
 // Capturer OK et Cancel
 void CWizTab::OnOK( ) {
-  // Sauver et appliquer préférences
+  // Sauver et appliquer prÃ©fÃ©rences
   ApplyAndSave();
 }
 void CWizTab::OnCancel( ) {
-  // Recharger préférences
+  // Recharger prÃ©fÃ©rences
   LoadPrefs();
 }
 */

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -29,7 +29,7 @@ Please visit our Website: http://www.httrack.com
 
 // Tab Control Principal
 
-// En-tête pour l'affichage des tabs
+// En-tÃªte pour l'affichage des tabs
 #include "NewProj.h"
 #include "Wid1.h"
 #include "trans.h"
@@ -55,7 +55,7 @@ protected:
   
   // Attributes
 public:
-  // Déclaration des classes-dialog pour les différents Tab Control
+  // DÃ©claration des classes-dialog pour les diffÃ©rents Tab Control
   CFirstInfo*        m_tab0;
   CNewProj*          m_tab1;
   Wid1*              m_tab2;

--- a/WinHTTrack/Wizard.cpp
+++ b/WinHTTrack/Wizard.cpp
@@ -79,11 +79,11 @@ BOOL wizard::OnInitDialog()
   SetIcon(httrack_icon,true);  
   SetForegroundWindow();   // yop en premier plan!
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemText(,"");
     SetWindowTextCP(this, LANG(LANG_L1) /*"Question du wizard"*/);
-    SetDlgItemTextCP(this, IDC_STATIC_answer,LANG(LANG_L2) /*"Votre réponse:"*/);
+    SetDlgItemTextCP(this, IDC_STATIC_answer,LANG(LANG_L2) /*"Votre rÃ©ponse:"*/);
   }
 
 	return TRUE;  // return TRUE unless you set the focus to a control

--- a/WinHTTrack/Wizard2.cpp
+++ b/WinHTTrack/Wizard2.cpp
@@ -81,8 +81,8 @@ BOOL wizard2::OnInitDialog()
   tm=SetTimer(WM_TIMER,1000,NULL);
   SetForegroundWindow();   // yop en premier plan!
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemText(,"");
     SetWindowTextCP(this, LANG(LANG_N1)); // "Question du wizard");
     SetDlgItemTextCP(this, IDCANCEL,LANG(LANG_N2)); // "NON");

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -114,13 +114,13 @@ BOOL Cabout::OnInitDialog()
     int curr_lng=LANG_T(-1);
     QLANG_T(0);
     strcpybuff(lang_str,"LANGUAGE_NAME");
-    LANG_LOAD(lang_str);    // 0 english 1 français..
+    LANG_LOAD(lang_str);    // 0 english 1 franÃ§ais..
     while(strlen(lang_str)) {
       m_ctl_lang.AddString(lang_str);
       i++;
       QLANG_T(i);
       strcpybuff(lang_str,"LANGUAGE_NAME");
-      LANG_LOAD(lang_str);    // 0 english 1 français..
+      LANG_LOAD(lang_str);    // 0 english 1 franÃ§ais..
     }
     QLANG_T(curr_lng);
     //LANG_T(min(old_lang,i-1));
@@ -186,9 +186,9 @@ void Cabout::OnSelchangelang()
 
       QLANG_T(i);
       strcpybuff(lang_str,"LANGUAGE_NAME");
-      LANG_LOAD(lang_str);    // 0 english 1 français..
+      LANG_LOAD(lang_str);    // 0 english 1 franÃ§ais..
 
-      //LANG_T(i);    // 0 english 1 français..
+      //LANG_T(i);    // 0 english 1 franÃ§ais..
       if (strcmp(st,lang_str)==0) {
         LANG_T(i);
         setlang();
@@ -198,7 +198,7 @@ void Cabout::OnSelchangelang()
       }
     }
     /* error */
-    LANG_T(0);    // 0 english 1 français..
+    LANG_T(0);    // 0 english 1 franÃ§ais..
   }
   setlang();
 }

--- a/WinHTTrack/htssystem.h
+++ b/WinHTTrack/htssystem.h
@@ -24,7 +24,7 @@ would dishonor our work and waste the many hours we have spent on it.
 
 Please visit our Website: http://www.httrack.com
 */
-// Définition de la plate-forme utilisée
+// DÃ©finition de la plate-forme utilisÃ©e
 
 // Sun Solaris .......... 0 
 // Windows/95 ........... 1 
@@ -37,6 +37,6 @@ Please visit our Website: http://www.httrack.com
 //#define HTS_ANALYSTE 2
 
 
-// Fin de la définition
+// Fin de la dÃ©finition
 
 

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -68,7 +68,7 @@ static char THIS_FILE[] = __FILE__;
 #endif
 
 // Refresh
-//extern int INFILLMEM_LOCKED;     // refresh mémoire en cours
+//extern int INFILLMEM_LOCKED;     // refresh mÃ©moire en cours
 extern InpInfo SInfo;
 int inprogress_refresh();
 
@@ -405,7 +405,7 @@ void Cinprogress::OnDestroy()
   if (form.m_hWnd)
     form.EndDialog(IDOK);       // terminer!
   this_CSplitterFrame->CheckRestore();
-  //Sleep(150);             // évite les problèmes d'accès à m_hWnd juste avant le destroy
+  //Sleep(150);             // Ã©vite les problÃ¨mes d'accÃ¨s Ã  m_hWnd juste avant le destroy
   CPropertyPage::OnDestroy();
 }
 
@@ -454,7 +454,7 @@ BOOL Cinprogress::OnInitDialog()
   element[1][12]=&m_nm12;
   element[1][13]=&m_nm13;
 
-  // rajouté
+  // rajoutÃ©
   element[4][0]=&m_nn0;
   element[4][1]=&m_nn1;
   element[4][2]=&m_nn2;
@@ -506,10 +506,10 @@ BOOL Cinprogress::OnInitDialog()
     m->CheckMenuItem(ID_FILE_PAUSE,MF_UNCHECKED);
   }
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
-    SetDlgItemTextCP(this, IDC_STATIC_bytes,LANG(LANG_H8) /*"Octets sauvés:"*/);
+    SetDlgItemTextCP(this, IDC_STATIC_bytes,LANG(LANG_H8) /*"Octets sauvÃ©s:"*/);
     SetDlgItemTextCP(this, IDC_STATIC_scanned,LANG(LANG_H9) /*"Liens parcourus:"*/);
     SetDlgItemTextCP(this, IDC_STATIC_time,LANG(LANG_H10) /*"Temps:"*/);
     SetDlgItemTextCP(this, IDC_STATIC_sockets,LANG(LANG_H11) /*"Connexions:"*/);
@@ -586,12 +586,12 @@ void Cinprogress::OniplogErr() {
 
 void Cinprogress::Oniplog(int mode)  {
 	char catbuff[CATBUFF_SIZE];
-  if (!BackAffLog) {  // pas encore lancé
+  if (!BackAffLog) {  // pas encore lancÃ©
     strcpybuff(pathlog,dialog0->GetPath());
     if (strlen(pathlog)>0)
     if ((pathlog[strlen(pathlog)-1]!='/') && (pathlog[strlen(pathlog)-1]!='\\'))
       strcatbuff(pathlog,"/");
-    // fichier log existe ou on est télécommandé par un !
+    // fichier log existe ou on est tÃ©lÃ©commandÃ© par un !
     if ( (fexist(fconcat(catbuff,sizeof(catbuff),pathlog,"hts-err.txt")))
       || (fexist(fconcat(catbuff,sizeof(catbuff),pathlog,"hts-log.txt")))
       || (ShellOptions != NULL && ShellOptions->choixdeb[0]=='!') ) {
@@ -655,7 +655,7 @@ void Cinprogress::OnModifyOpt()
 
     opt->log = opt->errlog = NULL;
 
-    // dévalider champs (non modifiés)
+    // dÃ©valider champs (non modifiÃ©s)
     opt->maxsite = -1;
     opt->maxfile_nonhtml = -1;
     opt->maxfile_html = -1;
@@ -884,7 +884,7 @@ const char* Cinprogress::GetTip(int ID)
 {
   switch(ID) {
     //case IDC_STOPALL: return LANG(LANG_H4); break; // "Stop the mirror","Stopper le miroir"); break;
-    //case IDC_hide:    return LANG(LANG_H5); break; // "Hide this window behind the system tray","Cacher la fenêtre dans la barre système"); break;
+    //case IDC_hide:    return LANG(LANG_H5); break; // "Hide this window behind the system tray","Cacher la fenÃªtre dans la barre systÃ¨me"); break;
     case IDC_sk0:     return LANG(LANG_H6); break; // "Click to skip a link or interrupt parsing","Clic pour sauter un lien ou interrompre"); break;
     case IDC_sk1: case IDC_sk2: case IDC_sk3: case IDC_sk4:
     case IDC_sk5: case IDC_sk6: case IDC_sk7: case IDC_sk8: case IDC_sk9:
@@ -954,7 +954,7 @@ LRESULT Cinprogress::DragDropText(WPARAM wParam,LPARAM lParam) {
             hts_resetaddurl(global_opt);
             AfxMessageBox(LANG(LANG_DIAL13));
           }
-          hts_setpause(global_opt, pause);      // remettre pause éventuelle
+          hts_setpause(global_opt, pause);      // remettre pause Ã©ventuelle
         }
         CEasyDropTarget::ReleaseStringToArray(tab);
         tab=NULL;
@@ -970,8 +970,8 @@ void Cinprogress::OnTimer(UINT_PTR nIDEvent)
   WHTT_LOCK();
   if (!termine) {
     if (SInfo.refresh) {
-      hts_is_parsing(global_opt, 0);        // refresh demandé si en mode parsing
-      // while(INFILLMEM_LOCKED) Sleep(10);    // attendre au cas où
+      hts_is_parsing(global_opt, 0);        // refresh demandÃ© si en mode parsing
+      // while(INFILLMEM_LOCKED) Sleep(10);    // attendre au cas oÃ¹
       if (!termine)
         inprogress_refresh();        // on refresh!
     }

--- a/WinHTTrack/inprogress.h
+++ b/WinHTTrack/inprogress.h
@@ -54,7 +54,7 @@ public:
   void StatsBuffer_info(int id);
   void StopTimer();
 
-  CWnd* element[5][NStatsBuffer];    // ici 10=NStatsBuffer -- les éléments (status nom slide bouton)
+  CWnd* element[5][NStatsBuffer];    // ici 10=NStatsBuffer -- les Ã©lÃ©ments (status nom slide bouton)
 	//Cinprogress(CWnd* pParent = NULL);   // standard constructor
   CWinThread * BackAffLog;
   Ciplog form;

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -292,7 +292,7 @@ void LANG_LOAD(char* limit_to) {
             }  while (strnotempty(test));
           }
 
-          if (!strnotempty(test)) {         // éviter doublons
+          if (!strnotempty(test)) {         // Ã©viter doublons
             // conv_printf(key,key);
             size_t len;
             char* buff;
@@ -694,7 +694,7 @@ void LANG_DELETE() {
   coucal_delete(&NewLangStrKeys);
 }
 
-// sélection de la langue
+// sÃ©lection de la langue
 void LANG_INIT() {
   CWinApp* pApp = AfxGetApp();
   if (pApp) {

--- a/WinHTTrack/splitter.cpp
+++ b/WinHTTrack/splitter.cpp
@@ -169,15 +169,15 @@ void CSplitterFrame::CheckRestore() {
 
 
 BOOL CSplitterFrame::Create( LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle , const RECT& rect , CMDIFrameWnd* pParentWnd , CCreateContext* pContext ) {
-  /* recréer control tabs */
+  /* recrÃ©er control tabs */
   this_app->NewTabs();
 
-  // Enlever bordure fenêtre, et mettre en plein écran (pas de fenêtre dans la fenêtre!!)
+  // Enlever bordure fenÃªtre, et mettre en plein Ã©cran (pas de fenÃªtre dans la fenÃªtre!!)
   dwStyle&=(~(WS_MINIMIZEBOX|WS_BORDER|WS_CAPTION|WS_OVERLAPPED|WS_OVERLAPPEDWINDOW));
   dwStyle|=(WS_MAXIMIZE);
   int r=CMDIChildWnd::Create(lpszClassName,lpszWindowName,dwStyle ,rect ,pParentWnd ,pContext );
   if (r) {
-    // Mettre en maximisé
+    // Mettre en maximisÃ©
     WINDOWPLACEMENT pl;
     RECT rc;
     rc.top=0;
@@ -199,7 +199,7 @@ BOOL CSplitterFrame::Create( LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWOR
   icnd.uCallbackMessage=wm_IcnRest;  // notre callback
   icnd.hIcon=AfxGetApp()->LoadIcon(IDR_MAINFRAME);
 
-  // Retourner résultat
+  // Retourner rÃ©sultat
   return r;
 }
 
@@ -311,7 +311,7 @@ BOOL CSplitterFrame::SetNewView(int row, int col, CRuntimeClass* pViewClass) {
   m_wndSplitter.DeleteView(row, col);                // delete old view
 
   /* */
-  /* recréer control tabs */
+  /* recrÃ©er control tabs */
   this_app->NewTabs();
   /* */
 
@@ -334,7 +334,7 @@ BOOL CSplitterFrame::SetNewView(int row, int col, CRuntimeClass* pViewClass) {
 }
 
 BOOL CSplitterFrame::SetSaved() {
-  GetActiveDocument()->SetModifiedFlag(FALSE);      // Document sauvé
+  GetActiveDocument()->SetModifiedFlag(FALSE);      // Document sauvÃ©
   return 1;
 }
 
@@ -394,7 +394,7 @@ void CSplitterFrame::EnableSaveEntries(BOOL state) {
 }
 
 void CSplitterFrame::SetMenuPrefs() {
-  if (LANG_T(-1)) {    // Patcher en français
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     CMenu* menu = GetParent()->GetParent()->GetMenu();
     if (menu) {
       ModifyMenuCP(menu, 0,MF_BYPOSITION,0,LANG(LANG_P1));

--- a/WinHTTrack/trans.cpp
+++ b/WinHTTrack/trans.cpp
@@ -199,19 +199,19 @@ BOOL Ctrans::OnInitDialog()
   SetIcon(httrack_icon,true);  
 	EnableToolTips(true);     // TOOL TIPS
 
-  // Patcher l'interface pour les Français ;-)
-  if (LANG_T(-1)) {    // Patcher en français
+  // Patcher l'interface pour les FranÃ§ais ;-)
+  if (LANG_T(-1)) {    // Patcher en franÃ§ais
     //SetDlgItemTextCP(this, ,"");
-    SetWindowTextCP(this, LANG(LANG_J9) /*"Démarrer.."*/);
-    SetDlgItemTextCP(this, IDC_select_start,LANG(LANG_J10) /*"Vous pouvez démarrer le miroir en pressant la touche DEMARRER,\nou définir avant les options de connexion"*/);
+    SetWindowTextCP(this, LANG(LANG_J9) /*"DÃ©marrer.."*/);
+    SetDlgItemTextCP(this, IDC_select_start,LANG(LANG_J10) /*"Vous pouvez dÃ©marrer le miroir en pressant la touche DEMARRER,\nou dÃ©finir avant les options de connexion"*/);
     SetDlgItemTextCP(this, IDC_select_save,LANG(LANG_J10b));
     SetDlgItemTextCP(this, IDC_STATIC_delay,LANG(LANG_J11) /*"Retarder"*/);
-    SetDlgItemTextCP(this, IDC_wait,LANG(LANG_J12) /*"Attendre avant de commencer jusqu'à: (hh/mm/ss)"*/);
+    SetDlgItemTextCP(this, IDC_wait,LANG(LANG_J12) /*"Attendre avant de commencer jusqu'Ã : (hh/mm/ss)"*/);
     //SetDlgItemTextCP(this, IDC_avant,LANG(LANG_BACK) /*"<- AVANT"*/);
     SetDlgItemTextCP(this, IDCANCEL,LANG(LANG_QUIT) /*"Quitter"*/);
     SetDlgItemTextCP(this, IDOK,LANG(LANG_J13) /*"DEMARRER!"*/);
     SetDlgItemTextCP(this, IDC_STATIC_ras,LANG(LANG_J14) /*"Connexion provider"*/);
-    SetDlgItemTextCP(this, IDC_cnx,LANG(LANG_J15) /*"Connecter à ce provider"*/);
+    SetDlgItemTextCP(this, IDC_cnx,LANG(LANG_J15) /*"Connecter Ã  ce provider"*/);
     SetDlgItemTextCP(this, IDC_rasdisc,LANG_J16);
   }
 
@@ -247,7 +247,7 @@ void Ctrans::FillProviderList(int fill)
         GetDlgItem(IDC_STATIC_ras)->ModifyStyle(WS_DISABLED,0);
         GetDlgItem(IDC_STATIC_ras)->RedrawWindow();
         m_ctlrasid.ResetContent();
-        m_ctlrasid.InsertString(-1,LANG(LANG_J2 /*"do not connect to a provider (already connected)","pas de connexion à un provider (déja connecté)"*/));
+        m_ctlrasid.InsertString(-1,LANG(LANG_J2 /*"do not connect to a provider (already connected)","pas de connexion Ã  un provider (dÃ©ja connectÃ©)"*/));
         for(i=0;i<(int) ent;i++) {
           m_ctlrasid.InsertString(-1,adr[i].szEntryName);
         }
@@ -310,8 +310,8 @@ const char* Ctrans::GetTip(int ID)
     case IDC_hh: case IDC_mm: case IDC_ss: 
       return LANG(LANG_J3); break; // "Schedule the mirror","Programmer un miroir"); break;
     case IDCANCEL:  return LANG(LANG_J4); break; // "Quit WinHTTrack","Quitter WinHTTrack"); break;
-    case IDC_avant: return LANG(LANG_J5); break; // "Back to the start page","Retour à la première page"); break;
-    case IDOK:      return LANG(LANG_J6); break; // "Click to start!","Clic pour démarrer!"); break;
+    case IDC_avant: return LANG(LANG_J5); break; // "Back to the start page","Retour Ã  la premiÃ¨re page"); break;
+    case IDOK:      return LANG(LANG_J6); break; // "Click to start!","Clic pour dÃ©marrer!"); break;
     case IDC_rasdisc: return LANG_J17; break;
     //case : return ""; break;
   }
@@ -360,13 +360,13 @@ BOOL Ctrans::OnWizardFinish( )
 	// TODO: Add extra validation here
   int r = m_ctlrasid.GetCurSel();
   strcpybuff(RasString,"");
-  if ((r!=CB_ERR) && (r != 0)) {    // sélection provider
+  if ((r!=CB_ERR) && (r != 0)) {    // sÃ©lection provider
     if (m_ctlrasid.GetLBText(r,RasString) != CB_ERR) {
       if (strlen(RasString)>0) {
         //
 #if USE_RAS
         if (LibRasUse) {
-          if (strlen(RasString)>0) {    // sélection provider
+          if (strlen(RasString)>0) {    // sÃ©lection provider
             BOOL ifpass;
             dial.dwSize = sizeof(dial);
             strcpybuff(dial.szEntryName,RasString);
@@ -377,11 +377,11 @@ BOOL Ctrans::OnWizardFinish( )
             strcpybuff(dial.szDomain,"");
             if (!LibRas->RasGetEntryDialParams(NULL,&dial,&ifpass)) {
               if (!ifpass) {    // pas de pass
-                AfxMessageBox(LANG(LANG_J7 /*"No saved password for this connection!","Pas de mot de passe sauvé pour cette connexion!"*/));
+                AfxMessageBox(LANG(LANG_J7 /*"No saved password for this connection!","Pas de mot de passe sauvÃ© pour cette connexion!"*/));
                 return 0;    // cancel
               }
             } else {
-              AfxMessageBox(LANG(LANG_J8 /*"Can not get RAS setup","Impossible d'obtenir les paramètres de connexion"*/));
+              AfxMessageBox(LANG(LANG_J8 /*"Can not get RAS setup","Impossible d'obtenir les paramÃ¨tres de connexion"*/));
               return 0;    // cancel
             }
           }
@@ -396,7 +396,7 @@ BOOL Ctrans::OnWizardFinish( )
   UpdateData(TRUE);         // DoDataExchange
   compute_options() ;
 
-  // Index "top" si nécessaire!
+  // Index "top" si nÃ©cessaire!
   if (maintab->m_option3.m_windebug) {
     fp_debug=fopen("winhttrack.log","wb");
   } else {


### PR DESCRIPTION
The 49 non-ASCII sources kept their French comments as raw ISO-8859-1 bytes, so any UTF-8-default editor rewrites them to U+FFFD on save, which is why the tree needed byte-wise sed/perl edits. This transcodes them to UTF-8, matching the engine tree, so the files edit cleanly with ordinary tools.

It is behavior-neutral: the high bytes are comment-only (à ç è é ê ô ù), no compiled narrow literal is non-ASCII, and each file was proven to round-trip back to its original bytes. `/source-charset:utf-8` makes MSVC parse the UTF-8 deterministically while the ANSI execution charset stays the system code page. The `.rc` and other resource inputs stay Latin-1+CRLF (different compiler, own codepage rules); the CI encoding check now asserts sources decode as strict UTF-8.