### PR TITLE
Expose the engine's WARC CDXJ index and WACZ packaging

### DIFF
--- a/WinHTTrack/OptionTab9.cpp
+++ b/WinHTTrack/OptionTab9.cpp
@@ -61,6 +61,8 @@ COptionTab9::COptionTab9() : CPropertyPage(COptionTab9::IDD)
 	m_index2 = FALSE;
 	m_index_mail = FALSE;
 	m_warc = FALSE;
+	m_warccdx = FALSE;
+	m_wacz = FALSE;
 	m_singlefile = FALSE;
 	m_singlefilemax = _T("");
 	m_changes = FALSE;
@@ -83,6 +85,8 @@ void COptionTab9::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_index2, m_index2);
 	DDX_Check(pDX, IDC_index_mail, m_index_mail);
 	DDX_Check(pDX, IDC_warc, m_warc);
+	DDX_Check(pDX, IDC_warccdx, m_warccdx);
+	DDX_Check(pDX, IDC_wacz, m_wacz);
 	DDX_Check(pDX, IDC_singlefile, m_singlefile);
 	DDX_Text(pDX, IDC_singlefilemax, m_singlefilemax);
 	DDV_MaxChars(pDX, m_singlefilemax, 19);  // an LLint byte count is 19 digits at most
@@ -127,6 +131,8 @@ BOOL COptionTab9::OnInitDialog()
     GetDlgItem(IDC_logf)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_Cache2)  ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_warc)    ->ModifyStyle(0,WS_DISABLED);
+    GetDlgItem(IDC_warccdx) ->ModifyStyle(0,WS_DISABLED);
+    GetDlgItem(IDC_wacz)    ->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_singlefile)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_singlefilemax)->ModifyStyle(0,WS_DISABLED);
     GetDlgItem(IDC_STATIC_singlefilemax)->ModifyStyle(0,WS_DISABLED);
@@ -140,6 +146,8 @@ BOOL COptionTab9::OnInitDialog()
     GetDlgItem(IDC_logf)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_Cache2)  ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_warc)    ->ModifyStyle(WS_DISABLED,0);
+    GetDlgItem(IDC_warccdx) ->ModifyStyle(WS_DISABLED,0);
+    GetDlgItem(IDC_wacz)    ->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_singlefile)->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_singlefilemax)->ModifyStyle(WS_DISABLED,0);
     GetDlgItem(IDC_STATIC_singlefilemax)->ModifyStyle(WS_DISABLED,0);
@@ -198,6 +206,8 @@ const char* COptionTab9::GetTip(int ID)
     case IDC_logf:    return LANG(LANG_I7); break; // "Create log files for error and info report","Générer des fichiers d'audit pour les erreurs et les messages"); break;
     case IDC_Cache2:  return LANG(LANG_I1e); break;
     case IDC_warc:    return "Write an ISO-28500 WARC archive (.warc.gz)"; break;
+    case IDC_warccdx: return "Also write a sorted CDXJ index next to the archive"; break;
+    case IDC_wacz:    return "Package the archive and its index as a WACZ file"; break;
     case IDC_singlefile: return LANG(LANG_SINGLEFILETIP); break;
     case IDC_singlefilemax: return LANG(LANG_SINGLEFILEMAXTIP); break;
     case IDC_changes: return LANG(LANG_CHANGESTIP); break;

--- a/WinHTTrack/OptionTab9.h
+++ b/WinHTTrack/OptionTab9.h
@@ -58,6 +58,8 @@ public:
 	BOOL	m_index2;
 	BOOL	m_index_mail;
 	BOOL	m_warc;
+	BOOL	m_warccdx;
+	BOOL	m_wacz;
 	BOOL	m_singlefile;
 	CString	m_singlefilemax;
 	BOOL	m_changes;

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -557,6 +557,8 @@ void compute_options() {
   if(maintab->m_option2.m_external) ShellOptions->external = "x"; else ShellOptions->external = ""; 
   if(maintab->m_option2.m_nopurge) ShellOptions->nopurge = "X0"; else ShellOptions->nopurge = "";
   if(maintab->m_option9.m_warc) ShellOptions->warc = "1"; else ShellOptions->warc = "";
+  if(maintab->m_option9.m_warccdx) ShellOptions->warccdx = "1"; else ShellOptions->warccdx = "";
+  if(maintab->m_option9.m_wacz) ShellOptions->wacz = "1"; else ShellOptions->wacz = "";
   if(maintab->m_option8.m_sitemap) ShellOptions->sitemap = "1"; else ShellOptions->sitemap = "";
   ShellOptions->sitemapurl = maintab->m_option8.m_sitemapurl;
   if(maintab->m_option9.m_singlefile) ShellOptions->singlefile = "1"; else ShellOptions->singlefile = "";
@@ -1979,6 +1981,13 @@ void lance(void) {
   // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
   if (ShellOptions->warc.GetLength() != 0) {
     args.Add("--warc");
+    // neither sub-option names an archive on its own, so both stay gated on --warc
+    if (ShellOptions->warccdx.GetLength() != 0) {
+      args.Add("--warc-cdx");
+    }
+    if (ShellOptions->wacz.GetLength() != 0) {
+      args.Add("--wacz");
+    }
   }
 
   // Long forms, own tokens: same reason as --warc above. Each option's own checkbox
@@ -2572,6 +2581,8 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection, "NoQueryStrings",maintab->m_option2.m_hidequery);
     MyWriteProfileInt(path,strSection, "NoPurgeOldFiles",maintab->m_option2.m_nopurge);
     MyWriteProfileInt(path,strSection, "Warc",maintab->m_option9.m_warc);
+    MyWriteProfileInt(path,strSection, "WarcCdx",maintab->m_option9.m_warccdx);
+    MyWriteProfileInt(path,strSection, "Wacz",maintab->m_option9.m_wacz);
     MyWriteProfileInt(path,strSection, "Sitemap",maintab->m_option8.m_sitemap);
     MyWriteProfileString(path,strSection, "SitemapUrl",maintab->m_option8.m_sitemapurl);
     MyWriteProfileInt(path,strSection, "SingleFile",maintab->m_option9.m_singlefile);
@@ -2690,6 +2701,10 @@ void Write_profile(CString path,int load_path) {
     MyWriteProfileInt(path,strSection,"NoPurgeOldFiles", n);
     n=maintab->m_option9.IsDlgButtonChecked(IDC_warc);
     MyWriteProfileInt(path,strSection,"Warc", n);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_warccdx);
+    MyWriteProfileInt(path,strSection,"WarcCdx", n);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_wacz);
+    MyWriteProfileInt(path,strSection,"Wacz", n);
     if ((n=maintab->m_option2.m_ctl_build.GetCurSel()) != CB_ERR)
       MyWriteProfileInt(path,strSection, "Build", n);
     st = maintab->m_option2.Bopt.m_BuildString;
@@ -2930,6 +2945,8 @@ void Read_profile(CString path,int load_path) {
   maintab->m_option2.m_hidequery = MyGetProfileInt(path,strSection, "NoQueryStrings",0);
   maintab->m_option2.m_nopurge   = MyGetProfileInt(path,strSection, "NoPurgeOldFiles",0);
   maintab->m_option9.m_warc      = MyGetProfileInt(path,strSection, "Warc",0);
+  maintab->m_option9.m_warccdx   = MyGetProfileInt(path,strSection, "WarcCdx",0);
+  maintab->m_option9.m_wacz      = MyGetProfileInt(path,strSection, "Wacz",0);
   maintab->m_option8.m_sitemap   = MyGetProfileInt(path,strSection, "Sitemap",0);
   maintab->m_option8.m_sitemapurl = MyGetProfileString(path,strSection, "SitemapUrl");
   maintab->m_option9.m_singlefile = MyGetProfileInt(path,strSection, "SingleFile",0);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -262,7 +262,8 @@ public:
     maxconn, maxlinks, hh, mm, ss, buff_filtres, buff_MIME, 
     _RasString, accept_language, other_headers, default_referer,
     cookiesfile, pausefiles, keepwww, keepslashes, keepqueryorder,
-    stripquery, sitemap, sitemapurl, singlefile, singlefilemax, changes;
+    stripquery, sitemap, sitemapurl, singlefile, singlefilemax, changes,
+    warccdx, wacz;
   CString LINE_back;
   RASDIALPARAMS _dial;
 };

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -647,7 +647,7 @@ BEGIN
     EDITTEXT        IDC_sitemapurl,140,174,116,12,ES_AUTOHSCROLL
 END
 
-IDD_OPTION9 DIALOGEX 0, 0, 325, 176
+IDD_OPTION9 DIALOGEX 0, 0, 325, 198
 STYLE DS_SETFONT | WS_CHILD | WS_DISABLED | WS_CAPTION | WS_SYSMENU
 CAPTION "Log, Index, Cache"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -656,15 +656,17 @@ BEGIN
     CONTROL         "Do not re-download locally erased files",IDC_norecatch,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,32,304,9
     CONTROL         "Write WARC archive",IDC_warc,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,48,305,9
-    CONTROL         "Create Log files",IDC_logf,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,64,159,9
-    COMBOBOX        IDC_logtype,175,64,105,56,CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Make an index",IDC_index,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,80,304,9
-    CONTROL         "Make a word database",IDC_index2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,96,304,9
-    CONTROL         "Build a mail archive",IDC_index_mail,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,112,306,9
-    CONTROL         "Inline assets as data: URIs (self-contained pages)",IDC_singlefile,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,128,305,9
-    LTEXT           "Largest inlined asset (bytes):",IDC_STATIC_singlefilemax,32,145,140,8
-    EDITTEXT        IDC_singlefilemax,175,143,64,12,ES_AUTOHSCROLL | ES_NUMBER
-    CONTROL         "Report what changed since the previous mirror",IDC_changes,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,160,305,9
+    CONTROL         "Also write a CDXJ index",IDC_warccdx,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,32,64,145,9
+    CONTROL         "Package the archive as WACZ",IDC_wacz,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,64,141,9
+    CONTROL         "Create Log files",IDC_logf,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,80,159,9
+    COMBOBOX        IDC_logtype,175,80,105,56,CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Make an index",IDC_index,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,96,304,9
+    CONTROL         "Make a word database",IDC_index2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,112,304,9
+    CONTROL         "Build a mail archive",IDC_index_mail,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,128,306,9
+    CONTROL         "Inline assets as data: URIs (self-contained pages)",IDC_singlefile,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,144,305,9
+    LTEXT           "Largest inlined asset (bytes):",IDC_STATIC_singlefilemax,32,161,140,8
+    EDITTEXT        IDC_singlefilemax,175,159,64,12,ES_AUTOHSCROLL | ES_NUMBER
+    CONTROL         "Report what changed since the previous mirror",IDC_changes,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,176,305,9
 END
 
 IDD_OPTION10 DIALOG  0, 0, 309, 61

--- a/WinHTTrack/resource.h
+++ b/WinHTTrack/resource.h
@@ -552,6 +552,8 @@ Please visit our Website: http://www.httrack.com
 #define IDC_singlefilemax               1326
 #define IDC_STATIC_singlefilemax        1327
 #define IDC_changes                     1328
+#define IDC_warccdx                     1329
+#define IDC_wacz                        1330
 #define ID_MENUITEM32771                32771
 #define ID_MENUITEM32772                32772
 #define ID_EXIT                         32772
@@ -623,7 +625,7 @@ Please visit our Website: http://www.httrack.com
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        247
 #define _APS_NEXT_COMMAND_VALUE         32837
-#define _APS_NEXT_CONTROL_VALUE         1329
+#define _APS_NEXT_CONTROL_VALUE         1331
 #define _APS_NEXT_SYMED_VALUE           108
 #endif
 #endif


### PR DESCRIPTION
The GUI has had the `--warc` toggle since 3.49-13 but not the two options that shipped alongside it, so a WARC crawl started from the desktop could not write the CDXJ index or the WACZ package. Both are now checkboxes under the WARC row on the Log/Index/Cache page.

Neither is passed to the engine unless the WARC box is ticked. `--warc-cdx` on its own sets the CDXJ flag but never names an archive, so it would quietly do nothing, which is the same trap `--single-file-max-size` is already gated against.

The page grows from 176 to 198 dialog units to fit the new row. That is the height the property sheet already uses for its tallest page (`IDD_OPTION5`), so no other tab moves. I cannot run the GUI from here, so the layout has only been through CI and should get a look on a real window before this lands.