### PR TITLE
Bump WinHTTrack.rc to 3.49-14 to match the engine

### DIFF
--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -771,8 +771,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,49,13,0
- PRODUCTVERSION 3,49,13,0
+ FILEVERSION 3,49,14,0
+ PRODUCTVERSION 3,49,14,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -790,13 +790,13 @@ BEGIN
             VALUE "Comments", "Website Copier [Offline Browser]"
             VALUE "CompanyName", "HTTrack"
             VALUE "FileDescription", "WinHTTrack Website Copier, Copy Websites to Your Computer"
-            VALUE "FileVersion", "3.49.13"
+            VALUE "FileVersion", "3.49.14"
             VALUE "InternalName", "WinHTTrack"
             VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors"
             VALUE "LegalTrademarks", "This software is covered by the GNU General Public License version 3"
             VALUE "OriginalFilename", "WinHTTrack.exe"
             VALUE "ProductName", "HTTrack Website Copier"
-            VALUE "ProductVersion", "3.49-13"
+            VALUE "ProductVersion", "3.49-14"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
The engine bumped `HTTRACK_VERSION` to 3.49-14, so CI's version-agreement gate fails on master until `WinHTTrack.exe` reports the same. Bumps `FileVersion` and `ProductVersion` (string and comma forms) in `WinHTTrack.rc`.