### PR TITLE
Bound the language-name copy in LANG_LOAD

### DIFF
--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -342,7 +342,7 @@ BOOL CWinHTTrackApp::InitInstance()
         char name[1024];
         QLANG_T(i);
         strcpybuff(name, "LANGUAGE_NAME");
-        LANG_LOAD(name);
+        LANG_LOAD(name,sizeof(name));
         if (name[0] == '\0')
           break;
       }

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -114,13 +114,13 @@ BOOL Cabout::OnInitDialog()
     int curr_lng=LANG_T(-1);
     QLANG_T(0);
     strcpybuff(lang_str,"LANGUAGE_NAME");
-    LANG_LOAD(lang_str);    // 0 english 1 français..
+    LANG_LOAD(lang_str,sizeof(lang_str));    // 0 english 1 français..
     while(strlen(lang_str)) {
       m_ctl_lang.AddString(lang_str);
       i++;
       QLANG_T(i);
       strcpybuff(lang_str,"LANGUAGE_NAME");
-      LANG_LOAD(lang_str);    // 0 english 1 français..
+      LANG_LOAD(lang_str,sizeof(lang_str));    // 0 english 1 français..
     }
     QLANG_T(curr_lng);
     //LANG_T(min(old_lang,i-1));
@@ -186,7 +186,7 @@ void Cabout::OnSelchangelang()
 
       QLANG_T(i);
       strcpybuff(lang_str,"LANGUAGE_NAME");
-      LANG_LOAD(lang_str);    // 0 english 1 français..
+      LANG_LOAD(lang_str,sizeof(lang_str));    // 0 english 1 français..
 
       //LANG_T(i);    // 0 english 1 français..
       if (strcmp(st,lang_str)==0) {

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -226,7 +226,7 @@ WinLangid WINDOWS_LANGID[] = {
   { 0, NULL }
 };
 
-void LANG_LOAD(char* limit_to) {
+void LANG_LOAD(char* limit_to, size_t limit_size) {
   CWaitCursor wait;
   //
   extern int NewLangStrSz;
@@ -325,9 +325,12 @@ void LANG_LOAD(char* limit_to) {
     hashname=LANGINTKEY(name);
   }
 
-  /* Empty name is the caller's enumeration terminator: never substitute a placeholder. */
+  /* Empty name is the caller's enumeration terminator: never substitute a placeholder.
+     lstrcpynA, not strcpybuff: limit_to is a pointer, so the buff() macros lose the
+     bound and degrade to a plain strcpy of whatever lang.def holds. */
   if (limit_to) {
-    strcpybuff(limit_to,hashname);
+    if (limit_size > 0)
+      lstrcpynA(limit_to,hashname,(int) limit_size);
     return;
   }
 
@@ -536,7 +539,7 @@ void LANG_INIT() {
 int LANG_T(int l) {
   if (l>=0) {
     QLANG_T(l);
-    LANG_LOAD(NULL);
+    LANG_LOAD(NULL,0);
     /* Persist only what loaded: LANG_LOAD() falls back to 0 on a bad index, and that is what must be saved. */
     CWinApp* pApp = AfxGetApp();
     if (pApp)

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -326,8 +326,8 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
   }
 
   /* Empty name is the caller's enumeration terminator: never substitute a placeholder.
-     lstrcpynA, not strcpybuff: limit_to is a pointer, so the buff() macros lose the
-     bound and degrade to a plain strcpy of whatever lang.def holds. */
+     lstrcpynA, not strcpybuff: limit_to is a pointer, so buff() cannot size it and falls
+     back to a plain strcpy. */
   if (limit_to) {
     if (limit_size > 0)
       lstrcpynA(limit_to,hashname,(int) limit_size);

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -28,9 +28,8 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_DEFNEWLANG
 #define HTS_DEFNEWLANG
 
-/* limit_to: set to the current language's name, truncated to limit_size and always
-   terminated, or left EMPTY when the index names none. Callers walk the index until
-   that empty name, so never return a placeholder. Pass NULL/0 to reload instead. */
+/* limit_to: current language's name, truncated to limit_size and NUL-terminated, or
+   EMPTY past the last language (callers loop until empty); pass NULL/0 to just reload. */
 void LANG_LOAD(char* limit_to, size_t limit_size);
 void LANG_INIT();
 int LANG_T(int);

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -28,9 +28,10 @@ Please visit our Website: http://www.httrack.com
 #ifndef HTS_DEFNEWLANG
 #define HTS_DEFNEWLANG
 
-/* limit_to: set to the current language's name, or left EMPTY when the index names
-   none. Callers walk the index until that empty name, so never return a placeholder. */
-void LANG_LOAD(char* limit_to);
+/* limit_to: set to the current language's name, truncated to limit_size and always
+   terminated, or left EMPTY when the index names none. Callers walk the index until
+   that empty name, so never return a placeholder. Pass NULL/0 to reload instead. */
+void LANG_LOAD(char* limit_to, size_t limit_size);
 void LANG_INIT();
 int LANG_T(int);
 int QLANG_T(int l);


### PR DESCRIPTION
Callers pass a 1024-byte buffer, and a `lang.def` name value can be longer, so a long enough entry overflowed the caller stack. The copy looked bounds-checked but was not; the reason is in the comment at the call.

The capacity now comes from the caller and the copy goes through `lstrcpynA`, which always terminates. Truncation rather than an abort, since this is a display name; an empty name still stays empty, so the enumeration terminator #64 restored is unaffected.

Pre-existing, and found by an adversarial reviewer on #64.