### PR TITLE
Use the engine's UTF-8 to system-codepage converter

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -156,6 +156,7 @@ httrackp *global_opt = NULL;
 extern "C" {
   HTSEXT_API void qsec2str(char *st,TStamp t);
   HTSEXT_API char *hts_convertStringSystemToUTF8(const char *s, size_t size);
+  HTSEXT_API char *hts_convertStringUTF8ToSystem(const char *s, size_t size);
 }
 
 // construction index général
@@ -1674,6 +1675,18 @@ char *strdupt_utf8(const char *const s) {
   // argv[] entry is always non-NULL and freet()-able (same libc heap under /MD).
   char *const utf8 = hts_convertStringSystemToUTF8(s, strlen(s));
   return utf8 != NULL ? utf8 : strdupt(s);
+}
+
+// The other direction, for the ANSI-only Win32 calls left in this MBCS build.
+// Contract in Shell.h.
+void CopyTextUTF8ToCP(LPSTR dest, int destSize, LPCSTR lpString) {
+  if (destSize <= 0)
+    return;
+  // freet() nulls its argument, so not const.
+  char *cp = hts_convertStringUTF8ToSystem(lpString, strlen(lpString));
+  // On failure the raw bytes beat showing nothing at all.
+  lstrcpynA(dest, cp != NULL ? cp : lpString, destSize);
+  freet(cp);
 }
 
 bool ShellOpen(LPCSTR file, int nShowCmd) {

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -147,6 +147,11 @@ extern const char* WhttLocation;
 // Caller frees with freet(); returns the bytes unchanged if conversion fails, never NULL.
 char *strdupt_utf8(const char *const s);
 
+// The reverse: copy a UTF-8 string into dest as the ANSI codepage, always
+// NUL-terminated. For the ANSI-only APIs left in this MBCS build, such as
+// TTN_NEEDTEXTA tooltip text. Falls back to the raw bytes if conversion fails.
+void CopyTextUTF8ToCP(LPSTR dest, int destSize, LPCSTR lpString);
+
 // Drop a trailing '/' or '\\', reporting whether there was one. Empty-string safe.
 inline bool StripTrailingSlash(char* s) {
   const size_t len = (s != NULL) ? strlen(s) : 0;

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -624,17 +624,6 @@ static _bstr_t ConvertCodepage(LPCSTR str, UINT codePage)
   return returnValue;
 }
 
-void CopyTextUTF8ToCP(LPSTR dest, int destSize, LPCSTR lpString) {
-  if (destSize <= 0)
-    return;
-  _bstr_t s = ConvertCodepage(lpString, CP_UTF8);
-  if (s.length() != 0
-      && WideCharToMultiByte(CP_ACP, 0, s, -1, dest, destSize, NULL, NULL) > 0)
-    return;
-  // Not valid UTF-8, or longer than dest: hand back the raw bytes rather than nothing.
-  lstrcpynA(dest, lpString, destSize);
-}
-
 BOOL SetDlgItemTextCP(HWND hDlg, int nIDDlgItem, LPCSTR lpString) {
   if (NewLangCP != CP_THREAD_ACP)
     return SetDlgItemTextW(hDlg, nIDDlgItem, ConvertCodepage(lpString, NewLangCP));

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -55,9 +55,5 @@ BOOL SetWindowTextUTF8(CWnd* wnd, LPCSTR lpString);
 BOOL ModifyMenuCP(HMENU hMnu, UINT uPosition, UINT uFlags, UINT uIDNewItem, LPCSTR lpNewItem);
 BOOL ModifyMenuCP(CMenu* menu, UINT uPosition, UINT uFlags, UINT uIDNewItem, LPCSTR lpNewItem);
 
-/* UTF-8 -> the ANSI codepage, into dest (always NUL-terminated). For the ANSI-only
-   APIs left in this MBCS build, such as TTN_NEEDTEXTA tooltip text. */
-void CopyTextUTF8ToCP(LPSTR dest, int destSize, LPCSTR lpString);
-
 #endif
 


### PR DESCRIPTION
The GUI was doing the `MultiByteToWideChar`/`WideCharToMultiByte` dance itself, because the engine exported nothing going back from UTF-8. xroche/httrack#698 adds `hts_convertStringUTF8ToSystem`, so delegate to it the way `strdupt_utf8` already delegates in the other direction.

The helper also moves next to `strdupt_utf8`. Both are engine-boundary conversions, and having one of them sitting among the language-file routines was the reason the duplicate got written in the first place.

Needs the engine at xroche/httrack#698 or newer. CI builds engine master unpinned, so it picks that up by itself.