### PR TITLE
Make the mirror panel grow with the window

### DIFF
--- a/WinHTTrack/DialogContainer.cpp
+++ b/WinHTTrack/DialogContainer.cpp
@@ -146,27 +146,34 @@ void CDialogContainer::OnInitialUpdate()
   sizeTotal.cy = view_h;
   SetScrollSizes(MM_TEXT, sizeTotal);
   scrollsize_declared=TRUE;
-  //
   CRect curRect;
   GetClientRect(curRect);
-  //tab->MoveWindow(curRect);	
+  SizeSheets(curRect.Width(), curRect.Height());
 }
 
-void CDialogContainer::OnSize(UINT nType, int cx, int cy) 
+/* Fit both sheets to the pane. Both, not just the visible one: starting or ending a
+   mirror only toggles WS_VISIBLE between them, so a sheet left behind at the old size
+   would reappear wrong. */
+void CDialogContainer::SizeSheets(int cx, int cy)
+{
+  // Never below the natural size; under that the form view scrolls instead.
+  const int w = max(cx, view_w);
+  const int h = max(cy, view_h);
+  // CScrollView physically moves its children as it scrolls, so honour the offset.
+  const CPoint scroll = GetScrollPosition();
+  CWizTab* const sheets[2] = { tab, tab2 };
+  for(int i=0 ; i<2 ; i++) {
+    if (sheets[i] != NULL && sheets[i]->m_hWnd != NULL)
+      sheets[i]->SetWindowPos(NULL, -scroll.x, -scroll.y, w, h,
+                              SWP_NOZORDER|SWP_NOACTIVATE);
+  }
+}
+
+void CDialogContainer::OnSize(UINT nType, int cx, int cy)
 {
 	CFormView::OnSize(nType, cx, cy);
-	
-  if (scrollsize_declared) {
-    if (tab->m_hWnd) {
-      // now capture current size and resize child
-      CRect curRect;
-      GetClientRect(curRect);
-      //curRect.left=curRect.top=0;
-      //curRect.right=max(curRect.right,view_w);
-      //curRect.bottom=max(curRect.bottom,view_h);
-      //tab->MoveWindow(curRect);	
-    }
-  }
-	
+
+  if (scrollsize_declared)
+    SizeSheets(cx, cy);
 }
 

--- a/WinHTTrack/DialogContainer.h
+++ b/WinHTTrack/DialogContainer.h
@@ -53,6 +53,8 @@ protected:
   CWizTab* tab2;
   BOOL scrollsize_declared;
   int view_w,view_h;
+  /* Fit both sheets to a pane of cx by cy, never below the sheets' natural size. */
+  void SizeSheets(int cx, int cy);
 
 // Form Data
 public:

--- a/WinHTTrack/WinHTTrack.vcxproj
+++ b/WinHTTrack/WinHTTrack.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Wizard.cpp" />
     <ClCompile Include="Wizard2.cpp" />
     <ClCompile Include="WizLinks.cpp" />
+    <ClCompile Include="WndLayout.cpp" />
     <ClCompile Include="WizTab.cpp" />
     <ClCompile Include="XSHBrowseForFolder.cpp" />
 
@@ -241,6 +242,7 @@
     <ClInclude Include="wizard.h" />
     <ClInclude Include="wizard2.h" />
     <ClInclude Include="WizLinks.h" />
+    <ClInclude Include="WndLayout.h" />
     <ClInclude Include="WizTab.h" />
     <ClInclude Include="XSHBrowseForFolder.h" />
   </ItemGroup>

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -94,6 +94,8 @@ CWizTab::~CWizTab()
 }
 
 void CWizTab::DoInits() {
+  m_pageBase.SetRectEmpty();     // BuildLayout fills these once the sheet exists
+  m_pageBaseClient.cx=m_pageBaseClient.cy=0;
   m_tab0=NULL;
   m_tab1=NULL;
   m_tab2=NULL;
@@ -206,6 +208,7 @@ void CWizTab::EndInProgress()
 BEGIN_MESSAGE_MAP(CWizTab, CPropertySheet)
 //{{AFX_MSG_MAP(CWizTab)
 ON_WM_HELPINFO()
+ON_WM_SIZE()
 	//}}AFX_MSG_MAP
 ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
 ON_COMMAND(ID_HELP,OnHelpInfo2)
@@ -252,11 +255,92 @@ BOOL CWizTab::OnInitDialog()
   int r = CPropertySheet::OnInitDialog();
   //xx RemovePage(m_tabprogress);
   //xx RemovePage(m_tabend);
+  BuildLayout();   // children are still where the template put them
   SetWizardButtons(PSWIZB_BACK|PSWIZB_NEXT);
   SetWindowPos(&wndTop,0,0,0,0,SWP_NOZORDER|SWP_NOSIZE|SWP_NOOWNERZORDER);
   SetActivePage(0);
   WHTT_LOCATION("FirstInfo");
 
+  return r;
+}
+
+static BOOL IsSheetPage(CPropertySheet* sheet, HWND hwnd)
+{
+  for(int i=0 ; i<sheet->GetPageCount() ; i++) {
+    const CPropertyPage* const page = sheet->GetPage(i);
+    if (page != NULL && page->m_hWnd == hwnd)
+      return TRUE;
+  }
+  return FALSE;
+}
+
+void CWizTab::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_pageBase.SetRectEmpty();
+
+  CRect client;
+  GetClientRect(client);
+  m_pageBaseClient = client.Size();
+
+  // Wizard mode hides the tab control but still gives it the page area, so it serves
+  // as the reference before any page has a window.
+  CWnd* ref = GetActivePage();
+  if (ref == NULL || ref->m_hWnd == NULL)
+    ref = GetTabControl();
+  if (ref != NULL && ref->m_hWnd != NULL) {
+    ref->GetWindowRect(m_pageBase);
+    ScreenToClient(m_pageBase);
+  }
+
+  for(CWnd* child = GetWindow(GW_CHILD) ; child != NULL ; child = child->GetWindow(GW_HWNDNEXT)) {
+    if (IsSheetPage(this, child->m_hWnd))
+      continue;                      // LayoutActivePage owns these
+    switch(child->GetDlgCtrlID()) {
+      case ID_WIZBACK: case ID_WIZNEXT: case ID_WIZFINISH:
+      case IDOK: case IDCANCEL: case IDHELP:
+        m_layout.Add(child, 100, 0, 100, 0);   // keep the strip in the bottom right
+        break;
+      default: {
+        TCHAR cls[16];
+        // The rule above the buttons is the only other static the sheet owns.
+        if (::GetClassName(child->m_hWnd, cls, (int)_countof(cls)) > 0
+            && _tcsicmp(cls, _T("Static")) == 0)
+          m_layout.Add(child, 0, 100, 100, 0);
+        break;
+      }
+    }
+  }
+}
+
+void CWizTab::LayoutActivePage()
+{
+  CPropertyPage* const page = GetActivePage();
+  if (page == NULL || page->m_hWnd == NULL
+      || m_pageBase.IsRectEmpty() || m_pageBaseClient.cx == 0)
+    return;
+  CRect client;
+  GetClientRect(client);
+  const int dx = max(client.Width() - m_pageBaseClient.cx, 0);
+  const int dy = max(client.Height() - m_pageBaseClient.cy, 0);
+  page->SetWindowPos(NULL, m_pageBase.left, m_pageBase.top,
+                     m_pageBase.Width() + dx, m_pageBase.Height() + dy,
+                     SWP_NOZORDER|SWP_NOACTIVATE);
+}
+
+void CWizTab::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertySheet::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+  LayoutActivePage();
+}
+
+LRESULT CWizTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
+{
+  const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
+  // A page comctl32 has just shown comes back at its creation rect.
+  if (message == PSM_SETCURSEL || message == PSM_SETCURSELID)
+    LayoutActivePage();
   return r;
 }
 

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -36,6 +36,7 @@ Please visit our Website: http://www.httrack.com
 #include "FirstInfo.h"
 #include "inprogress.h"
 #include "infoend.h"
+#include "WndLayout.h"
 
 class CWizTab : public CPropertySheet
 {
@@ -77,6 +78,9 @@ public:
 public:
   virtual ~CWizTab();
   virtual BOOL OnInitDialog();
+  /* Give the page comctl32 has just shown the sheet's current size. comctl32 restores
+     the rect the page had at creation, so this has to run after every page change. */
+  void LayoutActivePage();
   void ApplyAndSave();
   void Apply();
   void LoadPrefs();
@@ -90,9 +94,15 @@ protected:
   void ClearInits();
   
   const char* GetTip(int id);
+  void BuildLayout();
+  CWndLayout m_layout;   /* buttons and the separator; the page is sized separately */
+  CRect m_pageBase;      /* page rect, and the client size it was measured against */
+  CSize m_pageBaseClient;
   //{{AFX_MSG(CWizTab)
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
+  virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	afx_msg void OnHelpInfo2();
   //afx_msg void OnOK( );
   //afx_msg void OnCancel( );

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -78,7 +78,7 @@ void CWndLayout::Add(CWnd* ctrl, int moveX, int sizeX, int moveY, int sizeY)
   m_items.Add(item);
 }
 
-void CWndLayout::Add(CWnd* parent, UINT id, int moveX, int sizeX, int moveY, int sizeY)
+void CWndLayout::AddId(CWnd* parent, UINT id, int moveX, int sizeX, int moveY, int sizeY)
 {
   if (parent == NULL || id == 0)
     return;

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -1,0 +1,120 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: WinHTTrack subroutines:                                */
+/*       Percentage anchoring for fixed dialog templates        */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#include "stdafx.h"
+#include "WndLayout.h"
+
+#ifdef _DEBUG
+#define new DEBUG_NEW
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#endif
+
+CWndLayout::CWndLayout()
+{
+  m_parent = NULL;
+  m_base.cx = m_base.cy = 0;
+}
+
+void CWndLayout::Reset(CWnd* parent)
+{
+  m_items.RemoveAll();
+  m_parent = NULL;
+  m_base.cx = m_base.cy = 0;
+  if (parent != NULL && parent->m_hWnd != NULL) {
+    CRect client;
+    parent->GetClientRect(client);
+    m_parent = parent->m_hWnd;
+    m_base = client.Size();
+  }
+}
+
+void CWndLayout::Add(CWnd* ctrl, int moveX, int sizeX, int moveY, int sizeY)
+{
+  if (ctrl == NULL || ctrl->m_hWnd == NULL)
+    return;
+  CWnd* const parent = ctrl->GetParent();
+  if (parent == NULL)
+    return;
+
+  ITEM item;
+  item.hwnd = ctrl->m_hWnd;
+  ctrl->GetWindowRect(item.base);
+  parent->ScreenToClient(item.base);
+  item.moveX = moveX;
+  item.sizeX = sizeX;
+  item.moveY = moveY;
+  item.sizeY = sizeY;
+  m_items.Add(item);
+}
+
+void CWndLayout::Add(CWnd* parent, UINT id, int moveX, int sizeX, int moveY, int sizeY)
+{
+  if (parent == NULL || id == 0)
+    return;
+  Add(parent->GetDlgItem(id), moveX, sizeX, moveY, sizeY);
+}
+
+void CWndLayout::Apply(int cx, int cy) const
+{
+  const INT_PTR count = m_items.GetSize();
+  if (count == 0 || m_base.cx == 0 || m_base.cy == 0)
+    return;
+
+  // Never shrink below the template: the form view scrolls instead, so the controls
+  // stay whole rather than folding into each other.
+  const int dx = max(cx - m_base.cx, 0);
+  const int dy = max(cy - m_base.cy, 0);
+
+  HDWP defer = ::BeginDeferWindowPos((int) count);
+  for(INT_PTR i=0 ; i<count ; i++) {
+    const ITEM& item = m_items[i];
+    if (!::IsWindow(item.hwnd))
+      continue;
+    const int x = item.base.left + dx * item.moveX / 100;
+    const int y = item.base.top + dy * item.moveY / 100;
+    const int w = item.base.Width() + dx * item.sizeX / 100;
+    const int h = item.base.Height() + dy * item.sizeY / 100;
+    const UINT flags = SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOCOPYBITS;
+    if (defer != NULL)
+      defer = ::DeferWindowPos(defer, item.hwnd, NULL, x, y, w, h, flags);
+    else
+      ::SetWindowPos(item.hwnd, NULL, x, y, w, h, flags);
+  }
+  if (defer != NULL)
+    ::EndDeferWindowPos(defer);
+
+  // Statics and group boxes leave their old pixels behind when they move.
+  if (::IsWindow(m_parent))
+    ::InvalidateRect(m_parent, NULL, TRUE);
+}

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -1,0 +1,79 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: WinHTTrack subroutines:                                */
+/*       Percentage anchoring for fixed dialog templates        */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#ifndef WINHTTRACK_WNDLAYOUT_H
+#define WINHTTRACK_WNDLAYOUT_H
+
+#include <afxtempl.h>   /* CArray; StdAfx.h brings in the rest of MFC */
+
+/* Lets a dialog laid out from a fixed template follow its parent's size.
+   Each control keeps the rect the template gave it and then takes a percentage of
+   however much the window has grown: "move" shifts its origin, "size" stretches it.
+   Two controls sharing the growth 50/50 use move 0/size 50 and move 50/size 50.
+
+   Record the controls once the dialog exists (OnInitDialog), then call Apply from
+   OnSize. Positions are always recomputed from the recorded template rects, so
+   repeated resizes cannot accumulate rounding drift. */
+class CWndLayout
+{
+public:
+  CWndLayout();
+
+  /* Forget every control and take the parent's current client size as the baseline.
+     Call before the first Add. */
+  void Reset(CWnd* parent);
+
+  /* Anchor one control, by window or by dialog ID. Percentages are of the growth in
+     that axis; 0 pins the control to the template. A control that is missing, or a
+     zero ID, is ignored so a caller can loop over an optional row. */
+  void Add(CWnd* ctrl, int moveX, int sizeX, int moveY = 0, int sizeY = 0);
+  void Add(CWnd* parent, UINT id, int moveX, int sizeX, int moveY = 0, int sizeY = 0);
+
+  /* Reposition everything for a client area of cx by cy. Cheap enough for WM_SIZE:
+     one DeferWindowPos pass, no redraw of untouched controls. */
+  void Apply(int cx, int cy) const;
+
+  BOOL IsEmpty() const { return m_items.GetSize() == 0; }
+
+private:
+  struct ITEM {
+    HWND hwnd;
+    CRect base;                  /* template rect, in parent client coordinates */
+    int moveX, sizeX, moveY, sizeY;
+  };
+  CArray<ITEM,ITEM&> m_items;
+  HWND m_parent;
+  CSize m_base;                  /* client size the rects above were recorded at */
+};
+
+#endif

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -53,11 +53,14 @@ public:
      Call before the first Add. */
   void Reset(CWnd* parent);
 
-  /* Anchor one control, by window or by dialog ID. Percentages are of the growth in
-     that axis; 0 pins the control to the template. A control that is missing, or a
-     zero ID, is ignored so a caller can loop over an optional row. */
+  /* Anchor one control. Percentages are of the growth in that axis; 0 pins the
+     control to the template. A control that is missing, or a zero ID, is ignored so
+     a caller can loop over an optional row.
+     AddId is deliberately not an overload of Add: the IDC_* macros are plain ints, so
+     Add(this, IDC_x, 0, 100) would bind to Add(CWnd*, int, int, int) and silently
+     anchor the dialog itself with a four-digit percentage. */
   void Add(CWnd* ctrl, int moveX, int sizeX, int moveY = 0, int sizeY = 0);
-  void Add(CWnd* parent, UINT id, int moveX, int sizeX, int moveY = 0, int sizeY = 0);
+  void AddId(CWnd* parent, UINT id, int moveX, int sizeX, int moveY = 0, int sizeY = 0);
 
   /* Reposition everything for a client area of cx by cy. Cheap enough for WM_SIZE:
      one DeferWindowPos pass, no redraw of untouched controls. */

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -259,6 +259,7 @@ BEGIN_MESSAGE_MAP(Cinprogress, CPropertyPage)
 	ON_BN_CLICKED(IDC_st12, Onst12)
 	ON_BN_CLICKED(IDC_st13, Onst13)
 	ON_WM_TIMER()
+	ON_WM_SIZE()
 	ON_BN_CLICKED(IDC_inphide, Oninphide)
 	//}}AFX_MSG_MAP
   ON_MESSAGE( wm_CEasyDropTargetCallback, DragDropText)
@@ -500,6 +501,29 @@ BOOL Cinprogress::OnInitDialog()
   element[3][12]=&m_sk12;
   element[3][13]=&m_sk13;
 
+  /* Where the panel's extra width goes. The two text columns, which are the ones that
+     clip, split it evenly; the bar and the SKIP button ride along at the right edge.
+     Height is deliberately left alone: the row count is fixed at NStatsBuffer. */
+  m_layout.Reset(this);
+  m_layout.Add(this, IDC_inforun, 0, 100);
+  m_layout.Add(this, IDC_STATIC_informations, 0, 100);
+  m_layout.Add(this, IDC_STATIC_actions, 0, 100);
+  {
+    /* Second column of the statistics block, so it does not strand at the left. */
+    static const UINT stats[] = {
+      IDC_STATIC_scanned, IDC_i2, IDC_STATIC_written, IDC_i6,
+      IDC_STATIC_updated, IDC_i7, IDC_STATIC_errors,  IDC_i5
+    };
+    for(int i=0 ; i<(int)_countof(stats) ; i++)
+      m_layout.Add(this, stats[i], 50, 0);
+  }
+  for(int row=0 ; row<NStatsBuffer ; row++) {
+    m_layout.Add(element[1][row],   0, 50);   /* URL      */
+    m_layout.Add(element[4][row],  50, 50);   /* filename */
+    m_layout.Add(element[2][row], 100,  0);   /* bar      */
+    m_layout.Add(element[3][row], 100,  0);   /* SKIP     */
+  }
+
   /* Init checkbox */
   CMenu* m;
   if (m = AfxGetApp()->GetMainWnd()->GetMenu()) {
@@ -552,6 +576,12 @@ BOOL Cinprogress::OnInitDialog()
 
 	return TRUE;  // return TRUE unless you set the focus to a control
 	              // EXCEPTION: OCX Property Pages should return FALSE
+}
+
+void Cinprogress::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
 }
 
 void Cinprogress::StartTimer() {

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -505,9 +505,9 @@ BOOL Cinprogress::OnInitDialog()
      clip, split it evenly; the bar and the SKIP button ride along at the right edge.
      Height is deliberately left alone: the row count is fixed at NStatsBuffer. */
   m_layout.Reset(this);
-  m_layout.Add(this, IDC_inforun, 0, 100);
-  m_layout.Add(this, IDC_STATIC_informations, 0, 100);
-  m_layout.Add(this, IDC_STATIC_actions, 0, 100);
+  m_layout.AddId(this, IDC_inforun, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_informations, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_actions, 0, 100);
   {
     /* Second column of the statistics block, so it does not strand at the left. */
     static const UINT stats[] = {
@@ -515,7 +515,7 @@ BOOL Cinprogress::OnInitDialog()
       IDC_STATIC_updated, IDC_i7, IDC_STATIC_errors,  IDC_i5
     };
     for(int i=0 ; i<(int)_countof(stats) ; i++)
-      m_layout.Add(this, stats[i], 50, 0);
+      m_layout.AddId(this, stats[i], 50, 0);
   }
   for(int row=0 ; row<NStatsBuffer ; row++) {
     m_layout.Add(element[1][row],   0, 50);   /* URL      */

--- a/WinHTTrack/inprogress.h
+++ b/WinHTTrack/inprogress.h
@@ -36,6 +36,7 @@ Please visit our Website: http://www.httrack.com
 #include "Shell.h"
 #include "iplog.h"
 #include "EasyDropTarget.h"
+#include "WndLayout.h"
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -55,6 +56,7 @@ public:
   void StopTimer();
 
   CWnd* element[5][NStatsBuffer];    // ici 10=NStatsBuffer -- les éléments (status nom slide bouton)
+  CWndLayout m_layout;               // anchors the row grid to the panel width
 	//Cinprogress(CWnd* pParent = NULL);   // standard constructor
   CWinThread * BackAffLog;
   Ciplog form;
@@ -207,6 +209,7 @@ public:
 	afx_msg void Onst12();
 	afx_msg void Onst13();
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg void Oninphide();
 	//}}AFX_MSG
   afx_msg LRESULT DragDropText(WPARAM wParam,LPARAM lParam);


### PR DESCRIPTION
Nothing in the chain passed a size down. The splitter resized its pane and `CDialogContainer::OnSize` threw the number away, so both property sheets kept the size comctl32 gave them at creation and the panel only gained grey space. The frame starts maximized, so that was the first thing a user saw.

The container now fits both sheets to the pane, floored at their natural size so the form view still scrolls when the pane is smaller. Both sheets rather than just the visible one: starting a mirror only toggles `WS_VISIBLE` between them, so the one left behind would come back at the old size. Wizard-mode sheets have no tab control to stretch, so `CWizTab` lays out its own children, keeping the button strip at the bottom and letting the active page fill the rest. comctl32 hands a page its creation rect every time it shows it, so that has to be reapplied on every page change and not only on resize.

`CWndLayout` is the new piece: a control keeps its template rect and takes a percentage of the growth, always recomputed from the template so repeated resizes cannot drift. In the transfer rows the URL and filename columns split the new width, since those are the two that clip, while the progress bar and SKIP anchor right.

Height is left alone deliberately. `NStatsBuffer` fixes the panel at fourteen rows, so there is nothing to fill vertical space with. Only the transfer page is anchored so far; the five wizard pages grow without moving their contents, which is no worse than today.

Sits on top of #60. Closes xroche/httrack#114 (cross-repo, so it will need closing by hand). CI cannot see layout, so this wants a look on the VM before it lands.