### PR TITLE
Query Log/Index/Cache checkboxes on their own page when saving a profile

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2600,18 +2600,18 @@ void Write_profile(CString path,int load_path) {
     // 2
     n=maintab->m_option3.IsDlgButtonChecked(IDC_Cache);
     MyWriteProfileInt(path,strSection,"Cache", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_norecatch);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_norecatch);
     MyWriteProfileInt(path,strSection,"NoRecatch", n);
     n = ((maintab->m_option2.IsDlgButtonChecked(IDC_dos))?1:0)
       + ((maintab->m_option2.IsDlgButtonChecked(IDC_iso9660)?1:0)<<1);
     MyWriteProfileInt(path,strSection,"Dos", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_index);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_index);
     MyWriteProfileInt(path,strSection,"Index", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_index2);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_index2);
     MyWriteProfileInt(path,strSection,"WordIndex", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_index_mail);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_index_mail);
     MyWriteProfileInt(path,strSection,"MailIndex", n);
-    n=maintab->m_option2.IsDlgButtonChecked(IDC_logf);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_logf);
     MyWriteProfileInt(path,strSection,"Log", n);
     n=maintab->m_option2.IsDlgButtonChecked(IDC_errpage);
     MyWriteProfileInt(path,strSection,"NoErrorPages", n);


### PR DESCRIPTION
When the options window is open, `Write_profile` reads five Log/Index/Cache checkboxes (do-not-recatch, make-an-index, word-index, mail-index, create-log-files) from the Build page (`m_option2`) instead of the page that hosts them (`m_option9`). `IsDlgButtonChecked` is scoped to one property page, so four of the ids are not found on the Build page and read back as 0, and NoRecatch collides with the ISO9660 checkbox (both id 1031), so it mirrors that unrelated toggle. This routes all five to `m_option9`, matching the member-variable save branch right above it.

It is latent, not live: the property sheet is only ever shown modally and nothing calls `Write_profile` while it is open, so every real save today goes through the correct member-variable branch. The fix keeps the wrong-page branch correct in case the sheet is ever made modeless or gains an Apply button.

Found while relocating the WARC checkbox in #53, which was the same wrong-page mistake.