### PR TITLE
Give the Add/Remove Programs entry an icon

### DIFF
--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -53,6 +53,8 @@ OutputBaseFilename=httrack_{#Arch}_{#AppVersion}
 OutputDir={#OutDir}
 SetupIconFile={#GuiDir}\WinHTTrack\res\Shell.ico
 UninstallIconFile={#GuiDir}\WinHTTrack\res\Shell.ico
+; Add/Remove Programs reads DisplayIcon, which only this directive writes.
+UninstallDisplayIcon={app}\WinHTTrack.exe
 #if Arch == "x64"
 ArchitecturesInstallIn64BitMode=x64compatible
 ArchitecturesAllowed=x64compatible


### PR DESCRIPTION
Add/Remove Programs shows whatever the uninstall key `DisplayIcon` points at, and only `UninstallDisplayIcon` writes it. The installer set `SetupIconFile` and `UninstallIconFile`, which cover `setup.exe` and the uninstaller stub respectively, so the product entry itself had none.

Points it at the installed `WinHTTrack.exe`, which already carries the icon, so no extra file ships.

Reported from VM testing.