### PR TITLE
Size the transfer-row URL buffers for the URLs they are given

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1070,7 +1070,9 @@ int __cdecl httrackengine_loop(t_hts_callbackarg *carg, httrackp *opt,
                                int lien_n,int lien_tot,
                                int stat_time,
                                hts_stat_struct* stats) {    // appelé à chaque boucle de HTTrack
-  static char s[HTS_URLMAXSIZE*2]="";  // utilisé plus loin
+  // Takes url_adr + '/' + url_fil, each HTS_URLMAXSIZE*2 in lien_back. The buff()
+  // macros abort instead of truncating, so the sum has to fit.
+  static char s[HTS_URLMAXSIZE*4]="";  // utilisé plus loin
   int stat_written=-1;
   int stat_updated=-1;
   int stat_errors=-1;

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -80,7 +80,8 @@ Please visit our Website: http://www.httrack.com
 #define dynclear(dest) { if (dest) { free(dest); dest=NULL; }}
 
 typedef struct t_StatsBuffer {
-  char nom[HTS_URLMAXSIZE*2];
+  /* Holds url_adr + '/' + url_fil, so it has to be able to take both whole. */
+  char nom[HTS_URLMAXSIZE*4];
   char fichier[HTS_URLMAXSIZE];
   char etat[256];
   char url_sav[HTS_URLMAXSIZE*2];    // pour cancel


### PR DESCRIPTION
`httrackengine_loop` composes "host + `/` + path" into a 2048-byte buffer out of two `lien_back` fields that are 2048 bytes each. The `buff()` macros abort rather than truncate on overflow, so a long enough URL takes the whole GUI down in the middle of a mirror instead of just showing a clipped row. Same shape as engine #669, where an oversized `-%F` footer aborted the crawl.

The composition buffer now has room for both fields plus the separator, and `t_StatsBuffer.nom` is widened to match because the composed string is copied into it whole.

Found while working on xroche/httrack#114; unrelated to that fix, so it is split out. It does matter for the ordering though: #60 stops truncating the composed string to 32 characters before it reaches `nom`, so once #60 is in, `nom` needs the width this PR gives it.