### PR TITLE
Stop indexing an empty page array, and redo a dropped layout pass

### DIFF
--- a/WinHTTrack/DialogContainer.cpp
+++ b/WinHTTrack/DialogContainer.cpp
@@ -146,6 +146,12 @@ void CDialogContainer::OnInitialUpdate()
   sizeTotal.cy = view_h;
   SetScrollSizes(MM_TEXT, sizeTotal);
   scrollsize_declared=TRUE;
+  /* Only now are the sheets their final WS_CHILD selves, so this is the first moment
+     their template geometry can be recorded truthfully. */
+  if (tab != NULL && tab->m_hWnd != NULL)
+    tab->BuildLayout();
+  if (tab2 != NULL && tab2->m_hWnd != NULL)
+    tab2->BuildLayout();
   CRect curRect;
   GetClientRect(curRect);
   SizeSheets(curRect.Width(), curRect.Height());

--- a/WinHTTrack/DialogContainer.cpp
+++ b/WinHTTrack/DialogContainer.cpp
@@ -146,8 +146,7 @@ void CDialogContainer::OnInitialUpdate()
   sizeTotal.cy = view_h;
   SetScrollSizes(MM_TEXT, sizeTotal);
   scrollsize_declared=TRUE;
-  /* Only now are the sheets their final WS_CHILD selves, so this is the first moment
-     their template geometry can be recorded truthfully. */
+  /* Both sheets are fully built only now; contract in WizTab.h. */
   if (tab != NULL && tab->m_hWnd != NULL)
     tab->BuildLayout();
   if (tab2 != NULL && tab2->m_hWnd != NULL)

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -317,8 +317,8 @@ void CWizTab::LayoutActivePage()
 {
   if (m_pageBase.IsRectEmpty() || m_pageBaseClient.cx == 0)
     return;
-  /* Not GetActivePage(): with the page array emptied, as FinalInProgress does between
-     RemovePage and AddPage, it indexes it at -1 and hands back a wild pointer. */
+  /* Not GetActivePage(): FinalInProgress empties the page array between RemovePage and
+     AddPage, and it then indexes -1 and hands back a wild pointer. */
   const int active = GetActiveIndex();
   if (active < 0 || active >= GetPageCount())
     return;

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -255,7 +255,6 @@ BOOL CWizTab::OnInitDialog()
   int r = CPropertySheet::OnInitDialog();
   //xx RemovePage(m_tabprogress);
   //xx RemovePage(m_tabend);
-  BuildLayout();   // children are still where the template put them
   SetWizardButtons(PSWIZB_BACK|PSWIZB_NEXT);
   SetWindowPos(&wndTop,0,0,0,0,SWP_NOZORDER|SWP_NOSIZE|SWP_NOOWNERZORDER);
   SetActivePage(0);
@@ -285,7 +284,8 @@ void CWizTab::BuildLayout()
 
   // Wizard mode hides the tab control but still gives it the page area, so it serves
   // as the reference before any page has a window.
-  CWnd* ref = GetActivePage();
+  const int active = GetActiveIndex();
+  CWnd* ref = (active >= 0 && active < GetPageCount()) ? (CWnd*) GetPage(active) : NULL;
   if (ref == NULL || ref->m_hWnd == NULL)
     ref = GetTabControl();
   if (ref != NULL && ref->m_hWnd != NULL) {
@@ -315,9 +315,15 @@ void CWizTab::BuildLayout()
 
 void CWizTab::LayoutActivePage()
 {
-  CPropertyPage* const page = GetActivePage();
-  if (page == NULL || page->m_hWnd == NULL
-      || m_pageBase.IsRectEmpty() || m_pageBaseClient.cx == 0)
+  if (m_pageBase.IsRectEmpty() || m_pageBaseClient.cx == 0)
+    return;
+  /* Not GetActivePage(): with the page array emptied, as FinalInProgress does between
+     RemovePage and AddPage, it indexes it at -1 and hands back a wild pointer. */
+  const int active = GetActiveIndex();
+  if (active < 0 || active >= GetPageCount())
+    return;
+  CPropertyPage* const page = GetPage(active);
+  if (page == NULL || page->m_hWnd == NULL)
     return;
   CRect client;
   GetClientRect(client);

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -81,9 +81,9 @@ public:
   /* Give the page comctl32 has just shown the sheet's current size. comctl32 restores
      the rect the page had at creation, so this has to run after every page change. */
   void LayoutActivePage();
-  /* Record where the template put everything. Must run once the sheet is its final
-     WS_CHILD self: MFC restyles it from a popup after WM_INITDIALOG, which moves the
-     client origin and would bake a caption's worth of offset into every rect. */
+  /* Records template geometry. Run it once the sheet is built and its active page has a
+     window, so the page's own rect is measured instead of the hidden tab control
+     standing in for it. */
   void BuildLayout();
   void ApplyAndSave();
   void Apply();

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -81,6 +81,10 @@ public:
   /* Give the page comctl32 has just shown the sheet's current size. comctl32 restores
      the rect the page had at creation, so this has to run after every page change. */
   void LayoutActivePage();
+  /* Record where the template put everything. Must run once the sheet is its final
+     WS_CHILD self: MFC restyles it from a popup after WM_INITDIALOG, which moves the
+     client origin and would bake a caption's worth of offset into every rect. */
+  void BuildLayout();
   void ApplyAndSave();
   void Apply();
   void LoadPrefs();
@@ -94,7 +98,6 @@ protected:
   void ClearInits();
   
   const char* GetTip(int id);
-  void BuildLayout();
   CWndLayout m_layout;   /* buttons and the separator; the page is sized separately */
   CRect m_pageBase;      /* page rect, and the client size it was measured against */
   CSize m_pageBaseClient;

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -85,6 +85,14 @@ void CWndLayout::AddId(CWnd* parent, UINT id, int moveX, int sizeX, int moveY, i
   Add(parent->GetDlgItem(id), moveX, sizeX, moveY, sizeY);
 }
 
+CRect CWndLayout::Target(const ITEM& item, int dx, int dy)
+{
+  const CPoint origin(item.base.left + dx * item.moveX / 100,
+                      item.base.top  + dy * item.moveY / 100);
+  return CRect(origin, CSize(item.base.Width()  + dx * item.sizeX / 100,
+                             item.base.Height() + dy * item.sizeY / 100));
+}
+
 void CWndLayout::Apply(int cx, int cy) const
 {
   const INT_PTR count = m_items.GetSize();
@@ -96,23 +104,30 @@ void CWndLayout::Apply(int cx, int cy) const
   const int dx = max(cx - m_base.cx, 0);
   const int dy = max(cy - m_base.cy, 0);
 
+  static const UINT flags = SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOCOPYBITS;
+
   HDWP defer = ::BeginDeferWindowPos((int) count);
-  for(INT_PTR i=0 ; i<count ; i++) {
+  for(INT_PTR i=0 ; defer != NULL && i<count ; i++) {
     const ITEM& item = m_items[i];
     if (!::IsWindow(item.hwnd))
       continue;
-    const int x = item.base.left + dx * item.moveX / 100;
-    const int y = item.base.top + dy * item.moveY / 100;
-    const int w = item.base.Width() + dx * item.sizeX / 100;
-    const int h = item.base.Height() + dy * item.sizeY / 100;
-    const UINT flags = SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOCOPYBITS;
-    if (defer != NULL)
-      defer = ::DeferWindowPos(defer, item.hwnd, NULL, x, y, w, h, flags);
-    else
-      ::SetWindowPos(item.hwnd, NULL, x, y, w, h, flags);
+    const CRect to = Target(item, dx, dy);
+    // A failure destroys the HDWP and drops everything already deferred, so the pass
+    // has to be redone the plain way rather than continued.
+    defer = ::DeferWindowPos(defer, item.hwnd, NULL,
+                             to.left, to.top, to.Width(), to.Height(), flags);
   }
   if (defer != NULL)
     ::EndDeferWindowPos(defer);
+  else {
+    for(INT_PTR i=0 ; i<count ; i++) {
+      const ITEM& item = m_items[i];
+      if (::IsWindow(item.hwnd)) {
+        const CRect to = Target(item, dx, dy);
+        ::SetWindowPos(item.hwnd, NULL, to.left, to.top, to.Width(), to.Height(), flags);
+      }
+    }
+  }
 
   // Statics and group boxes leave their old pixels behind when they move.
   if (::IsWindow(m_parent))

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -74,6 +74,9 @@ private:
     CRect base;                  /* template rect, in parent client coordinates */
     int moveX, sizeX, moveY, sizeY;
   };
+  /* Where one item lands once the window has grown by (dx,dy). */
+  static CRect Target(const ITEM& item, int dx, int dy);
+
   CArray<ITEM,ITEM&> m_items;
   HWND m_parent;
   CSize m_base;                  /* client size the rects above were recorded at */


### PR DESCRIPTION
Two real defects from #61, plus a call-site move.

`GetActivePage()` is `m_pages[GetActiveIndex()]` with no bounds check outside a debug ASSERT, and `GetActiveIndex()` returns -1 when nothing is selected. `FinalInProgress` and `EndInProgress` both empty the array before refilling it, and `RemovePage` relayouts synchronously, so a `WM_SIZE` arriving mid-rebuild read `m_pages[-1]` and dereferenced whatever came back. Both call sites now go through `GetActiveIndex` and `GetPageCount`.

`DeferWindowPos` destroys the HDWP on failure, dropping every position already queued, and the loop then carried on with `SetWindowPos` for the remainder so the earlier controls silently kept their old rects. It now redoes the whole pass.

`BuildLayout` also moves from `CWizTab::OnInitDialog` to `CDialogContainer::OnInitialUpdate`. My first rationale for this was wrong: there is no popup-to-WS_CHILD restyle after WM_INITDIALOG, MFC injects the style into the template at PSCB_PRECREATE, and the recorded rects are identical either way. What the move actually buys is that the active page has a window at the later point, so `m_pageBase` is the page rect rather than the hidden tab control standing in for it.

Nothing here is visible in normal use, and VM testing confirmed no change to the startup window.