### PR TITLE
Add a "Write WARC archive" option to the Build tab

### DIFF
--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -57,6 +57,7 @@ COptionTab2::COptionTab2() : CPropertyPage(COptionTab2::IDD)
 	m_errpage = FALSE;
 	m_external = FALSE;
 	m_nopurge = FALSE;
+	m_warc = FALSE;
 	m_hidepwd = FALSE;
 	m_hidequery = FALSE;
 	m_iso9660 = FALSE;
@@ -78,6 +79,7 @@ void COptionTab2::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_errpage, m_errpage);
 	DDX_Check(pDX, IDC_external, m_external);
 	DDX_Check(pDX, IDC_nopurge, m_nopurge);
+	DDX_Check(pDX, IDC_warc, m_warc);
 	DDX_Check(pDX, IDC_hidepwd, m_hidepwd);
 	DDX_Check(pDX, IDC_hidequery, m_hidequery);
 	DDX_Check(pDX, IDC_iso9660, m_iso9660);
@@ -134,6 +136,7 @@ BOOL COptionTab2::OnInitDialog()
     GetDlgItem(IDC_iso9660) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_errpage) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_nopurge) ->ModifyStyle(0,WS_DISABLED);
+    GetDlgItem(IDC_warc)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_external)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_hidepwd) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_hidequery)->ModifyStyle(0,WS_DISABLED);
@@ -144,6 +147,7 @@ BOOL COptionTab2::OnInitDialog()
     GetDlgItem(IDC_iso9660) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_errpage) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_nopurge) ->ModifyStyle(WS_DISABLED,0);
+    GetDlgItem(IDC_warc)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_external)->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_hidepwd) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_hidequery)->ModifyStyle(WS_DISABLED,0);
@@ -199,6 +203,7 @@ const char* COptionTab2::GetTip(int ID)
     case IDC_errpage: return LANG(LANG_I9); break; // "Do not write html error pages","Ne pas générer les fichiers d'erreur html"); break;
     case IDC_external: return LANG(LANG_I29); break; // extern
     case IDC_nopurge: return LANG(LANG_I1a); break; // erase old files
+    case IDC_warc: return "Write an ISO-28500 WARC archive (.warc.gz)"; break;
     case IDC_hidepwd: return LANG(LANG_I30); break;
     case IDC_hidequery: return LANG_I30b; break;
   }

--- a/WinHTTrack/OptionTab2.h
+++ b/WinHTTrack/OptionTab2.h
@@ -62,6 +62,7 @@ public:
 	BOOL	m_errpage;
 	BOOL	m_external;
 	BOOL	m_nopurge;
+	BOOL	m_warc;
 	BOOL	m_hidepwd;
 	BOOL	m_hidequery;
 	BOOL	m_iso9660;

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -557,7 +557,7 @@ void compute_options() {
   if(maintab->m_option2.m_errpage) ShellOptions->errpage = "o0"; else ShellOptions->errpage = ""; 
   if(maintab->m_option2.m_external) ShellOptions->external = "x"; else ShellOptions->external = ""; 
   if(maintab->m_option2.m_nopurge) ShellOptions->nopurge = "X0"; else ShellOptions->nopurge = "";
-  if(maintab->m_option2.m_warc) ShellOptions->warc = "%r"; else ShellOptions->warc = "";
+  if(maintab->m_option2.m_warc) ShellOptions->warc = "1"; else ShellOptions->warc = "";
   if(maintab->m_option2.m_hidepwd) ShellOptions->hidepwd = "%x"; else ShellOptions->hidepwd = "";
   if(maintab->m_option2.m_hidequery) ShellOptions->hidequery = "%q0"; else ShellOptions->hidequery = ""; 
   
@@ -1897,7 +1897,6 @@ void lance(void) {
   single += ShellOptions->link;
   single += ShellOptions->external;
   single += ShellOptions->nopurge;
-  single += ShellOptions->warc;    // -%r: engine writes an auto-named .warc.gz
   single += ShellOptions->hidepwd;
   single += ShellOptions->hidequery;
   single += ShellOptions->robots;
@@ -1944,7 +1943,13 @@ void lance(void) {
   single += ShellOptions->maxlinks;
   single += ShellOptions->proxyftp;  
   single += "#f";  // flush
-  
+
+  // WARC: emit --warc as its own token, not in the compacted -%... string, whose
+  // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
+  if (ShellOptions->warc.GetLength() != 0) {
+    args.Add("--warc");
+  }
+
   if (ShellOptions->user.GetLength() != 0) {
     args.Add("-F");
     args.Add(ShellOptions->user);

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -556,8 +556,9 @@ void compute_options() {
   if(maintab->m_option1.m_htmlfirst) ShellOptions->htmlfirst = "p7"; else ShellOptions->htmlfirst = ""; 
   if(maintab->m_option2.m_errpage) ShellOptions->errpage = "o0"; else ShellOptions->errpage = ""; 
   if(maintab->m_option2.m_external) ShellOptions->external = "x"; else ShellOptions->external = ""; 
-  if(maintab->m_option2.m_nopurge) ShellOptions->nopurge = "X0"; else ShellOptions->nopurge = ""; 
-  if(maintab->m_option2.m_hidepwd) ShellOptions->hidepwd = "%x"; else ShellOptions->hidepwd = ""; 
+  if(maintab->m_option2.m_nopurge) ShellOptions->nopurge = "X0"; else ShellOptions->nopurge = "";
+  if(maintab->m_option2.m_warc) ShellOptions->warc = "%r"; else ShellOptions->warc = "";
+  if(maintab->m_option2.m_hidepwd) ShellOptions->hidepwd = "%x"; else ShellOptions->hidepwd = "";
   if(maintab->m_option2.m_hidequery) ShellOptions->hidequery = "%q0"; else ShellOptions->hidequery = ""; 
   
   ShellOptions->keepwww = maintab->m_option1.m_keepwww ? "--keep-www-prefix" : "";
@@ -1896,6 +1897,7 @@ void lance(void) {
   single += ShellOptions->link;
   single += ShellOptions->external;
   single += ShellOptions->nopurge;
+  single += ShellOptions->warc;    // -%r: engine writes an auto-named .warc.gz
   single += ShellOptions->hidepwd;
   single += ShellOptions->hidequery;
   single += ShellOptions->robots;
@@ -2504,6 +2506,7 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection, "NoPwdInPages",maintab->m_option2.m_hidepwd);
     MyWriteProfileInt(path,strSection, "NoQueryStrings",maintab->m_option2.m_hidequery);
     MyWriteProfileInt(path,strSection, "NoPurgeOldFiles",maintab->m_option2.m_nopurge);
+    MyWriteProfileInt(path,strSection, "Warc",maintab->m_option2.m_warc);
     MyWriteProfileInt(path,strSection, "Cookies",maintab->m_option8.m_cookies);
     MyWriteProfileInt(path,strSection, "CheckType",maintab->m_option8.m_checktype);
     MyWriteProfileInt(path,strSection, "ParseJava",maintab->m_option8.m_parsejava);
@@ -2615,6 +2618,8 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection,"NoExternalPages", n);
     n=maintab->m_option2.IsDlgButtonChecked(IDC_nopurge);
     MyWriteProfileInt(path,strSection,"NoPurgeOldFiles", n);
+    n=maintab->m_option2.IsDlgButtonChecked(IDC_warc);
+    MyWriteProfileInt(path,strSection,"Warc", n);
     if ((n=maintab->m_option2.m_ctl_build.GetCurSel()) != CB_ERR)
       MyWriteProfileInt(path,strSection, "Build", n);
     st = maintab->m_option2.Bopt.m_BuildString;
@@ -2844,6 +2849,7 @@ void Read_profile(CString path,int load_path) {
   maintab->m_option2.m_hidepwd   = MyGetProfileInt(path,strSection, "NoPwdInPages",0);
   maintab->m_option2.m_hidequery = MyGetProfileInt(path,strSection, "NoQueryStrings",0);
   maintab->m_option2.m_nopurge   = MyGetProfileInt(path,strSection, "NoPurgeOldFiles",0);
+  maintab->m_option2.m_warc      = MyGetProfileInt(path,strSection, "Warc",0);
   maintab->m_option8.m_cookies    = MyGetProfileInt(path,strSection, "Cookies",1);
   maintab->m_option8.m_checktype  = MyGetProfileInt(path,strSection, "CheckType",1);
   maintab->m_option8.m_parsejava  = MyGetProfileInt(path,strSection, "ParseJava",1);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -250,7 +250,7 @@ public:
     conn, tog, cache, robots, choixdeb, build, filtre, htmlfirst, 
     index, index2, index_mail, dos, time, rate, hostquit, ka, 
     user, footer, log, testall, parseall, link, path, 
-    retry, errpage, external, nopurge, hidepwd, hidequery, 
+    retry, errpage, external, nopurge, warc, hidepwd, hidequery,
     cookies, checktype, parsejava, Cache2, logtype, norecatch, 
     toler, updhack, urlhack, http10, waittime, maxtime, maxrate, 
     maxconn, maxlinks, hh, mm, ss, buff_filtres, buff_MIME, 

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -592,7 +592,7 @@ BEGIN
     CONTROL         "Keep the original query-string order",IDC_keepqueryorder,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,133,309,10
 END
 
-IDD_OPTION2 DIALOG  0, 0, 296, 150
+IDD_OPTION2 DIALOG  0, 0, 296, 165
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION | WS_SYSMENU
 CAPTION "Build"
 FONT 8, "MS Sans Serif"
@@ -607,6 +607,7 @@ BEGIN
     CONTROL         "Hide passwords",IDC_hidepwd,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,105,269,9
     CONTROL         "Hide query strings",IDC_hidequery,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,120,269,9
     CONTROL         "Do not purge old files",IDC_nopurge,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,135,269,9
+    CONTROL         "Write WARC archive",IDC_warc,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,150,269,9
 END
 
 IDD_OPTION7 DIALOG  0, 0, 315, 197

--- a/WinHTTrack/resource.h
+++ b/WinHTTrack/resource.h
@@ -189,6 +189,7 @@ Please visit our Website: http://www.httrack.com
 #define IDC_external                    1035
 #define IDC_prox                        1036
 #define IDC_nopurge                     1036
+#define IDC_warc                        1321
 #define IDC_portprox                    1037
 #define IDC_hidepwd                     1037
 #define IDC_choix2                      1038
@@ -615,7 +616,7 @@ Please visit our Website: http://www.httrack.com
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        247
 #define _APS_NEXT_COMMAND_VALUE         32837
-#define _APS_NEXT_CONTROL_VALUE         1321
+#define _APS_NEXT_CONTROL_VALUE         1322
 #define _APS_NEXT_SYMED_VALUE           108
 #endif
 #endif


### PR DESCRIPTION
Adds a "Write WARC archive" checkbox to the Build options tab. Tick it and WinHTTrack passes `-%r`, so the engine writes an auto-named `.warc.gz` next to the mirror (a standard ISO-28500 archive of the crawl). It is cloned end to end from the existing "Do not purge old files" checkbox, so it persists through `winprofile.ini` and is disabled in update-on-the-fly mode like the other Build options. Off by default, so existing runs are unchanged.

It needs the engine WARC support (core PR #671), which is not on `xroche/httrack` master yet, so older engines do not recognise `-%r`. Nothing here references a WARC engine symbol, so CI is unaffected and the option just does nothing until the engine lands it. Please do not merge before that PR.

Toggle-only for now (auto-named archive). A custom `--warc-file` name field and wiring the label into the `LANG()` localization table are follow-ups. There is no argv unit-test harness on the WinHTTrack side, so verification is a manual GUI run producing a valid `.warc.gz`.