### PR TITLE
Fix crash when a mirror ends with the Options or View-transfers panel open

### DIFF
--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -994,6 +994,22 @@ BOOL Cinprogress::DestroyWindow()
 LRESULT Cinprogress::OnEndMirror(WPARAM /* wP*/, LPARAM /*lP*/) {
 	char catbuff[CATBUFF_SIZE];
 	char catbuff2[CATBUFF_SIZE];
+
+  // A panel opened mid-mirror (Options -> maintab, View transfers ->
+  // _Cinprogress_inst) runs a nested modal loop on this thread; the teardown
+  // below destroys the progress view under it and would leave DoModal() driving
+  // freed windows. Close it, then re-post so teardown runs after the loop unwinds.
+  if (maintab != NULL && maintab->m_hWnd != NULL) {
+    maintab->EndDialog(IDCANCEL);
+    PostMessage(wm_MirrorFinished);
+    return S_OK;
+  }
+  if (_Cinprogress_inst != NULL && _Cinprogress_inst->m_hWnd != NULL) {
+    _Cinprogress_inst->EndDialog(IDCANCEL);
+    PostMessage(wm_MirrorFinished);
+    return S_OK;
+  }
+
   //this_CSplitterFrame->SetNewView(0,1,RUNTIME_CLASS(Cinfoend));
 
   // Copie de trans.cpp

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -995,10 +995,9 @@ LRESULT Cinprogress::OnEndMirror(WPARAM /* wP*/, LPARAM /*lP*/) {
 	char catbuff[CATBUFF_SIZE];
 	char catbuff2[CATBUFF_SIZE];
 
-  // A panel opened mid-mirror (Options -> maintab, View transfers ->
-  // _Cinprogress_inst) runs a nested modal loop on this thread; the teardown
-  // below destroys the progress view under it and would leave DoModal() driving
-  // freed windows. Close it, then re-post so teardown runs after the loop unwinds.
+  // A panel open mid-mirror (Options, View transfers) runs a nested modal loop on
+  // this thread; tearing the view down now would free it under a live DoModal().
+  // Close it and re-post so teardown runs only after that loop has unwound.
   if (maintab != NULL && maintab->m_hWnd != NULL) {
     maintab->EndDialog(IDCANCEL);
     PostMessage(wm_MirrorFinished);


### PR DESCRIPTION
Leaving the Options panel open while a mirror finishes crashes WinHTTrack (`inprogress.cpp:648`); leaving View transfers open freezes it. Both panels run a nested modal loop on the GUI thread, and the worker thread's end-of-mirror `SendMessage(wm_MirrorFinished)` dispatches `OnEndMirror` inside that loop, which then tears down and destroys the progress view underneath the live `DoModal`. View log escapes because it runs its modal loop on a separate thread.

The fix closes the open panel and re-posts the end-of-mirror message so teardown happens after the loop unwinds.

Closes #57