### PR TITLE
First-run language selector shows Bulgarian instead of the running language

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -397,7 +397,10 @@ jobs:
           # lang.def is a FILE at the engine root, not inside lang\. The GUI reads it
           # from the app directory at startup and refuses to run without it. The old
           # installer swept it up with a wildcard; enumerating files by hand lost it.
+          # lang.indexes sits next to it and maps the system locale to a language, which
+          # is how the first run picks one instead of always starting in English.
           Copy-Item "httrack\lang.def" $bin
+          Copy-Item "httrack\lang.indexes" $bin
           foreach ($d in @('lang', 'html', 'templates')) {
             Copy-Item "httrack\$d" (Join-Path $bin $d) -Recurse -Force
           }
@@ -426,6 +429,9 @@ jobs:
           }
           if (-not (Test-Path (Join-Path $bin 'lang.def'))) {
             throw "package is missing lang.def: the GUI refuses to start without it"
+          }
+          if (-not (Test-Path (Join-Path $bin 'lang.indexes'))) {
+            throw "package is missing lang.indexes: the first run would ignore the system locale"
           }
           if (-not (Test-Path (Join-Path $bin 'httrack.exe'))) {
             throw "package is missing httrack.exe: the command-line version ships with the GUI"
@@ -723,6 +729,11 @@ jobs:
           # box. [1-9] not \d: "after 0 entries" would pass while proving nothing.
           if ("$so" -notmatch 'language list ends after [1-9]\d* entries') {
             throw "selftest did not check that the language list terminates"
+          }
+          # lang.indexes counts from LANGUAGE_1 and our indices from 0: an unchecked
+          # off-by-one would seed the first run in the neighbouring language.
+          if ("$so" -notmatch 'lang\.indexes offset checked on [1-9]\d* locales') {
+            throw "selftest did not check the lang.indexes offset"
           }
 
           # --selftest throws one exception on purpose. A crash report that resolves nothing

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -332,11 +332,13 @@ BOOL CWinHTTrackApp::InitInstance()
         printf("MBCS->UTF-8 ok\n");
       }
     }
+    int nlangs = 0;
     /* Walk the languages as the About box does: losing LANG_LOAD()'s empty-name
        terminator hangs it on the first run, past where --selftest ever reaches. */
     {
       const int LANG_SANE_MAX = 512;   /* lang.def ships a few dozen */
       const int saved = QLANG_T(-1);
+      CStringArray names;
       int i;
       for(i=0 ; i<LANG_SANE_MAX ; i++) {
         char name[1024];
@@ -345,6 +347,15 @@ BOOL CWinHTTrackApp::InitInstance()
         LANG_LOAD(name,sizeof(name));
         if (name[0] == '\0')
           break;
+        /* The About box selects its entry by name, so a duplicate would select the wrong one. */
+        for(INT_PTR j=0 ; j<names.GetSize() ; j++) {
+          if (names[j] == name) {
+            fprintf(stderr, "FATAL: languages %d and %d are both named '%s'\n", (int) j, i, name);
+            fflush(stderr);
+            ExitProcess(4);
+          }
+        }
+        names.Add(name);
       }
       QLANG_T(saved);
       if (i >= LANG_SANE_MAX) {
@@ -352,7 +363,44 @@ BOOL CWinHTTrackApp::InitInstance()
         fflush(stderr);
         ExitProcess(4);
       }
+      nlangs = i;
       printf("language list ends after %d entries\n", i);
+    }
+    /* lang.indexes seeds the first run from the system locale, but it numbers from
+       LANGUAGE_1 while our indices start at 0: pin that offset against the list above. */
+    {
+      static const struct { const char* tag; const char* name; } expect[] = {
+        { "en", "English" }, { "fr", "Francais" }, { "bg", "Bulgarian" },
+        { "pt_br", "Portugues-Brasil" }, { NULL, NULL }
+      };
+      const int saved = QLANG_T(-1);
+      int k;
+      for(k=0 ; expect[k].tag != NULL ; k++) {
+        char name[1024];
+        const int index = LANG_INDEX_OF(expect[k].tag);
+        if (index < 0 || index >= nlangs) {
+          fprintf(stderr, "FATAL: lang.indexes gives '%s' the unusable index %d\n",
+                  expect[k].tag, index);
+          fflush(stderr);
+          ExitProcess(5);
+        }
+        QLANG_T(index);
+        strcpybuff(name, "LANGUAGE_NAME");
+        LANG_LOAD(name,sizeof(name));
+        if (strcmp(name, expect[k].name) != 0) {
+          fprintf(stderr, "FATAL: lang.indexes maps '%s' to '%s', expected '%s'\n",
+                  expect[k].tag, name, expect[k].name);
+          fflush(stderr);
+          ExitProcess(5);
+        }
+      }
+      QLANG_T(saved);
+      if (LANG_INDEX_OF("zz") >= 0) {
+        fprintf(stderr, "FATAL: lang.indexes matched the bogus tag 'zz'\n");
+        fflush(stderr);
+        ExitProcess(5);
+      }
+      printf("lang.indexes offset checked on %d locales\n", k);
     }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -112,11 +112,14 @@ BOOL Cabout::OnInitDialog()
     //int old_lang=LANG_T(-1);
     int i=0;
     int curr_lng=LANG_T(-1);
+    CString curr_name;
     QLANG_T(0);
     strcpybuff(lang_str,"LANGUAGE_NAME");
     LANG_LOAD(lang_str,sizeof(lang_str));    // 0 english 1 français..
     while(strlen(lang_str)) {
       m_ctl_lang.AddString(lang_str);
+      if (i==curr_lng)
+        curr_name=lang_str;
       i++;
       QLANG_T(i);
       strcpybuff(lang_str,"LANGUAGE_NAME");
@@ -124,11 +127,11 @@ BOOL Cabout::OnInitDialog()
     }
     QLANG_T(curr_lng);
     //LANG_T(min(old_lang,i-1));
+    /* CBS_SORT reorders the list, so match on the string that was added: it is the lang/
+       basename, which for several languages differs from the translated LANGUAGE_NAME. */
+    m_ctl_lang.SetCurSel(m_ctl_lang.FindStringExact(-1,curr_name));
   }
 
-  /* sel: items were added in language-index order above */
-  m_ctl_lang.SetCurSel(LANG_T(-1));
-  
   EnableToolTips(true);     // TOOL TIPS
   setlang();
   SetIcon(httrack_icon,false);

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -226,6 +226,24 @@ WinLangid WINDOWS_LANGID[] = {
   { 0, NULL }
 };
 
+/* Locate a shipped data file next to the executable, falling back to the working directory. */
+static CString LANG_DATAFILE(const char* relative) {
+  TCHAR ModulePath[MAX_PATH + 1];
+  ModulePath[0] = '\0';
+  ::GetModuleFileName(NULL, ModulePath, sizeof(ModulePath)/sizeof(TCHAR) - 1);
+  TCHAR* pos = _tcsrchr(ModulePath, '\\');
+  if (pos != NULL)
+  {
+    * ( pos + 1) = '\0';
+  } else {
+    ModulePath[0] = '\0';
+  }
+  CString name = CString(ModulePath) + relative;
+  if (!fexist((char*)LPCTSTR(name)))
+    name = relative;
+  return name;
+}
+
 void LANG_LOAD(char* limit_to, size_t limit_size) {
   CWaitCursor wait;
   //
@@ -254,23 +272,9 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
     }
   }
 
-  TCHAR ModulePath[MAX_PATH + 1];
-  ModulePath[0] = '\0';
-  ::GetModuleFileName(NULL, ModulePath, sizeof(ModulePath)/sizeof(TCHAR) - 1);
-  TCHAR* pos = _tcsrchr(ModulePath, '\\');
-  if (pos != NULL)
-  {
-    * ( pos + 1) = '\0';
-  } else {
-    ModulePath[0] = '\0';
-  }
-
   /* Load master file (list of keys and internal keys) */
-  CString app = ModulePath;
   if (!limit_to) {
-    CString mname=app+"lang.def";
-    if (!fexist((char*)LPCTSTR(mname)))
-      mname="lang.def";
+    CString mname=LANG_DATAFILE("lang.def");
     FILE* fp=fopen(mname,"rb");
     if (fp) {
       char intkey[8192];
@@ -364,9 +368,7 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
         hashname=LANGINTKEY(name);
       }
       lbasename.Format("lang/%s.txt",hashname);
-      CString lname=app+lbasename;
-      if (!fexist((char*)LPCTSTR(lname)))
-        lname=lbasename;
+      CString lname=LANG_DATAFILE(lbasename);
       FILE* fp=fopen(lname,"rb");
       if (fp) {
         char extkey[8192];
@@ -528,11 +530,57 @@ void LANG_DELETE() {
   coucal_delete(&NewLangStrKeys);
 }
 
+int LANG_INDEX_OF(const char* tag) {
+  int index = -1;
+  if (!strnotempty(tag))
+    return -1;
+  FILE* fp = fopen(LANG_DATAFILE("lang.indexes"), "rb");
+  if (fp) {
+    char line[256];
+    while(index < 0 && !feof(fp)) {
+      linput_cpp(fp,line,(int)sizeof(line)-1);
+      char* sep = strchr(line,':');
+      if (sep != NULL) {
+        *sep = '\0';
+        if (strcmp(line,tag) == 0)
+          index = atoi(sep+1) - 1;   /* lang.indexes counts from LANGUAGE_1 */
+      }
+    }
+    fclose(fp);
+  }
+  return index;
+}
+
+/* First run only: pick the language matching the system UI language, English otherwise. */
+static int LANG_FROM_LOCALE() {
+  const LCID lcid = MAKELCID(GetUserDefaultUILanguage(),SORT_DEFAULT);
+  char lang[16];
+  char country[16];
+  char tag[40];
+  int index = -1;
+  if (GetLocaleInfoA(lcid,LOCALE_SISO639LANGNAME,lang,(int)sizeof(lang)) == 0)
+    return 0;
+  _strlwr_s(lang,sizeof(lang));
+  /* Only pt_br and zh_tw are split by country; everything else keys off the language alone. */
+  if (GetLocaleInfoA(lcid,LOCALE_SISO3166CTRYNAME,country,(int)sizeof(country)) != 0) {
+    _strlwr_s(country,sizeof(country));
+    _snprintf_s(tag,sizeof(tag),_TRUNCATE,"%s_%s",lang,country);
+    index = LANG_INDEX_OF(tag);
+  }
+  if (index < 0)
+    index = LANG_INDEX_OF(lang);
+  return (index >= 0) ? index : 0;
+}
+
 // sélection de la langue
 void LANG_INIT() {
   CWinApp* pApp = AfxGetApp();
   if (pApp) {
-    LANG_T(pApp->GetProfileInt("Language","IntId",0));
+    /* -1 means never chosen: seed from the locale rather than silently starting in English. */
+    int lng = pApp->GetProfileInt("Language","IntId",-1);
+    if (lng < 0)
+      lng = LANG_FROM_LOCALE();
+    LANG_T(lng);
   }
 }
 

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -32,6 +32,9 @@ Please visit our Website: http://www.httrack.com
    EMPTY past the last language (callers loop until empty); pass NULL/0 to just reload. */
 void LANG_LOAD(char* limit_to, size_t limit_size);
 void LANG_INIT();
+/* Language index for an ISO tag ("fr", "pt_br") as listed in the engine's lang.indexes,
+   or -1 when the tag or the file is missing. */
+int LANG_INDEX_OF(const char* tag);
 int LANG_T(int);
 int QLANG_T(int l);
 //char* LANGSEL(char* lang0,...);


### PR DESCRIPTION
The About box combo carries `CBS_SORT`, so it reorders itself after `OnInitDialog` fills it in language-index order, and `SetCurSel(LANG_T(-1))` was passing a language index where an item index belongs. On a fresh install that lands on Bulgarian. It now matches on the string that was actually added, which is the `lang/` basename and not the translated `LANGUAGE_NAME`. The two disagree for six languages, and matching on the latter is what left the field blank in #188.

`LANG_INIT` never consulted the system locale either: a profile default of 0 was indistinguishable from a stored "English". It defaults to -1 now and, only when nothing is stored, maps the system UI language through the engine `lang.indexes`. Anything unresolved (file missing, unknown tag, index out of range) falls back to English.

`lang.indexes` counts from `LANGUAGE_1` while our indices start at 0, so `--selftest` pins that offset against the language list itself rather than trusting it, and checks the names are unique since `FindStringExact` now depends on that. CI stages the file next to `lang.def` and asserts both.

Closes #73