### PR TITLE
Move the WARC checkbox to the Log/Index/Cache tab

### DIFF
--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -57,7 +57,6 @@ COptionTab2::COptionTab2() : CPropertyPage(COptionTab2::IDD)
 	m_errpage = FALSE;
 	m_external = FALSE;
 	m_nopurge = FALSE;
-	m_warc = FALSE;
 	m_hidepwd = FALSE;
 	m_hidequery = FALSE;
 	m_iso9660 = FALSE;
@@ -79,7 +78,6 @@ void COptionTab2::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_errpage, m_errpage);
 	DDX_Check(pDX, IDC_external, m_external);
 	DDX_Check(pDX, IDC_nopurge, m_nopurge);
-	DDX_Check(pDX, IDC_warc, m_warc);
 	DDX_Check(pDX, IDC_hidepwd, m_hidepwd);
 	DDX_Check(pDX, IDC_hidequery, m_hidequery);
 	DDX_Check(pDX, IDC_iso9660, m_iso9660);
@@ -136,7 +134,6 @@ BOOL COptionTab2::OnInitDialog()
     GetDlgItem(IDC_iso9660) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_errpage) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_nopurge) ->ModifyStyle(0,WS_DISABLED);
-    GetDlgItem(IDC_warc)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_external)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_hidepwd) ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_hidequery)->ModifyStyle(0,WS_DISABLED);
@@ -147,7 +144,6 @@ BOOL COptionTab2::OnInitDialog()
     GetDlgItem(IDC_iso9660) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_errpage) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_nopurge) ->ModifyStyle(WS_DISABLED,0);
-    GetDlgItem(IDC_warc)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_external)->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_hidepwd) ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_hidequery)->ModifyStyle(WS_DISABLED,0);
@@ -203,7 +199,6 @@ const char* COptionTab2::GetTip(int ID)
     case IDC_errpage: return LANG(LANG_I9); break; // "Do not write html error pages","Ne pas générer les fichiers d'erreur html"); break;
     case IDC_external: return LANG(LANG_I29); break; // extern
     case IDC_nopurge: return LANG(LANG_I1a); break; // erase old files
-    case IDC_warc: return "Write an ISO-28500 WARC archive (.warc.gz)"; break;
     case IDC_hidepwd: return LANG(LANG_I30); break;
     case IDC_hidequery: return LANG_I30b; break;
   }

--- a/WinHTTrack/OptionTab2.h
+++ b/WinHTTrack/OptionTab2.h
@@ -62,7 +62,6 @@ public:
 	BOOL	m_errpage;
 	BOOL	m_external;
 	BOOL	m_nopurge;
-	BOOL	m_warc;
 	BOOL	m_hidepwd;
 	BOOL	m_hidequery;
 	BOOL	m_iso9660;

--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -59,6 +59,7 @@ COptionTab9::COptionTab9() : CPropertyPage(COptionTab9::IDD)
 	m_norecatch = FALSE;
 	m_index2 = FALSE;
 	m_index_mail = FALSE;
+	m_warc = FALSE;
 	//}}AFX_DATA_INIT
 }
 
@@ -77,6 +78,7 @@ void COptionTab9::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_norecatch, m_norecatch);
 	DDX_Check(pDX, IDC_index2, m_index2);
 	DDX_Check(pDX, IDC_index_mail, m_index_mail);
+	DDX_Check(pDX, IDC_warc, m_warc);
 	//}}AFX_DATA_MAP
 }
 
@@ -113,6 +115,7 @@ BOOL COptionTab9::OnInitDialog()
     GetDlgItem(IDC_index_mail)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_logf)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_Cache2)  ->ModifyStyle(0,WS_DISABLED);
+    GetDlgItem(IDC_warc)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_logtype) ->ModifyStyle(0,WS_DISABLED);
   } else {
     GetDlgItem(IDC_norecatch)->ModifyStyle(WS_DISABLED,0);
@@ -121,6 +124,7 @@ BOOL COptionTab9::OnInitDialog()
     GetDlgItem(IDC_index_mail)->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_logf)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_Cache2)  ->ModifyStyle(WS_DISABLED,0);
+    GetDlgItem(IDC_warc)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_logtype) ->ModifyStyle(WS_DISABLED,0);
   }
 
@@ -174,6 +178,7 @@ const char* COptionTab9::GetTip(int ID)
     case IDC_index_mail:return LANG(LANG_I6c); break;
     case IDC_logf:    return LANG(LANG_I7); break; // "Create log files for error and info report","Générer des fichiers d'audit pour les erreurs et les messages"); break;
     case IDC_Cache2:  return LANG(LANG_I1e); break;
+    case IDC_warc:    return "Write an ISO-28500 WARC archive (.warc.gz)"; break;
     case IDC_logtype: return LANG(LANG_I1f); break;
   }
   return "";

--- a/WinHTTrack/OptionTab9.h
+++ b/WinHTTrack/OptionTab9.h
@@ -57,6 +57,7 @@ public:
 	BOOL	m_norecatch;
 	BOOL	m_index2;
 	BOOL	m_index_mail;
+	BOOL	m_warc;
 	//}}AFX_DATA
 
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -557,7 +557,7 @@ void compute_options() {
   if(maintab->m_option2.m_errpage) ShellOptions->errpage = "o0"; else ShellOptions->errpage = ""; 
   if(maintab->m_option2.m_external) ShellOptions->external = "x"; else ShellOptions->external = ""; 
   if(maintab->m_option2.m_nopurge) ShellOptions->nopurge = "X0"; else ShellOptions->nopurge = "";
-  if(maintab->m_option2.m_warc) ShellOptions->warc = "1"; else ShellOptions->warc = "";
+  if(maintab->m_option9.m_warc) ShellOptions->warc = "1"; else ShellOptions->warc = "";
   if(maintab->m_option2.m_hidepwd) ShellOptions->hidepwd = "%x"; else ShellOptions->hidepwd = "";
   if(maintab->m_option2.m_hidequery) ShellOptions->hidequery = "%q0"; else ShellOptions->hidequery = ""; 
   
@@ -2511,7 +2511,7 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection, "NoPwdInPages",maintab->m_option2.m_hidepwd);
     MyWriteProfileInt(path,strSection, "NoQueryStrings",maintab->m_option2.m_hidequery);
     MyWriteProfileInt(path,strSection, "NoPurgeOldFiles",maintab->m_option2.m_nopurge);
-    MyWriteProfileInt(path,strSection, "Warc",maintab->m_option2.m_warc);
+    MyWriteProfileInt(path,strSection, "Warc",maintab->m_option9.m_warc);
     MyWriteProfileInt(path,strSection, "Cookies",maintab->m_option8.m_cookies);
     MyWriteProfileInt(path,strSection, "CheckType",maintab->m_option8.m_checktype);
     MyWriteProfileInt(path,strSection, "ParseJava",maintab->m_option8.m_parsejava);
@@ -2623,7 +2623,7 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection,"NoExternalPages", n);
     n=maintab->m_option2.IsDlgButtonChecked(IDC_nopurge);
     MyWriteProfileInt(path,strSection,"NoPurgeOldFiles", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_warc);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_warc);
     MyWriteProfileInt(path,strSection,"Warc", n);
     if ((n=maintab->m_option2.m_ctl_build.GetCurSel()) != CB_ERR)
       MyWriteProfileInt(path,strSection, "Build", n);
@@ -2854,7 +2854,7 @@ void Read_profile(CString path,int load_path) {
   maintab->m_option2.m_hidepwd   = MyGetProfileInt(path,strSection, "NoPwdInPages",0);
   maintab->m_option2.m_hidequery = MyGetProfileInt(path,strSection, "NoQueryStrings",0);
   maintab->m_option2.m_nopurge   = MyGetProfileInt(path,strSection, "NoPurgeOldFiles",0);
-  maintab->m_option2.m_warc      = MyGetProfileInt(path,strSection, "Warc",0);
+  maintab->m_option9.m_warc      = MyGetProfileInt(path,strSection, "Warc",0);
   maintab->m_option8.m_cookies    = MyGetProfileInt(path,strSection, "Cookies",1);
   maintab->m_option8.m_checktype  = MyGetProfileInt(path,strSection, "CheckType",1);
   maintab->m_option8.m_parsejava  = MyGetProfileInt(path,strSection, "ParseJava",1);

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -592,7 +592,7 @@ BEGIN
     CONTROL         "Keep the original query-string order",IDC_keepqueryorder,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,133,309,10
 END
 
-IDD_OPTION2 DIALOG  0, 0, 296, 165
+IDD_OPTION2 DIALOG  0, 0, 296, 150
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION | WS_SYSMENU
 CAPTION "Build"
 FONT 8, "MS Sans Serif"
@@ -607,7 +607,6 @@ BEGIN
     CONTROL         "Hide passwords",IDC_hidepwd,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,105,269,9
     CONTROL         "Hide query strings",IDC_hidequery,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,120,269,9
     CONTROL         "Do not purge old files",IDC_nopurge,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,135,269,9
-    CONTROL         "Write WARC archive",IDC_warc,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,150,269,9
 END
 
 IDD_OPTION7 DIALOG  0, 0, 315, 197
@@ -653,6 +652,7 @@ BEGIN
     CONTROL         "Store ALL files in cache",IDC_Cache2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,16,305,9
     CONTROL         "Do not re-download locally erased files",IDC_norecatch,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,32,304,9
+    CONTROL         "Write WARC archive",IDC_warc,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,48,305,9
     CONTROL         "Create Log files",IDC_logf,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,64,159,9
     COMBOBOX        IDC_logtype,175,64,105,56,CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Make an index",IDC_index,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,80,304,9


### PR DESCRIPTION
The "Write WARC archive" checkbox belongs with the cache options, not on the Build tab where #52 first placed it. WARC records the raw fetch transactions (a sibling of the hts-cache), not a browsable-mirror build format, so this moves it to the Log/Index/Cache tab, matching the webhttrack reference UI (option9.html) and the core CLI `--help` grouping.

The move is mechanical: `OptionTab2`/`IDD_OPTION2` to `OptionTab9`/`IDD_OPTION9`, keeping the same `IDC_warc` id, the `--warc` argv token, and the winprofile.ini "Warc" key. No behavior or persistence change, only which tab shows the control.

Follow-up to #52.