### PR TITLE
Give the restored window a sensible default size

### DIFF
--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -139,8 +139,24 @@ void CMainFrame::InitialShowWindow(UINT nCmdShow)
 	WINDOWPLACEMENT wp;
 	if (!ReadWindowPlacement(&wp))
 	{
-		ShowWindow(SW_SHOWMAXIMIZED);   /* by default, maximized */
-		//ShowWindow(nCmdShow);
+		/* Maximized, but give the restored size something as well: with no explicit
+		   rcNormalPosition the frame keeps CW_USEDEFAULT, so the first un-maximize
+		   drops to a small window however large the screen is. */
+		CRect work;
+		if (!::SystemParametersInfo(SPI_GETWORKAREA, 0, &work, 0))
+			work.SetRect(0, 0, ::GetSystemMetrics(SM_CXSCREEN), ::GetSystemMetrics(SM_CYSCREEN));
+		CRect normal(0, 0, work.Width()*3/4, work.Height()*3/4);
+		normal.OffsetRect(work.left + (work.Width() - normal.Width())/2,
+		                  work.top + (work.Height() - normal.Height())/2);
+
+		WINDOWPLACEMENT init;
+		init.length = sizeof(init);
+		init.flags = 0;
+		init.showCmd = SW_SHOWMAXIMIZED;   /* by default, maximized */
+		init.ptMinPosition = CPoint(-1, -1);
+		init.ptMaxPosition = CPoint(-1, -1);
+		init.rcNormalPosition = normal;
+		SetWindowPlacement(&init);
 		return;
 	}
 	if (nCmdShow != SW_SHOWNORMAL)


### PR DESCRIPTION
The frame starts maximized, and on a first run nothing ever set its restored rectangle, so it kept the `CW_USEDEFAULT` one MFC created it with. Un-maximizing therefore dropped to a small window on any display, large ones included, and the panel gained scrollbars it had no reason to need.

Sets the restored rectangle to three quarters of the work area, centred, before maximizing. That scales with the screen rather than being a fixed guess, and it only applies when there is no saved placement to honour, so it never overrides a size the user has chosen.

Reported from VM testing, where un-maximizing showed scrollbars regardless of resolution. Pairs with #68, which cut what the panel demands in the first place.