### PR TITLE
Installer: say .whtt is the only file association

### DIFF
--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -64,7 +64,7 @@ SignedUninstaller=no
 #endif
 
 [Tasks]
-Name: "regfiles"; Description: "Associate the .whtt project file type with WinHTTrack, and add ""New > WinHTTrack Project"" to the Explorer menu"; GroupDescription: "Setup:"
+Name: "regfiles"; Description: "Associate the .whtt project file type (the only extension this affects) with WinHTTrack, and add ""New > WinHTTrack Project"" to the Explorer menu"; GroupDescription: "Setup:"
 Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "Additional icons:"
 Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescription: "Additional icons:"; Flags: unchecked
 


### PR DESCRIPTION
The installer's file-association option named `.whtt` but didn't make clear it was the only extension affected, so users couldn't tell what else enabling it would touch (xroche/httrack#187). This spells out that `.whtt` is the only association made. Since that one type is all the installer ever registers, the per-extension checkboxes the issue also floated wouldn't add anything.