### PR TITLE
Show only the transfer rows that fit, instead of demanding all fourteen

### DIFF
--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -230,7 +230,7 @@ BEGIN
     LTEXT           "",IDC_question,7,7,176,47
 END
 
-IDD_inprogress DIALOG  0, 0, 361, 267
+IDD_inprogress DIALOG  0, 0, 361, 207
 STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif"
 BEGIN
@@ -254,7 +254,7 @@ BEGIN
     LTEXT           "Errors:",IDC_STATIC_errors,199,70,66,8
     LTEXT           "",IDC_i5,274,70,72,8
     CONTROL         "Actions:",IDC_inphide,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,95,148,10
-    GROUPBOX        "",IDC_STATIC_actions,7,105,343,153
+    GROUPBOX        "",IDC_STATIC_actions,7,105,343,93
     CONTROL         "",IDC_st0,"Static",SS_LEFTNOWORDWRAP | SS_ENDELLIPSIS | SS_NOTIFY | WS_GROUP,15,117,40,8
     RTEXT           "",IDC_nm0,60,117,91,8,SS_NOTIFY | SS_PATHELLIPSIS
     CONTROL         "Progress1",IDC_sl0,"msctls_progress32",PBS_SMOOTH | WS_BORDER,240,117,50,8

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -109,6 +109,9 @@ Cinprogress::Cinprogress()
   timer=0;
   m_tip[0]='\0';
   memset(element,0,sizeof(element));   // GetTip walks it, and OnInitDialog fills it later
+  m_rowTop=m_rowPitch=m_rowHeight=0;   // zero pitch means "not measured yet"
+  m_groupTop=m_groupGap=m_bottomSlack=0;
+  m_rowsShown=NStatsBuffer;
   //{{AFX_DATA_INIT(Cinprogress)
 	m_inphide = FALSE;
 	//}}AFX_DATA_INIT
@@ -526,6 +529,24 @@ BOOL Cinprogress::OnInitDialog()
     m_layout.Add(element[3][row], 100,  0);   /* SKIP     */
   }
 
+  /* Row spacing and margins, taken from the template rather than from dialog units,
+     so the arithmetic below holds at any DPI. */
+  {
+    CRect page, r0, r1, group;
+    GetClientRect(page);
+    element[0][0]->GetWindowRect(r0);    ScreenToClient(r0);
+    element[0][1]->GetWindowRect(r1);    ScreenToClient(r1);
+    GetDlgItem(IDC_STATIC_actions)->GetWindowRect(group);
+    ScreenToClient(group);
+    m_rowTop     = r0.top;
+    m_rowPitch   = r1.top - r0.top;
+    m_rowHeight  = r0.Height();
+    m_groupTop   = group.top;
+    m_bottomSlack = page.Height() - group.bottom;
+    m_rowsShown  = RowsThatFit(page.Height());
+    m_groupGap   = group.bottom - (m_rowTop + (m_rowsShown-1)*m_rowPitch + m_rowHeight);
+  }
+
   /* Init checkbox */
   CMenu* m;
   if (m = AfxGetApp()->GetMainWnd()->GetMenu()) {
@@ -580,10 +601,59 @@ BOOL Cinprogress::OnInitDialog()
 	              // EXCEPTION: OCX Property Pages should return FALSE
 }
 
+int Cinprogress::RowsThatFit(int cy) const
+{
+  if (m_rowPitch <= 0)
+    return NStatsBuffer;
+  const int room = cy - m_bottomSlack - m_rowTop - m_rowHeight;
+  const int rows = 1 + (room > 0 ? room / m_rowPitch : 0);
+  return min(rows, NStatsBuffer);
+}
+
+/* A row is on screen only when the Actions box is open and the row fits. Same style
+   juggling as Oninphide, which is the other writer of these bits. */
+void Cinprogress::ApplyRowVisibility()
+{
+  const BOOL open = IsDlgButtonChecked(IDC_inphide);
+  for(int row=0 ; row<NStatsBuffer ; row++) {
+    const BOOL show = open && row < m_rowsShown;
+    for(int col=0 ; col<5 ; col++) {
+      CWnd* const w = element[col][row];
+      if (w == NULL || w->m_hWnd == NULL)
+        continue;
+      if (show) {
+        w->ModifyStyle(WS_DISABLED,0);
+        w->ModifyStyle(0,WS_VISIBLE);
+      } else {
+        w->ModifyStyle(0,WS_DISABLED);
+        w->ModifyStyle(WS_VISIBLE,0);
+      }
+    }
+  }
+}
+
 void Cinprogress::OnSize(UINT nType, int cx, int cy)
 {
   CPropertyPage::OnSize(nType, cx, cy);
   m_layout.Apply(cx, cy);
+
+  if (m_rowPitch <= 0)     /* before OnInitDialog recorded the geometry */
+    return;
+  m_rowsShown = RowsThatFit(cy);
+  ApplyRowVisibility();
+
+  /* Close the Actions frame under the last row on screen, rather than leaving it
+     hanging over empty space or past the bottom of the panel. */
+  CWnd* const box = GetDlgItem(IDC_STATIC_actions);
+  if (box != NULL && box->m_hWnd != NULL) {
+    CRect r;
+    box->GetWindowRect(r);
+    ScreenToClient(r);
+    const int bottom = m_rowTop + (m_rowsShown-1)*m_rowPitch + m_rowHeight + m_groupGap;
+    box->SetWindowPos(NULL, r.left, m_groupTop, r.Width(), bottom - m_groupTop,
+                      SWP_NOZORDER|SWP_NOACTIVATE);
+  }
+  Invalidate(TRUE);
 }
 
 void Cinprogress::StartTimer() {
@@ -1142,27 +1212,17 @@ BOOL Cinprogress::OnQueryCancel( ) {
 
 void Cinprogress::Oninphide() 
 {
+  /* Checked opens the panel. ModifyStyle takes (remove, add), which the old comments
+     here had backwards. */
   int status=IsDlgButtonChecked(IDC_inphide);
   if (status) {
-    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(WS_DISABLED,0);  // disabled
-    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(0,WS_VISIBLE);   // not visible
+    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(WS_DISABLED,0);
+    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(0,WS_VISIBLE);
   } else {
-    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(0,WS_DISABLED);  // not disabled
-    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(WS_VISIBLE,0);   // visible
+    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(0,WS_DISABLED);
+    GetDlgItem(IDC_STATIC_actions)->ModifyStyle(WS_VISIBLE,0);
   }
-  int i;
-  for(i=0;i<NStatsBuffer;i++) {
-    int j;
-    for(j=0;j<5;j++) {
-      if (status) {
-        inprogress->element[j][i]->ModifyStyle(WS_DISABLED,0);  // disabled
-        inprogress->element[j][i]->ModifyStyle(0,WS_VISIBLE);   // not visible
-      } else {
-        inprogress->element[j][i]->ModifyStyle(0,WS_DISABLED);  // not disabled
-        inprogress->element[j][i]->ModifyStyle(WS_VISIBLE,0);   // visible
-      }
-    }
-  }
+  ApplyRowVisibility();   // honours both this checkbox and how many rows fit
   RedrawWindow();
 }
 

--- a/WinHTTrack/inprogress.h
+++ b/WinHTTrack/inprogress.h
@@ -155,6 +155,15 @@ protected:
      is idle. Valid until the next call. */
   const char* RowTip(int row);
   char m_tip[HTS_URLMAXSIZE*4];
+  /* The transfer grid adapts to the panel height: rows that will not fit are hidden
+     rather than making the whole panel scroll. Geometry is measured from the template
+     at run time, so it stays right at any DPI. */
+  int RowsThatFit(int cy) const;
+  void ApplyRowVisibility();
+  int m_rowTop, m_rowPitch, m_rowHeight;   /* first row's top, row spacing, row height */
+  int m_groupTop, m_groupGap;              /* Actions frame top, and its gap under the last row */
+  int m_bottomSlack;                       /* page height left below the Actions frame */
+  int m_rowsShown;
   void OnHelpInfo2();
   UINT_PTR timer;
   void StartTimer();


### PR DESCRIPTION
The panel asked for 267 dialog units of height whatever the screen offered, and the form view scrolled when it could not have them. On a 1280x800 display at 125% scaling that exceeds the client area even maximized, so the wizard buttons sat below the fold behind a scrollbar from the very first launch.

The template is now sized for eight rows and the rest appear as the panel grows. The grid works out how many rows fit the current height, hides the others, and closes the Actions frame under the last one on screen. Spacing is measured from the template at run time rather than hardcoded in dialog units, so it holds at any DPI.

Row visibility had two writers, this and the Actions checkbox, so the checkbox now goes through the same helper instead of showing rows that do not fit. Its comments had `ModifyStyle` arguments backwards, corrected while there.

Independent of #65: no shared files, and this measures the page own geometry rather than the sheet, which is what #65 changes.

CI cannot see layout, so this wants a look on the VM. Worth checking both directions: a small window should drop rows rather than scroll, and a large one should show all fourteen.