### PR TITLE
Fix use-after-free in option-page tab titles after a language change

### DIFF
--- a/WinHTTrack/OptionTab1.cpp
+++ b/WinHTTrack/OptionTab1.cpp
@@ -46,7 +46,8 @@ COptionTab1::COptionTab1() : CPropertyPage(COptionTab1::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT1); // titre
+    m_strCaption = LANG(LANG_IOPT1); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab10.cpp
+++ b/WinHTTrack/OptionTab10.cpp
@@ -60,7 +60,8 @@ COptionTab10::COptionTab10() : CPropertyPage(COptionTab10::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT10); // titre
+    m_strCaption = LANG(LANG_IOPT10); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab11.cpp
+++ b/WinHTTrack/OptionTab11.cpp
@@ -46,7 +46,8 @@ COptionTab11::COptionTab11() : CPropertyPage(COptionTab11::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT11); // titre
+    m_strCaption = LANG(LANG_IOPT11); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -46,7 +46,8 @@ COptionTab2::COptionTab2() : CPropertyPage(COptionTab2::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT2); // titre
+    m_strCaption = LANG(LANG_IOPT2); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab3.cpp
+++ b/WinHTTrack/OptionTab3.cpp
@@ -46,7 +46,8 @@ COptionTab3::COptionTab3() : CPropertyPage(COptionTab3::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT3); // titre
+    m_strCaption = LANG(LANG_IOPT3); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab4.cpp
+++ b/WinHTTrack/OptionTab4.cpp
@@ -46,7 +46,8 @@ COptionTab4::COptionTab4() : CPropertyPage(COptionTab4::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT4); // titre
+    m_strCaption = LANG(LANG_IOPT4); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab5.cpp
+++ b/WinHTTrack/OptionTab5.cpp
@@ -46,7 +46,8 @@ COptionTab5::COptionTab5() : CPropertyPage(COptionTab5::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT5); // titre
+    m_strCaption = LANG(LANG_IOPT5); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -46,7 +46,8 @@ COptionTab6::COptionTab6() : CPropertyPage(COptionTab6::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT6); // titre
+    m_strCaption = LANG(LANG_IOPT6); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -54,7 +54,8 @@ COptionTab7::COptionTab7() : CPropertyPage(COptionTab7::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT7); // titre
+    m_strCaption = LANG(LANG_IOPT7); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -46,7 +46,8 @@ COptionTab8::COptionTab8() : CPropertyPage(COptionTab8::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT8); // titre
+    m_strCaption = LANG(LANG_IOPT8); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;

--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -46,7 +46,8 @@ COptionTab9::COptionTab9() : CPropertyPage(COptionTab9::IDD)
 {
   // Patcher titre
   if (LANG_T(-1)) {    // Patcher en français
-    m_psp.pszTitle=LANG(LANG_IOPT9); // titre
+    m_strCaption = LANG(LANG_IOPT9); // page-owned copy; the hash-table string is freed on a language change
+    m_psp.pszTitle = m_strCaption;
     m_psp.dwFlags|=PSP_USETITLE;
   }
   m_psp.dwFlags|=PSP_HASHELP;


### PR DESCRIPTION
Fixes the use-after-free behind the garbled option-tab titles in xroche/httrack#188 (French and the other non-English locales).

Each of the 11 option pages stored its tab title as a raw pointer into the language hash table (`m_psp.pszTitle = LANG(LANG_IOPTn)`), which is freed and reloaded when the language changes in the About box. The property sheet is built once at startup and lives for the session, so those pointers dangle from then on and are dereferenced at the next open. English is unaffected because the assignment is guarded on a non-English language. The fix copies each title into the page-owned `CPropertyPage::m_strCaption`, which survives the reload.

Can't build MFC on Linux, so CI is the check here. Ref xroche/httrack#188 (cross-repo, so I'll close it by hand after merge).