### PR TITLE
Sign releases with a Certum certificate

### DIFF
--- a/.github/actions/build-installer/action.yml
+++ b/.github/actions/build-installer/action.yml
@@ -53,6 +53,15 @@ runs:
         $arch = $env:ARCH
         if ($arch -notin 'x64', 'x86') { throw "arch must be x64 or x86, not '$arch'" }
 
+        # The payload directory and the architecture it is packaged as are paired by
+        # hand on the signing run, and a swap would build, install and run happily.
+        $pe = [IO.File]::ReadAllBytes((Join-Path $env:PAYLOAD_DIR 'WinHTTrack.exe'))
+        $machine = [BitConverter]::ToUInt16($pe, [BitConverter]::ToInt32($pe, 0x3c) + 4)
+        $want = if ($arch -eq 'x64') { 0x8664 } else { 0x14c }
+        if ($machine -ne $want) {
+          throw ('the payload WinHTTrack.exe is machine 0x{0:x}, not the 0x{1:x} an {2} installer needs' -f $machine, $want, $arch)
+        }
+
         # Single source of truth for the version: the engine's own header.
         $hg = Get-Content (Join-Path $env:ENGINE_DIR 'src\htsglobal.h') -Raw
         if ($hg -notmatch '#define\s+HTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSION' }
@@ -91,8 +100,8 @@ runs:
         if ($env:SIGN -eq 'true') {
           if ($env:THUMBPRINT -notmatch '^[0-9A-Fa-f]{40}$') { throw "a 40-hex thumbprint is needed to sign, got '$env:THUMBPRINT'" }
           if (-not (Get-Command signtool.exe -ErrorAction SilentlyContinue)) { throw 'signing was asked for but signtool.exe is not on PATH' }
-          # /DSign turns on SignedUninstaller and points the .iss at the tool named
-          # certum; $f is Inno's placeholder for the file to sign.
+          # /DSign asks Inno to sign setup.exe and the uninstaller; $f is its
+          # placeholder for the file.
           $iargs += '/DSign'
           $iargs += ("/Scertum=signtool.exe sign /sha1 $env:THUMBPRINT /fd sha256 /tr http://time.certum.pl /td sha256 " + '$f')
         }

--- a/.github/actions/build-installer/action.yml
+++ b/.github/actions/build-installer/action.yml
@@ -1,0 +1,121 @@
+# Shared by both jobs: the build job produces the unsigned installer every push
+# tests, and the sign job rebuilds it from signed binaries with /DSign, which is
+# what also gets the embedded uninstaller signed.
+name: Build the WinHTTrack installer
+description: Compile InnoSetup/httrack.iss over a staged payload directory, optionally signing.
+
+inputs:
+  payload-dir:
+    description: The staged bin directory ISCC packages (WinHTTrack.exe, the DLLs, lang/).
+    required: true
+  engine-dir:
+    description: The httrack engine checkout, for the version header and the shipped sources.
+    required: true
+  gui-dir:
+    description: The httrack-windows checkout, for the .iss itself, the licence and the icon.
+    required: true
+  arch:
+    description: x64 or x86.
+    required: true
+  out-dir:
+    description: Where to write the installer.
+    required: true
+  sign:
+    description: "'true' to sign setup.exe and unins000.exe: needs a signing session and signtool.exe on PATH."
+    default: 'false'
+  thumbprint:
+    description: SHA-1 thumbprint of the certificate to sign with.
+    default: ''
+
+outputs:
+  version:
+    description: HTTRACK_VERSION, read from the engine header.
+    value: ${{ steps.iscc.outputs.version }}
+  setup:
+    description: Full path of the installer that was built.
+    value: ${{ steps.iscc.outputs.setup }}
+
+runs:
+  using: composite
+  steps:
+    - id: iscc
+      shell: pwsh
+      # Via env rather than ${{ }} interpolation: a value containing $(...) would run.
+      env:
+        PAYLOAD_DIR: ${{ inputs.payload-dir }}
+        ENGINE_DIR: ${{ inputs.engine-dir }}
+        GUI_DIR: ${{ inputs.gui-dir }}
+        ARCH: ${{ inputs.arch }}
+        OUT_DIR: ${{ inputs.out-dir }}
+        SIGN: ${{ inputs.sign }}
+        THUMBPRINT: ${{ inputs.thumbprint }}
+      run: |
+        $arch = $env:ARCH
+        if ($arch -notin 'x64', 'x86') { throw "arch must be x64 or x86, not '$arch'" }
+
+        # Single source of truth for the version: the engine's own header.
+        $hg = Get-Content (Join-Path $env:ENGINE_DIR 'src\htsglobal.h') -Raw
+        if ($hg -notmatch '#define\s+HTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSION' }
+        $ver = $Matches[1]
+        # Inno stamps 0.0.0.0 unless it gets a valid version number, and "3.49-12" is not one.
+        if ($hg -notmatch '#define\s+HTTRACK_VERSIONID\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSIONID' }
+        $verid = $Matches[1]
+        Write-Host "version = $ver ($verid), arch = $arch"
+
+        # The VC++ runtime, bundled so a clean machine can actually start the app.
+        # vs/17 is the VS2022 line (14.4x). NOT vs/18: the 14.5x redistributable
+        # refuses to install on Windows 7, which is still our floor.
+        $redist = "$PWD\vc_redist.$arch.exe"
+        Invoke-WebRequest "https://aka.ms/vs/17/release/vc_redist.$arch.exe" -OutFile $redist
+        if ((Get-Item $redist).Length -lt 1MB) { throw 'vc_redist download looks wrong' }
+
+        # Bundled into a signed installer and run elevated, so verify who produced the
+        # bytes: aka.ms redirects, and TLS only authenticates the host we fetched from.
+        $sig = Get-AuthenticodeSignature $redist
+        if ($sig.Status -ne 'Valid') { throw "vc_redist signature is $($sig.Status)" }
+        if ($sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+          throw "vc_redist signed by an unexpected party: $($sig.SignerCertificate.Subject)"
+        }
+        Write-Host "vc_redist signer verified: $($sig.SignerCertificate.Subject)"
+
+        $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+        if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress | Out-Null }
+        if (-not (Test-Path $iscc)) { throw 'Inno Setup is not available' }
+
+        $iargs = @(
+          '/Q'
+          "/DArch=$arch", "/DAppVersion=$ver", "/DAppVersionNumeric=$verid"
+          "/DPayloadDir=$env:PAYLOAD_DIR", "/DEngineDir=$env:ENGINE_DIR", "/DGuiDir=$env:GUI_DIR"
+          "/DRedistFile=$redist", "/DOutDir=$env:OUT_DIR"
+        )
+        if ($env:SIGN -eq 'true') {
+          if ($env:THUMBPRINT -notmatch '^[0-9A-Fa-f]{40}$') { throw "a 40-hex thumbprint is needed to sign, got '$env:THUMBPRINT'" }
+          if (-not (Get-Command signtool.exe -ErrorAction SilentlyContinue)) { throw 'signing was asked for but signtool.exe is not on PATH' }
+          # /DSign turns on SignedUninstaller and points the .iss at the tool named
+          # certum; $f is Inno's placeholder for the file to sign.
+          $iargs += '/DSign'
+          $iargs += ("/Scertum=signtool.exe sign /sha1 $env:THUMBPRINT /fd sha256 /tr http://time.certum.pl /td sha256 " + '$f')
+        }
+
+        # ISCC fails if any Source: is missing, so a clean compile also proves the
+        # redistributable really is in the package.
+        & $iscc @iargs (Join-Path $env:GUI_DIR 'InnoSetup\httrack.iss')
+        if ($LASTEXITCODE -ne 0) { throw "ISCC failed ($LASTEXITCODE)" }
+
+        # By name, not by glob: both architectures write into one directory on the
+        # signing run, and picking the first match would test the wrong installer.
+        $setup = Get-Item (Join-Path $env:OUT_DIR "httrack_${arch}_$ver.exe")
+        Write-Host "  $($setup.Name) ($([math]::Round($setup.Length/1MB,1)) MB)"
+
+        # The installer is a fourth binary with its own copy of the product name. Inno
+        # stamps 0.0.0.0 rather than failing, so assert what it actually wrote.
+        $v = $setup.VersionInfo
+        # Inno pads these fields with trailing spaces, so trim before comparing.
+        $pn = "$($v.ProductName)".Trim()
+        $pv = "$($v.ProductVersion)".Trim()
+        Write-Host "  ProductName='$pn' ProductVersion='$pv'"
+        if ($pn -ne 'HTTrack Website Copier') { throw "the installer names the product '$pn'" }
+        if ($pv -ne $ver) { throw "the installer is version '$pv', not '$ver'" }
+
+        "version=$ver" | Out-File -Append $env:GITHUB_OUTPUT
+        "setup=$($setup.FullName)" | Out-File -Append $env:GITHUB_OUTPUT

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,146 @@
+# Install the installer, run the thing, uninstall it. Until this existed nothing had
+# ever executed: the manifest bug that stopped the exe from starting got through a
+# fully green build, because a compiler cannot tell you whether Windows will load the
+# binary. Shared so that the signing run tests the installer it is about to publish
+# exactly as the build run tests the unsigned one.
+name: Smoke-test the installer
+description: Install WinHTTrack silently, run the GUI and the CLI, then uninstall.
+
+inputs:
+  setup:
+    description: The installer to test.
+    required: true
+  version:
+    description: The version every binary must report.
+    required: true
+  thumbprint:
+    description: When set, every signature must be valid, timestamped, and this certificate's.
+    default: ''
+  install-dir:
+    description: Where to install.
+    default: C:\WinHTTrackTest
+
+runs:
+  using: composite
+  steps:
+    - shell: pwsh
+      env:
+        SETUP: ${{ inputs.setup }}
+        APPVER: ${{ inputs.version }}
+        THUMBPRINT: ${{ inputs.thumbprint }}
+        INSTALL_DIR: ${{ inputs.install-dir }}
+      run: |
+        $setup = Get-Item $env:SETUP
+        $dir = $env:INSTALL_DIR
+        # Without this, an empty version would make [regex]::Escape('') = '' and
+        # `-notmatch ''` false: every version assertion below would stop asserting.
+        if ([string]::IsNullOrWhiteSpace($env:APPVER)) { throw 'no version was passed: the version checks would be vacuous' }
+
+        # A catalog-signed file reports Microsoft as its signer whatever is embedded in
+        # it, so the thumbprint is the only assertion that cannot pass by accident.
+        function Test-Signature($path) {
+          $name = Split-Path $path -Leaf
+          $sig = Get-AuthenticodeSignature $path
+          if ($sig.Status -ne 'Valid') { return "$name is $($sig.Status), not Valid" }
+          if ($sig.SignerCertificate.Thumbprint -ne $env:THUMBPRINT) {
+            return "$name is signed by $($sig.SignerCertificate.Thumbprint), not $env:THUMBPRINT"
+          }
+          # A missing countersignature stays invisible until the certificate expires and
+          # every installer ever downloaded goes bad at once.
+          if (-not $sig.TimeStamperCertificate) { return "$name carries no RFC 3161 timestamp" }
+          Write-Host "  $name signed by $($sig.SignerCertificate.Subject), timestamped by $($sig.TimeStamperCertificate.Subject)"
+          return $null
+        }
+
+        if ($env:THUMBPRINT) {
+          $bad = Test-Signature $setup.FullName
+          if ($bad) { throw $bad }
+        }
+
+        $p = Start-Process $setup.FullName -Wait -PassThru -ArgumentList `
+          '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$dir","/LOG=$PWD\install.log"
+        if ($p.ExitCode -ne 0) { throw "installer exited $($p.ExitCode)" }
+
+        $exe = "$dir\WinHTTrack.exe"
+        if (-not (Test-Path $exe)) { throw "installer did not place WinHTTrack.exe" }
+
+        # Everything laid down, including the uninstaller Inno generates and the OpenSSL
+        # and zlib DLLs. Signing them is worth nothing if packaging then loses it.
+        if ($env:THUMBPRINT) {
+          $pes = @(Get-ChildItem $dir -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+          Write-Host "--- signatures on the $($pes.Count) installed binaries ---"
+          if ($pes.Count -lt 5) { throw "only $($pes.Count) binaries were installed: the check below would prove nothing" }
+          $bad = @($pes | ForEach-Object { Test-Signature $_.FullName } | Where-Object { $_ })
+          if ($bad) { throw ($bad -join "`n") }
+        }
+
+        # THE test. A non-zero exit here means the binary does not start: a bad
+        # manifest, a DLL that will not resolve, a broken install. All of which
+        # a green compile happily allows.
+        $p = Start-Process $exe -ArgumentList '--version' -Wait -PassThru `
+               -RedirectStandardOutput "$PWD\version.txt"
+        $out = (Get-Content "$PWD\version.txt" -Raw).Trim()
+        Write-Host "WinHTTrack.exe --version -> exit=$($p.ExitCode), output='$out'"
+        if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --version exited $($p.ExitCode): it does not start" }
+        if ($out -notmatch [regex]::Escape($env:APPVER)) { throw "expected version $env:APPVER, got '$out'" }
+        # --version only proves the binary LOADS: it exits before any data file is
+        # touched. That is exactly why a missing lang.def shipped. --selftest runs
+        # the real startup, through LANG_INIT, and exits before showing a window.
+        $report = Join-Path $env:TEMP 'WinHTTrack-exception.txt'
+        Remove-Item $report -ErrorAction SilentlyContinue
+        $p = Start-Process $exe -ArgumentList '--selftest' -Wait -PassThru `
+               -RedirectStandardOutput "$PWD\selftest.txt" -RedirectStandardError "$PWD\selftest.err"
+        $so = (Get-Content "$PWD\selftest.txt" -Raw -ErrorAction SilentlyContinue)
+        $se = (Get-Content "$PWD\selftest.err" -Raw -ErrorAction SilentlyContinue)
+        Write-Host "WinHTTrack.exe --selftest -> exit=$($p.ExitCode)"
+        if ($so) { Write-Host "  stdout: $($so.Trim())" }
+        if ($se) { Write-Host "  stderr: $($se.Trim())" }
+        if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
+        if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
+        # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into
+        # a dialog. --selftest exercises it; assert it actually RAN, or the check silently
+        # skips (its ANSI-codepage guard) and proves nothing.
+        if ("$so" -notmatch 'MBCS->UTF-8 ok') {
+          throw "selftest did not exercise the MBCS->UTF-8 conversion"
+        }
+        # Guards the empty-name terminator (newlang.h); losing it hangs the first-run About
+        # box. [1-9] not \d: "after 0 entries" would pass while proving nothing.
+        if ("$so" -notmatch 'language list ends after [1-9]\d* entries') {
+          throw "selftest did not check that the language list terminates"
+        }
+
+        # --selftest throws one exception on purpose. A crash report that resolves nothing
+        # is indistinguishable from a working one until someone needs it, so assert the
+        # whole chain here: first-chance hook -> shipped PDB -> function, file and line.
+        if (-not (Test-Path $report)) { throw "no crash report written: the first-chance hook never ran" }
+        $trace = Get-Content $report -Raw
+        Write-Host "--- crash report ---`n$trace"
+        if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
+        # Anchored past the "throw site" header on purpose: CrashReportLogException is
+        # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
+        # the fallback stack and would still be green with the hook dead.
+        if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
+          throw "no file:line on the throw stack: the shipped PDB carries no line info"
+        }
+
+        # The CLI is a separate binary against the same DLL: it can be broken while the
+        # GUI is fine. -#h prints the version and exits 0.
+        $cli = Join-Path $dir 'httrack.exe'
+        if (-not (Test-Path $cli)) { throw "the installer did not lay down httrack.exe" }
+        $p = Start-Process $cli -ArgumentList '-#h' -Wait -PassThru `
+               -RedirectStandardOutput "$PWD\cli.txt" -RedirectStandardError "$PWD\cli.err"
+        $co = (Get-Content "$PWD\cli.txt" -Raw -ErrorAction SilentlyContinue)
+        $co1 = ("$co".Trim() -split "\r?\n" | Select-Object -First 1)
+        Write-Host "httrack.exe -#h -> exit=$($p.ExitCode), output='$co1'"
+        if ($p.ExitCode -ne 0) { throw "httrack.exe -#h exited $($p.ExitCode)" }
+        if ($co -notmatch [regex]::Escape($env:APPVER)) {
+          throw "httrack.exe reported no version, or the wrong one: expected $env:APPVER"
+        }
+
+        Write-Host "::notice::WinHTTrack $env:APPVER installs, starts and runs ($($setup.Name))."
+
+        $unins = Get-ChildItem "$dir\unins*.exe" | Select-Object -First 1
+        $p = Start-Process $unins.FullName -Wait -PassThru -ArgumentList '/VERYSILENT','/NORESTART'
+        if ($p.ExitCode -ne 0) { throw "uninstaller exited $($p.ExitCode)" }
+        Start-Sleep -Seconds 3
+        if (Test-Path $exe) { throw "uninstall left WinHTTrack.exe behind" }

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -108,6 +108,11 @@ runs:
         if ("$so" -notmatch 'language list ends after [1-9]\d* entries') {
           throw "selftest did not check that the language list terminates"
         }
+        # lang.indexes counts from LANGUAGE_1 and our indices from 0: an unchecked
+        # off-by-one would seed the first run in the neighbouring language.
+        if ("$so" -notmatch 'lang\.indexes offset checked on [1-9]\d* locales') {
+          throw "selftest did not check the lang.indexes offset"
+        }
 
         # --selftest throws one exception on purpose. A crash report that resolves nothing
         # is indistinguishable from a working one until someone needs it, so assert the

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -16,6 +16,9 @@ inputs:
   thumbprint:
     description: When set, every signature must be valid, timestamped, and this certificate's.
     default: ''
+  require-signature:
+    description: "'true' to demand a thumbprint: signing must never be skipped just because one was not passed."
+    default: 'false'
   install-dir:
     description: Where to install.
     default: C:\WinHTTrackTest
@@ -28,6 +31,7 @@ runs:
         SETUP: ${{ inputs.setup }}
         APPVER: ${{ inputs.version }}
         THUMBPRINT: ${{ inputs.thumbprint }}
+        REQUIRE_SIG: ${{ inputs.require-signature }}
         INSTALL_DIR: ${{ inputs.install-dir }}
       run: |
         $setup = Get-Item $env:SETUP
@@ -35,6 +39,10 @@ runs:
         # Without this, an empty version would make [regex]::Escape('') = '' and
         # `-notmatch ''` false: every version assertion below would stop asserting.
         if ([string]::IsNullOrWhiteSpace($env:APPVER)) { throw 'no version was passed: the version checks would be vacuous' }
+        # Skipping the signature checks is the normal shape on every unsigned build,
+        # so the release path has to say out loud that it expects them.
+        if ($env:REQUIRE_SIG -eq 'true' -and -not $env:THUMBPRINT) { throw 'signatures were required but no thumbprint was passed' }
+        if ($env:THUMBPRINT -and $env:THUMBPRINT -notmatch '^[0-9A-Fa-f]{40}$') { throw "'$env:THUMBPRINT' is not a 40-hex thumbprint" }
 
         # A catalog-signed file reports Microsoft as its signer whatever is embedded in
         # it, so the thumbprint is the only assertion that cannot pass by accident.
@@ -67,7 +75,7 @@ runs:
         # Everything laid down, including the uninstaller Inno generates and the OpenSSL
         # and zlib DLLs. Signing them is worth nothing if packaging then loses it.
         if ($env:THUMBPRINT) {
-          $pes = @(Get-ChildItem $dir -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+          $pes = @(Get-ChildItem $dir -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll' })
           Write-Host "--- signatures on the $($pes.Count) installed binaries ---"
           if ($pes.Count -lt 5) { throw "only $($pes.Count) binaries were installed: the check below would prove nothing" }
           $bad = @($pes | ForEach-Object { Test-Signature $_.FullName } | Where-Object { $_ })

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -466,9 +466,8 @@ jobs:
           Write-Host "--- package contents ---"
           Get-ChildItem $bin | ForEach-Object { Write-Host "  $($_.Name)" }
 
-      # Self-imposed, and worth keeping now that no CA enforces it: every shipped
-      # binary and the installer must name one product and one version, or a user
-      # cannot tell what they have. Cheap here, embarrassing after publishing.
+      # Self-imposed now that no CA enforces it: every shipped binary and the
+      # installer must agree on product name and version. Cheap to catch here.
       - name: Check the binaries agree on product name and version
         shell: pwsh
         run: |
@@ -534,7 +533,6 @@ jobs:
           version: ${{ steps.installer.outputs.version }}
 
       - name: Upload the installer
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: httrack-setup-${{ matrix.platform }}
@@ -581,30 +579,30 @@ jobs:
       MSI_URL: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.4.92/SimplySignDesktop-9.4.4.92-64-bit-en.msi
       MSI_SHA256: 8ec420fc27798b86078b7bd02fe7152097e1b3005bab51820eaca8e57df84da3
     steps:
+      # An empty value would check out the engine's master instead, silently
+      # packaging sources that never went through the build job.
+      - name: Check the engine SHA came through
+        shell: pwsh
+        run: |
+          if ('${{ needs.build.outputs.engine-sha }}' -notmatch '^[0-9a-f]{40}$') {
+            throw 'the build job recorded no engine SHA'
+          }
+
       - name: Checkout httrack-windows
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: httrack-windows
 
       # The installer packs both source trees as well as the binaries (HTTrack is
-      # GPL), so the sign job needs the same two checkouts the build job had.
+      # GPL), so the sign job needs the same two checkouts the build job had. At
+      # the exact commit that was built, not at whatever the ref resolves to now.
       - name: Checkout httrack engine (sibling)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: xroche/httrack
-          ref: ${{ vars.HTTRACK_ENGINE_REF }}
+          ref: ${{ needs.build.outputs.engine-sha }}
           path: httrack
           submodules: recursive
-
-      - name: Check the engine is the tree that was built
-        shell: pwsh
-        run: |
-          $sha = (git -C httrack rev-parse HEAD).Trim()
-          $want = '${{ needs.build.outputs.engine-sha }}'
-          # The ref is a pinned SHA on tags, so this can only differ if it moved
-          # under us -- in which case we would be signing untested sources.
-          if ($sha -ne $want) { throw "the engine moved: the binaries are from $want, this tree is $sha" }
-          Write-Host "engine $sha"
 
       # The very binaries the build job smoke-tested, rather than a fresh compile.
       - name: Download the tested binaries
@@ -660,13 +658,15 @@ jobs:
       - name: Sign the binaries
         shell: pwsh
         run: |
-          foreach ($d in Get-ChildItem payload -Directory) {
+          # Nothing downstream would notice this loop running zero times: it would
+          # sign nothing and exit 0.
+          $dirs = @(Get-ChildItem payload -Directory)
+          if ($dirs.Count -ne 2) { throw "expected both architectures under payload\, found $($dirs.Count)" }
+          foreach ($d in $dirs) {
             # Sign what is there rather than a fixed list: OpenSSL is libssl-3.dll on
-            # x86 but libssl-3-x64.dll on x64, so a hardcoded set is wrong on one leg.
-            # The OpenSSL, zlib, zstd and brotli DLLs are signed too: we build them
-            # from source, they ship with our name on the installer, and Certum sets
-            # no rule against it.
-            $pes = @(Get-ChildItem $d.FullName -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+            # x86 but libssl-3-x64.dll on x64. Recursive because the installer packs
+            # subdirectories, so a PE below the top level would otherwise ship unsigned.
+            $pes = @(Get-ChildItem $d.FullName -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll' })
             foreach ($f in 'WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll') {
               if ($f -notin $pes.Name) { throw "$($d.Name) has no $f to sign" }
             }
@@ -727,6 +727,7 @@ jobs:
           setup: ${{ steps.x64.outputs.setup }}
           version: ${{ steps.x64.outputs.version }}
           thumbprint: ${{ env.THUMBPRINT }}
+          require-signature: 'true'
 
       - name: Install it, run it, uninstall it (x86)
         uses: ./httrack-windows/.github/actions/smoke-test
@@ -734,6 +735,7 @@ jobs:
           setup: ${{ steps.x86.outputs.setup }}
           version: ${{ steps.x86.outputs.version }}
           thumbprint: ${{ env.THUMBPRINT }}
+          require-signature: 'true'
 
       - name: Upload the signed installers
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -13,12 +13,16 @@ on:
     tags: ['[0-9]*', 'v*']
   pull_request:
   workflow_dispatch:
+    inputs:
+      sign:
+        # A rehearsal for the release: the signing job is otherwise only reachable
+        # by tagging, which is a poor place to discover that it does not work.
+        description: Run the signing job too (needs approval, and spends signatures)
+        type: boolean
+        default: false
 
 permissions:
   contents: read
-  # SignPath's GitHub app fetches the artifact and the run's metadata from GitHub's
-  # own API rather than trusting the build script, so it has to be able to read them.
-  actions: read
 
 jobs:
   # Cheap guard for the rules .gitattributes cannot enforce on its own.
@@ -154,6 +158,9 @@ jobs:
 
   build:
     runs-on: windows-2022
+    outputs:
+      # Both legs record the same value, so the matrix overwriting it is harmless.
+      engine-sha: ${{ steps.provenance.outputs.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -177,6 +184,7 @@ jobs:
           submodules: recursive
 
       - name: Record engine provenance
+        id: provenance
         shell: pwsh
         # Via env, not ${{ }} interpolation: a value containing $(...) would otherwise run.
         env:
@@ -185,7 +193,7 @@ jobs:
         run: |
           $sha = (git -C httrack rev-parse HEAD).Trim()
           Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='$env:ENGINE_REF')"
-          "ENGINE_SHA=$sha" | Out-File -Append $env:GITHUB_ENV
+          "sha=$sha" | Out-File -Append $env:GITHUB_OUTPUT
           # Two thirds of what we sign is built from the engine tree, so a tag that floats
           # cannot say what it shipped. A branch name is not a pin, so require a full SHA.
           if ($env:GH_REF -like 'refs/tags/*' -and $env:ENGINE_REF -notmatch '^[0-9a-f]{40}$') {
@@ -458,8 +466,9 @@ jobs:
           Write-Host "--- package contents ---"
           Get-ChildItem $bin | ForEach-Object { Write-Host "  $($_.Name)" }
 
-      # Signing enforces this: a mismatch fails the signing request on release day, not
-      # the build. Assert it here, where the only cost is a red build.
+      # Self-imposed, and worth keeping now that no CA enforces it: every shipped
+      # binary and the installer must name one product and one version, or a user
+      # cannot tell what they have. Cheap here, embarrassing after publishing.
       - name: Check the binaries agree on product name and version
         shell: pwsh
         run: |
@@ -508,271 +517,24 @@ jobs:
             --min-severity moderate --accept "$env:ACCEPTED" @expectArg
           if ($LASTEXITCODE -ne 0) { throw 'native dependency check failed' }
 
-      # Code signing, 1 of 2: the payload. SignPath signs an Inno installer as an opaque
-      # PE and cannot reach the files inside it, so sign these BEFORE ISCC packages them.
-      # Dormant until SIGNPATH_ORGANIZATION_ID exists, then tags only: releases need a
-      # human to approve each request. See SIGNING.md.
-      - name: Collect the binaries to sign
-        id: collect
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        shell: pwsh
-        run: |
-          $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
-          New-Item -ItemType Directory -Force unsigned | Out-Null
-          # Ours only. SignPath's code of conduct: "upstream OSS projects' binaries must
-          # not be signed using your subscription, but may be included in signed packages".
-          # So OpenSSL and zlib ship unsigned inside the signed installer, even though we
-          # do build them from source -- the rule is about who maintains the sources.
-          $ours = @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')
-          foreach ($f in $ours) {
-            $p = Join-Path $bin $f
-            if (-not (Test-Path $p)) { throw "nothing to sign: $f is missing" }
-            Copy-Item $p unsigned
-          }
-          Get-ChildItem unsigned | ForEach-Object { Write-Host "  will sign $($_.Name)" }
-
-      - name: Upload the unsigned binaries
-        id: unsigned-binaries
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: unsigned-binaries-${{ matrix.platform }}
-          path: unsigned/*
-          if-no-files-found: error
-
-      - name: Sign the binaries
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: winhttrack
-          signing-policy-slug: release-signing
-          artifact-configuration-slug: binaries
-          github-artifact-id: ${{ steps.unsigned-binaries.outputs.artifact-id }}
-          wait-for-completion: true
-          # Waits on a human clicking approve in SignPath's UI: give that a morning.
-          wait-for-completion-timeout-in-seconds: 14400
-          output-artifact-directory: signed
-
-      - name: Put the signed binaries back into the package
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        shell: pwsh
-        run: |
-          $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
-          # Enumerate once, recursively: SignPath may return a nested layout, and a flat
-          # glob would then copy nothing while every later step still calls these signed.
-          $files = @(Get-ChildItem 'signed' -Recurse -Include *.exe, *.dll -File)
-          # Assert the expected set by name. Validating only what came back passes happily
-          # when SignPath returns two of three, leaving the third unsigned in the installer.
-          $expected = @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')
-          $missing = $expected | Where-Object { $_ -notin $files.Name }
-          if ($missing) { throw "SignPath did not return: $($missing -join ', ')" }
-          foreach ($f in $files) {
-            $sig = Get-AuthenticodeSignature $f.FullName
-            Write-Host "  $($f.Name): $($sig.Status) $($sig.SignerCertificate.Subject)"
-            if ($sig.Status -ne 'Valid') { throw "$($f.Name) came back $($sig.Status), not Valid" }
-          }
-          $files | Copy-Item -Destination $bin -Force
-          Write-Host "::notice::signed $($files.Count) binaries"
-
-      # Build the installer, install it, and run the thing. Until now nothing had
-      # ever executed: the manifest bug that stopped the exe from starting got
-      # through a fully green build, because a compiler cannot tell you whether
-      # Windows will load the binary. --version answers that in one exit code.
       - name: Build the installer
-        shell: pwsh
-        run: |
-          $arch = if ('${{ matrix.platform }}' -eq 'x64') { 'x64' } else { 'x86' }
-
-          # Single source of truth for the version: the engine's own header.
-          $hg = Get-Content 'httrack\src\htsglobal.h' -Raw
-          if ($hg -notmatch '#define\s+HTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSION' }
-          $ver = $Matches[1]
-          # Inno stamps 0.0.0.0 unless it gets a valid version number, and "3.49-12" is not one.
-          if ($hg -notmatch '#define\s+HTTRACK_VERSIONID\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSIONID' }
-          $verid = $Matches[1]
-          Write-Host "version = $ver ($verid), arch = $arch"
-          "APPVER=$ver" | Out-File -Append $env:GITHUB_ENV
-          "SETUPARCH=$arch" | Out-File -Append $env:GITHUB_ENV
-
-          # The VC++ runtime, bundled so a clean machine can actually start the app.
-          # vs/17 is the VS2022 line (14.4x). NOT vs/18: the 14.5x redistributable
-          # refuses to install on Windows 7, which is still our floor.
-          $redist = "$PWD\vc_redist.$arch.exe"
-          Invoke-WebRequest "https://aka.ms/vs/17/release/vc_redist.$arch.exe" -OutFile $redist
-          if ((Get-Item $redist).Length -lt 1MB) { throw 'vc_redist download looks wrong' }
-
-          # Bundled into a signed installer and run elevated, so verify who produced the
-          # bytes: aka.ms redirects, and TLS only authenticates the host we fetched from.
-          $sig = Get-AuthenticodeSignature $redist
-          if ($sig.Status -ne 'Valid') { throw "vc_redist signature is $($sig.Status)" }
-          if ($sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
-            throw "vc_redist signed by an unexpected party: $($sig.SignerCertificate.Subject)"
-          }
-          Write-Host "vc_redist signer verified: $($sig.SignerCertificate.Subject)"
-
-          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
-          if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress | Out-Null }
-          if (-not (Test-Path $iscc)) { throw 'Inno Setup is not available' }
-
-          # ISCC fails if any Source: is missing, so a clean compile also proves the
-          # redistributable really is in the package.
-          & $iscc /Q `
-            "/DArch=$arch" "/DAppVersion=$ver" "/DAppVersionNumeric=$verid" `
-            "/DPayloadDir=$PWD\httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}" `
-            "/DEngineDir=$PWD\httrack" `
-            "/DGuiDir=$PWD\httrack-windows" `
-            "/DRedistFile=$redist" `
-            "/DOutDir=$PWD\installer" `
-            "httrack-windows\InnoSetup\httrack.iss"
-          if ($LASTEXITCODE -ne 0) { throw "ISCC failed ($LASTEXITCODE)" }
-          Get-ChildItem "$PWD\installer" | ForEach-Object { Write-Host "  $($_.Name) ($([math]::Round($_.Length/1MB,1)) MB)" }
-
-          # The installer is a fourth binary, with its own copy of the product name, and it
-          # gets signed too. Inno stamps 0.0.0.0 rather than failing, so assert what it wrote.
-          $setup = Get-ChildItem "$PWD\installer\*.exe" | Select-Object -First 1
-          $v = (Get-Item $setup.FullName).VersionInfo
-          # Inno pads these fields with trailing spaces, so trim before comparing.
-          $pn = "$($v.ProductName)".Trim()
-          $pv = "$($v.ProductVersion)".Trim()
-          Write-Host "  $($setup.Name) : ProductName='$pn' ProductVersion='$pv'"
-          if ($pn -ne 'HTTrack Website Copier') { throw "the installer names the product '$pn'" }
-          if ($pv -ne $ver) { throw "the installer is version '$pv', not '$ver'" }
-
-      # Code signing, 2 of 2: the wrapper the user downloads, which is what SmartScreen
-      # and UAC judge. Before the smoke test, so that what runs below is what ships.
-      - name: Upload the unsigned installer
-        id: unsigned-installer
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        id: installer
+        uses: ./httrack-windows/.github/actions/build-installer
         with:
-          name: unsigned-installer-${{ matrix.platform }}
-          path: installer/*.exe
-          if-no-files-found: error
-
-      - name: Sign the installer
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: winhttrack
-          signing-policy-slug: release-signing
-          artifact-configuration-slug: installer
-          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
-          wait-for-completion: true
-          wait-for-completion-timeout-in-seconds: 14400
-          output-artifact-directory: installer
-
-      - name: Check the installer really is signed
-        if: ${{ vars.SIGNPATH_ORGANIZATION_ID != '' && startsWith(github.ref, 'refs/tags/') }}
-        shell: pwsh
-        run: |
-          $setup = Get-ChildItem "$PWD\installer\*.exe" | Select-Object -First 1
-          $sig = Get-AuthenticodeSignature $setup.FullName
-          Write-Host "$($setup.Name): $($sig.Status)"
-          Write-Host "  signer:    $($sig.SignerCertificate.Subject)"
-          Write-Host "  timestamp: $($sig.TimeStamperCertificate.Subject)"
-          if ($sig.Status -ne 'Valid') { throw "the installer is $($sig.Status), not Valid" }
-          # SignPath timestamps for us, so nothing here proves it did. A missing counter-
-          # signature stays invisible until the cert expires and every installer goes bad.
-          if (-not $sig.TimeStamperCertificate) { throw "the signature carries no RFC 3161 timestamp" }
-          Write-Host "::notice::$($setup.Name) is signed by $($sig.SignerCertificate.Subject)"
+          payload-dir: ${{ github.workspace }}\httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}
+          engine-dir: ${{ github.workspace }}\httrack
+          gui-dir: ${{ github.workspace }}\httrack-windows
+          arch: ${{ matrix.platform == 'x64' && 'x64' || 'x86' }}
+          out-dir: ${{ github.workspace }}\installer
 
       - name: Install it, run it, uninstall it
-        shell: pwsh
-        run: |
-          $setup = Get-ChildItem "$PWD\installer\*.exe" | Select-Object -First 1
-          $dir = 'C:\WinHTTrackTest'
-
-          $p = Start-Process $setup.FullName -Wait -PassThru -ArgumentList `
-            '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$dir","/LOG=$PWD\install.log"
-          if ($p.ExitCode -ne 0) { throw "installer exited $($p.ExitCode)" }
-
-          $exe = "$dir\WinHTTrack.exe"
-          if (-not (Test-Path $exe)) { throw "installer did not place WinHTTrack.exe" }
-
-          # THE test. A non-zero exit here means the binary does not start: a bad
-          # manifest, a DLL that will not resolve, a broken install. All of which
-          # a green compile happily allows.
-          $p = Start-Process $exe -ArgumentList '--version' -Wait -PassThru `
-                 -RedirectStandardOutput "$PWD\version.txt"
-          $out = (Get-Content "$PWD\version.txt" -Raw).Trim()
-          Write-Host "WinHTTrack.exe --version -> exit=$($p.ExitCode), output='$out'"
-          if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --version exited $($p.ExitCode): it does not start" }
-          # Without this, an empty APPVER would make [regex]::Escape('') = '' and
-          # `-notmatch ''` false: the version assertion would quietly stop asserting.
-          if ([string]::IsNullOrWhiteSpace($env:APPVER)) { throw 'APPVER is unset: the version check would be vacuous' }
-          if ($out -notmatch [regex]::Escape($env:APPVER)) { throw "expected version $env:APPVER, got '$out'" }
-          # --version only proves the binary LOADS: it exits before any data file is
-          # touched. That is exactly why a missing lang.def shipped. --selftest runs
-          # the real startup, through LANG_INIT, and exits before showing a window.
-          $report = Join-Path $env:TEMP 'WinHTTrack-exception.txt'
-          Remove-Item $report -ErrorAction SilentlyContinue
-          $p = Start-Process $exe -ArgumentList '--selftest' -Wait -PassThru `
-                 -RedirectStandardOutput "$PWD\selftest.txt" -RedirectStandardError "$PWD\selftest.err"
-          $so = (Get-Content "$PWD\selftest.txt" -Raw -ErrorAction SilentlyContinue)
-          $se = (Get-Content "$PWD\selftest.err" -Raw -ErrorAction SilentlyContinue)
-          Write-Host "WinHTTrack.exe --selftest -> exit=$($p.ExitCode)"
-          if ($so) { Write-Host "  stdout: $($so.Trim())" }
-          if ($se) { Write-Host "  stderr: $($se.Trim())" }
-          if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
-          if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
-          # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into
-          # a dialog. --selftest exercises it; assert it actually RAN, or the check silently
-          # skips (its ANSI-codepage guard) and proves nothing.
-          if ("$so" -notmatch 'MBCS->UTF-8 ok') {
-            throw "selftest did not exercise the MBCS->UTF-8 conversion"
-          }
-          # Guards the empty-name terminator (newlang.h); losing it hangs the first-run About
-          # box. [1-9] not \d: "after 0 entries" would pass while proving nothing.
-          if ("$so" -notmatch 'language list ends after [1-9]\d* entries') {
-            throw "selftest did not check that the language list terminates"
-          }
-          # lang.indexes counts from LANGUAGE_1 and our indices from 0: an unchecked
-          # off-by-one would seed the first run in the neighbouring language.
-          if ("$so" -notmatch 'lang\.indexes offset checked on [1-9]\d* locales') {
-            throw "selftest did not check the lang.indexes offset"
-          }
-
-          # --selftest throws one exception on purpose. A crash report that resolves nothing
-          # is indistinguishable from a working one until someone needs it, so assert the
-          # whole chain here: first-chance hook -> shipped PDB -> function, file and line.
-          if (-not (Test-Path $report)) { throw "no crash report written: the first-chance hook never ran" }
-          $trace = Get-Content $report -Raw
-          Write-Host "--- crash report ---`n$trace"
-          if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
-          # Anchored past the "throw site" header on purpose: CrashReportLogException is
-          # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
-          # the fallback stack and would still be green with the hook dead.
-          if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
-            throw "no file:line on the throw stack: the shipped PDB carries no line info"
-          }
-
-          # The CLI is a separate binary against the same DLL: it can be broken while the
-          # GUI is fine. -#h prints the version and exits 0.
-          $cli = Join-Path $dir 'httrack.exe'
-          if (-not (Test-Path $cli)) { throw "the installer did not lay down httrack.exe" }
-          $p = Start-Process $cli -ArgumentList '-#h' -Wait -PassThru `
-                 -RedirectStandardOutput "$PWD\cli.txt" -RedirectStandardError "$PWD\cli.err"
-          $co = (Get-Content "$PWD\cli.txt" -Raw -ErrorAction SilentlyContinue)
-          $co1 = ("$co".Trim() -split "\r?\n" | Select-Object -First 1)
-          Write-Host "httrack.exe -#h -> exit=$($p.ExitCode), output='$co1'"
-          if ($p.ExitCode -ne 0) { throw "httrack.exe -#h exited $($p.ExitCode)" }
-          if ($co -notmatch [regex]::Escape($env:APPVER)) {
-            throw "httrack.exe reported no version, or the wrong one: expected $env:APPVER"
-          }
-
-          Write-Host "::notice::WinHTTrack $env:APPVER installs, starts and runs."
-
-          $unins = Get-ChildItem "$dir\unins*.exe" | Select-Object -First 1
-          $p = Start-Process $unins.FullName -Wait -PassThru -ArgumentList '/VERYSILENT','/NORESTART'
-          if ($p.ExitCode -ne 0) { throw "uninstaller exited $($p.ExitCode)" }
-          Start-Sleep -Seconds 3
-          if (Test-Path $exe) { throw "uninstall left WinHTTrack.exe behind" }
+        uses: ./httrack-windows/.github/actions/smoke-test
+        with:
+          setup: ${{ steps.installer.outputs.setup }}
+          version: ${{ steps.installer.outputs.version }}
 
       - name: Upload the installer
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: httrack-setup-${{ matrix.platform }}
@@ -796,3 +558,186 @@ jobs:
           name: msbuild-${{ matrix.platform }}-${{ matrix.configuration }}
           path: httrack-windows/msbuild.log
           if-no-files-found: ignore
+
+  # A GitHub environment gates a whole job, so signing cannot live in the build job:
+  # that job would carry the required-reviewer approval and every pull request would
+  # stop dead waiting for a click. One job for both architectures rather than a
+  # matrix, because a SimplySign session belongs to one machine and two runners would
+  # mint the same single-use TOTP code in the same window.
+  sign:
+    if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.sign }}
+    needs: build
+    runs-on: windows-2022
+    environment: signing
+    # Two tags pushed at once would fight over the signing session.
+    concurrency: certum-signing
+    permissions:
+      contents: read
+      # download-artifact reads this run's artifacts through the Actions API.
+      actions: read
+    env:
+      # Public material; the certificate itself is RSA-4096, valid to 2027-07-28.
+      THUMBPRINT: AEEE0C1672811FEBB33099FB433FC0D70E5B89C2
+      MSI_URL: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.4.92/SimplySignDesktop-9.4.4.92-64-bit-en.msi
+      MSI_SHA256: 8ec420fc27798b86078b7bd02fe7152097e1b3005bab51820eaca8e57df84da3
+    steps:
+      - name: Checkout httrack-windows
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: httrack-windows
+
+      # The installer packs both source trees as well as the binaries (HTTrack is
+      # GPL), so the sign job needs the same two checkouts the build job had.
+      - name: Checkout httrack engine (sibling)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: xroche/httrack
+          ref: ${{ vars.HTTRACK_ENGINE_REF }}
+          path: httrack
+          submodules: recursive
+
+      - name: Check the engine is the tree that was built
+        shell: pwsh
+        run: |
+          $sha = (git -C httrack rev-parse HEAD).Trim()
+          $want = '${{ needs.build.outputs.engine-sha }}'
+          # The ref is a pinned SHA on tags, so this can only differ if it moved
+          # under us -- in which case we would be signing untested sources.
+          if ($sha -ne $want) { throw "the engine moved: the binaries are from $want, this tree is $sha" }
+          Write-Host "engine $sha"
+
+      # The very binaries the build job smoke-tested, rather than a fresh compile.
+      - name: Download the tested binaries
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: WinHTTrack-*-Release
+          path: payload
+
+      - name: Locate signtool
+        shell: pwsh
+        run: |
+          $st = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
+                  Where-Object FullName -like '*\x64\*' | Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $st) { throw 'no signtool.exe in the Windows SDK' }
+          # On PATH because Inno's [SignTool] runs it by name too.
+          Add-Content -Path $env:GITHUB_PATH -Value $st.DirectoryName
+          Write-Host "signtool: $($st.FullName)"
+
+      - name: Install SimplySign Desktop
+        shell: pwsh
+        run: |
+          $msi = "$PWD\SimplySignDesktop.msi"
+          Invoke-WebRequest $env:MSI_URL -OutFile $msi
+          $got = (Get-FileHash $msi -Algorithm SHA256).Hash.ToLower()
+          if ($got -ne $env:MSI_SHA256) { throw "MSI is $got, not $env:MSI_SHA256" }
+
+          # It installs a virtual smart-card driver, so verify who produced the bytes.
+          $sig = Get-AuthenticodeSignature $msi
+          if ($sig.Status -ne 'Valid') { throw "MSI signature is $($sig.Status)" }
+          if ($sig.SignerCertificate.Subject -notmatch 'O=Asseco Data Systems S\.A\.') {
+            throw "MSI signed by an unexpected party: $($sig.SignerCertificate.Subject)"
+          }
+          Write-Host "MSI verified: $($sig.SignerCertificate.Subject)"
+
+          $p = Start-Process msiexec -Wait -PassThru -ArgumentList '/i', $msi, '/quiet', '/norestart'
+          # 3010 is "success, reboot required" -- fine, the driver loads anyway.
+          if ($p.ExitCode -notin 0, 3010) { throw "msiexec exited $($p.ExitCode)" }
+          $exe = 'C:\Program Files\Certum\SimplySign Desktop\SimplySignDesktop.exe'
+          if (-not (Test-Path $exe)) { throw "not where 9.4.4.92 installs: $exe" }
+          "SSD_EXE=$exe" | Out-File -Append $env:GITHUB_ENV
+
+      # Opens a two-hour window in which signtool can use the cloud key; everything
+      # below has to happen inside it.
+      - name: Sign in to SimplySign
+        shell: pwsh
+        env:
+          CERTUM_EMAIL: ${{ secrets.CERTUM_EMAIL }}
+          CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+        run: >
+          ./httrack-windows/tools/simplysign-login.ps1
+          -Exe "$env:SSD_EXE" -Thumbprint $env:THUMBPRINT
+
+      - name: Sign the binaries
+        shell: pwsh
+        run: |
+          foreach ($d in Get-ChildItem payload -Directory) {
+            # Sign what is there rather than a fixed list: OpenSSL is libssl-3.dll on
+            # x86 but libssl-3-x64.dll on x64, so a hardcoded set is wrong on one leg.
+            # The OpenSSL, zlib, zstd and brotli DLLs are signed too: we build them
+            # from source, they ship with our name on the installer, and Certum sets
+            # no rule against it.
+            $pes = @(Get-ChildItem $d.FullName -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+            foreach ($f in 'WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll') {
+              if ($f -notin $pes.Name) { throw "$($d.Name) has no $f to sign" }
+            }
+            Write-Host "--- $($d.Name): $($pes.Count) binaries ---"
+            foreach ($f in $pes) {
+              # Every file is a fresh call to the timestamp server; one hiccup should
+              # not cost a release.
+              for ($try = 1; ; $try++) {
+                signtool sign /sha1 $env:THUMBPRINT /fd sha256 /tr http://time.certum.pl /td sha256 $f.FullName
+                if ($LASTEXITCODE -eq 0) { break }
+                if ($try -ge 3) { throw "signtool exited $LASTEXITCODE on $($f.Name)" }
+                Start-Sleep -Seconds 15
+              }
+              $sig = Get-AuthenticodeSignature $f.FullName
+              if ($sig.SignerCertificate.Thumbprint -ne $env:THUMBPRINT) {
+                throw "$($f.Name) came back signed by $($sig.SignerCertificate.Thumbprint)"
+              }
+              if (-not $sig.TimeStamperCertificate) { throw "$($f.Name) carries no RFC 3161 timestamp" }
+              Write-Host "  signed $($f.Name)"
+            }
+          }
+
+      # Rebuilt from the signed binaries, because Inno packs them as opaque bytes:
+      # signing the installer afterwards would leave everything inside it unsigned.
+      # /DSign also gets the embedded uninstaller signed, which is the one file that
+      # could never be reached from outside.
+      - name: Build the signed installer (x64)
+        id: x64
+        uses: ./httrack-windows/.github/actions/build-installer
+        with:
+          payload-dir: ${{ github.workspace }}\payload\WinHTTrack-x64-Release
+          engine-dir: ${{ github.workspace }}\httrack
+          gui-dir: ${{ github.workspace }}\httrack-windows
+          arch: x64
+          out-dir: ${{ github.workspace }}\installer
+          sign: 'true'
+          thumbprint: ${{ env.THUMBPRINT }}
+
+      # Win32 is the platform the build job names; x86 is what the installer calls it.
+      - name: Build the signed installer (x86)
+        id: x86
+        uses: ./httrack-windows/.github/actions/build-installer
+        with:
+          payload-dir: ${{ github.workspace }}\payload\WinHTTrack-Win32-Release
+          engine-dir: ${{ github.workspace }}\httrack
+          gui-dir: ${{ github.workspace }}\httrack-windows
+          arch: x86
+          out-dir: ${{ github.workspace }}\installer
+          sign: 'true'
+          thumbprint: ${{ env.THUMBPRINT }}
+
+      # Same test the build job runs, over the file that will actually be published,
+      # plus the signatures: on the installer before it runs, and on everything it
+      # lays down afterwards.
+      - name: Install it, run it, uninstall it (x64)
+        uses: ./httrack-windows/.github/actions/smoke-test
+        with:
+          setup: ${{ steps.x64.outputs.setup }}
+          version: ${{ steps.x64.outputs.version }}
+          thumbprint: ${{ env.THUMBPRINT }}
+
+      - name: Install it, run it, uninstall it (x86)
+        uses: ./httrack-windows/.github/actions/smoke-test
+        with:
+          setup: ${{ steps.x86.outputs.setup }}
+          version: ${{ steps.x86.outputs.version }}
+          thumbprint: ${{ env.THUMBPRINT }}
+
+      - name: Upload the signed installers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: httrack-setup-signed
+          path: installer/*.exe
+          if-no-files-found: error

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -9,9 +9,9 @@
 ;        /DRedistFile=...\vc_redist.x64.exe /DOutDir=...\out ^
 ;        InnoSetup\httrack.iss
 ;
-; Signing is opt-in (/DSign) and off by default so unsigned CI builds work. The old
-; script hardcoded a .pfx on a personal drive and a Verisign timestamp URL that has
-; been dead for years; when signing returns it needs an RFC3161 one.
+; Signing is opt-in (/DSign) and off by default, so an ordinary CI build needs no
+; certificate. With it, ISCC signs setup.exe and the embedded uninstaller through the
+; sign tool the caller passes as /Scertum=signtool.exe sign ... $f.
 ;
 ; Replaces the old httrack.iss + httrack-x64.iss pair. They had drifted apart, and
 ; both referenced files that no longer exist (readme, copying, file_id.diz, src_win).
@@ -61,6 +61,7 @@ ArchitecturesAllowed=x64compatible
 #endif
 #ifdef Sign
 SignedUninstaller=yes
+SignTool=certum
 #else
 SignedUninstaller=no
 #endif

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -27,7 +27,7 @@ Every executable file in the package:
 | `WinHTTrack.exe` | the GUI |
 | `httrack.exe` | the command-line version |
 | `libhttrack.dll` | the engine, built from [xroche/httrack](https://github.com/xroche/httrack) |
-| `libcrypto-*.dll`, `libssl-*.dll`, `z.dll`, `zstd.dll`, `brotli*.dll` | OpenSSL, zlib, zstd and brotli, compiled from source during the build |
+| the other DLLs beside it | OpenSSL, zlib and the compression libraries, compiled from source during the build |
 | `httrack_*_*.exe` | the Inno Setup installer |
 | `unins000.exe` | the uninstaller it leaves behind |
 
@@ -35,8 +35,8 @@ Every executable file in the package:
 
 Only one thing ever signs a WinHTTrack binary: the
 [`windows-build`](.github/workflows/windows-build.yml) workflow, on a GitHub-hosted
-runner, in the `xroche/httrack-windows` repository, on a version tag. There is no key on
-a developer's machine to sign with. The signing job runs in a GitHub environment that
+runner, in the `xroche/httrack-windows` repository, on a version tag or on a run a
+maintainer starts by hand. There is no key on a developer's machine to sign with. The signing job runs in a GitHub environment that
 requires a human approval before it starts, so pushing a tag does not by itself sign
 anything.
 

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -3,75 +3,67 @@
 WinHTTrack's Windows binaries and its installer carry an Authenticode signature, so that
 Windows names a verified publisher instead of warning you about an unknown one.
 
-## Attribution
+## Who signs
 
-Free code signing provided by [SignPath.io](https://signpath.io), certificate by
-[SignPath Foundation](https://signpath.org).
+The certificate is a Certum Open Source Code Signing certificate, issued to Xavier Roche,
+who writes HTTrack. Certum prefixes every certificate of that kind, so the publisher
+Windows shows reads *Open Source Developer, Xavier Roche*. The private key lives in
+Certum's cloud HSM and cannot be exported from it.
 
-The certificate belongs to SignPath Foundation, not to HTTrack or to its author. SignPath
-is not a certificate authority, so it cannot issue a certificate in anyone else's name.
-Windows will therefore show *SignPath Foundation* as the publisher of a signed WinHTTrack
-installer. That is expected, and many other open-source projects sign the same way.
+| | |
+| --- | --- |
+| Subject | `CN=Open Source Developer Roche Xavier, L=Paris, C=FR` |
+| SHA-1 thumbprint | `AEEE0C1672811FEBB33099FB433FC0D70E5B89C2` |
+| Key | RSA 4096, signatures are SHA-256 |
+| Timestamps | `http://time.certum.pl`, RFC 3161 |
+| Valid | 2026-07-28 to 2027-07-28 |
 
 ## What is signed
 
-The code we maintain ourselves, and the installer that carries it:
+Every executable file in the package:
 
 | File | What it is |
 | --- | --- |
 | `WinHTTrack.exe` | the GUI |
 | `httrack.exe` | the command-line version |
 | `libhttrack.dll` | the engine, built from [xroche/httrack](https://github.com/xroche/httrack) |
+| `libcrypto-*.dll`, `libssl-*.dll`, `z.dll`, `zstd.dll`, `brotli*.dll` | OpenSSL, zlib, zstd and brotli, compiled from source during the build |
 | `httrack_*_*.exe` | the Inno Setup installer |
-
-Two things inside that installer stay unsigned, on purpose.
-
-The OpenSSL and zlib DLLs (`libssl-*.dll`, `libcrypto-*.dll`, `z.dll`) belong to their own
-upstream projects. We compile them from source during the build, but we do not maintain
-their code, and SignPath's code of conduct is clear that a project signs only binaries
-built from source its own team maintains. Upstream libraries may travel unsigned inside a
-signed package, so that is how they travel here.
-
-The uninstaller that Inno Setup embeds (`unins000.exe`) is the other one. Inno can only
-sign it by calling out to a `signtool`-style helper while it compiles, and SignPath's
-submission API does not work that way. The installer you actually download and double-click
-is signed, and that is the file Windows judges.
-
-## Team roles
-
-One person maintains HTTrack, and he holds all three SignPath roles:
-
-| Role | Who |
-| --- | --- |
-| Author (submits a signing request) | the GitHub Actions CI user, never a human |
-| Reviewer | Xavier Roche |
-| Approver | Xavier Roche |
-
-Anyone who is not a committer contributes through a pull request, which is reviewed before
-it merges. Everyone with write access to the source repositories uses multi-factor
-authentication on both GitHub and SignPath.
+| `unins000.exe` | the uninstaller it leaves behind |
 
 ## How signing happens
 
 Only one thing ever signs a WinHTTrack binary: the
-[`windows-build`](.github/workflows/windows-build.yml) workflow, on a GitHub-hosted runner,
-in the `xroche/httrack-windows` repository, on a version tag. Nobody can sign one from a
-developer's machine. The SignPath project uses origin verification, which means SignPath
-pulls the artifact and the build metadata from GitHub's own API instead of believing
-whatever the build script tells it, and it does not let interactive users submit artifacts
-at all.
+[`windows-build`](.github/workflows/windows-build.yml) workflow, on a GitHub-hosted
+runner, in the `xroche/httrack-windows` repository, on a version tag. There is no key on
+a developer's machine to sign with. The signing job runs in a GitHub environment that
+requires a human approval before it starts, so pushing a tag does not by itself sign
+anything.
 
-Signing takes two steps, because SignPath treats an Inno Setup installer as one opaque
-executable and cannot reach the files packed inside it:
+Every push and every pull request builds an installer, installs it, runs it and
+uninstalls it, unsigned. A tag adds a second job that takes those same binaries, signs
+each one, and rebuilds the installer around them. Inno Setup packs those binaries as
+opaque bytes, so signing the installer afterwards would leave everything inside it
+unsigned. The signed installer is then installed and run in turn, and every signature is
+checked against the thumbprint above before it is published.
 
-1. CI builds the binaries, then submits them to SignPath, which signs them;
-2. CI builds the installer from the signed binaries, then submits that, and SignPath signs
-   it in turn;
-3. CI installs, runs and uninstalls the signed installer, so the file it tests is the file
-   you get.
+## Verifying a signature
 
-Before either certificate is used, a human approves the request in SignPath's web
-interface.
+Right-click the installer, choose *Properties*, and open the *Digital Signatures* tab. Or
+from PowerShell:
+
+```powershell
+Get-AuthenticodeSignature .\httrack_x64_3.49-14.exe |
+  Format-List Status, SignerCertificate, TimeStamperCertificate
+```
+
+`Status` must say `Valid`, and the thumbprint must be the one above. The thumbprint is
+the part worth checking: any valid certificate at all produces `Valid`. The signatures
+carry an RFC 3161 timestamp, so they outlive the certificate that made them.
+
+Source releases of the engine are a separate matter: they are signed with the HTTrack PGP
+key `rsa4096/60C3AA7180598EFB`, which has nothing to do with Authenticode and is
+documented on [httrack.com](https://www.httrack.com/).
 
 ## Privacy policy
 
@@ -82,28 +74,12 @@ Copying a website is exactly such a request: when you give HTTrack a URL, it con
 site, and the sites it links to if you tell it to follow them. It sends nothing anywhere
 else, and it reports nothing back to us. HTTrack obeys `robots.txt` by default.
 
-## Verifying a signature
-
-Right-click the installer, choose *Properties*, and open the *Digital Signatures* tab. The
-signer should read SignPath Foundation, and the signature should be valid. From PowerShell:
-
-```powershell
-Get-AuthenticodeSignature .\httrack_x64_3.49.12.exe | Format-List Status, SignerCertificate
-```
-
-`Status` must say `Valid`. The signatures use SHA-256 and carry an RFC 3161 timestamp, so
-they survive the expiry of the certificate that made them.
-
-Source releases of the engine are a separate matter: they are signed with the HTTrack PGP
-key `rsa4096/60C3AA7180598EFB`, which has nothing to do with Authenticode and is documented
-on [httrack.com](https://www.httrack.com/).
-
 ## Reporting a problem
 
 Tell us if you think a WinHTTrack binary was signed that should not have been, or you find
 a signed binary that does not match the source it claims to come from. See
-[SECURITY.md](SECURITY.md). You can also report a serious case straight to SignPath
-Foundation, who can revoke the certificate.
+[SECURITY.md](SECURITY.md). A serious case can also go straight to Certum, who can revoke
+the certificate.
 
 ## Licence
 

--- a/tools/simplysign-login.ps1
+++ b/tools/simplysign-login.ps1
@@ -38,6 +38,7 @@ foreach ($kv in (($env:CERTUM_OTP_URI -replace '^[^?]*\??', '') -split '&')) {
     if ($p.Count -eq 2) { $q[$p[0].ToLower()] = [uri]::UnescapeDataString($p[1]) }
 }
 $secret = if ($q['secret']) { $q['secret'] } else { $env:CERTUM_OTP_URI }
+Write-Host "::add-mask::$secret"
 $alg = if ($q['algorithm']) { $q['algorithm'].ToUpper() } else { 'SHA1' }
 $digits = if ($q['digits']) { [int]$q['digits'] } else { 6 }
 $period = if ($q['period']) { [int]$q['period'] } else { 30 }
@@ -97,11 +98,10 @@ if ($proc.HasExited) { throw "SimplySign Desktop exited immediately (code $($pro
 $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
 Write-Host "desktop is $($b.Width)x$($b.Height), tray icon expected at $IconX,$IconY"
 if ($b.Width -ne 1024 -or $b.Height -ne 768) {
-    Write-Host "::warning::the icon coordinate was measured at 1024x768; this desktop differs, so the click may miss"
+    throw "the tray coordinate was measured on a 1024x768 desktop, and this one is $($b.Width)x$($b.Height)"
 }
 
-# The icon is visible rather than folded behind the chevron, and a double-click is
-# the gesture that opens the login window.
+# The icon is visible rather than folded behind the chevron.
 [M]::Double($IconX, $IconY)
 Start-Sleep -Seconds 6
 Show-TopLevel 'after the tray click'
@@ -117,7 +117,10 @@ $otp = Get-Otp
 Write-Host "::add-mask::$otp"
 
 $wshell = New-Object -ComObject WScript.Shell
-[void]$wshell.AppActivate($proc.Id)
+for ($try = 1; -not $wshell.AppActivate($proc.Id); $try++) {
+    if ($try -ge 3) { throw 'could not focus the login window: the keystrokes would go to whatever has focus' }
+    Start-Sleep -Seconds 2
+}
 Start-Sleep -Milliseconds 800
 $wshell.SendKeys("$(Protect-SendKeys $env:CERTUM_EMAIL){TAB}$otp{ENTER}")
 
@@ -129,7 +132,6 @@ do {
 } while (-not $cert -and (Get-Date) -lt $deadline)
 
 if (-not $cert) {
-    Show-TopLevel 'after typing'
     Write-Host "certificates in the store: $((Get-ChildItem Cert:\CurrentUser\My).Thumbprint -join ', ')"
     throw "$Thumbprint never appeared: the login was refused, or the code was wrong"
 }

--- a/tools/simplysign-login.ps1
+++ b/tools/simplysign-login.ps1
@@ -1,0 +1,137 @@
+# Log this runner into Certum SimplySign, so signtool can use the cloud key.
+#
+# SimplySign Desktop is a tray-only .NET application: no command line, no window, and
+# UI Automation cannot see inside the notification area (it enumerates the panes and
+# stops). The login dialog is therefore reachable only by clicking the tray icon at a
+# measured coordinate. Credentials come from the environment: CERTUM_EMAIL and
+# CERTUM_OTP_URI, the otpauth:// URI from the activation QR code.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Exe,
+    [Parameter(Mandatory)][string]$Thumbprint,
+    # Measured on the runner's 1024x768 desktop; x depends on how many icons are there.
+    [int]$IconX = 842,
+    [int]$IconY = 747
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $env:CERTUM_EMAIL) { throw 'CERTUM_EMAIL is empty' }
+if (-not $env:CERTUM_OTP_URI) { throw 'CERTUM_OTP_URI is empty' }
+
+function ConvertFrom-Base32([string]$s) {
+    $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+    $bits = -join (($s -replace '[=\s]', '').ToUpper().ToCharArray() | ForEach-Object {
+            $i = $alphabet.IndexOf($_)
+            if ($i -lt 0) { throw 'the seed is not valid base32' }
+            [Convert]::ToString($i, 2).PadLeft(5, '0')
+        })
+    [byte[]]@(for ($i = 0; $i + 8 -le $bits.Length; $i += 8) { [Convert]::ToByte($bits.Substring($i, 8), 2) })
+}
+
+# Honour the URI's own algorithm: Certum issues SHA-256 seeds, and a snippet that
+# assumes SHA-1 emits a wrong code silently, which looks exactly like a typing failure.
+$q = @{}
+foreach ($kv in (($env:CERTUM_OTP_URI -replace '^[^?]*\??', '') -split '&')) {
+    $p = $kv -split '=', 2
+    if ($p.Count -eq 2) { $q[$p[0].ToLower()] = [uri]::UnescapeDataString($p[1]) }
+}
+$secret = if ($q['secret']) { $q['secret'] } else { $env:CERTUM_OTP_URI }
+$alg = if ($q['algorithm']) { $q['algorithm'].ToUpper() } else { 'SHA1' }
+$digits = if ($q['digits']) { [int]$q['digits'] } else { 6 }
+$period = if ($q['period']) { [int]$q['period'] } else { 30 }
+
+function Get-Otp {
+    $key = ConvertFrom-Base32 $secret
+    $counter = [long][math]::Floor([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() / $period)
+    $cb = [BitConverter]::GetBytes($counter); [array]::Reverse($cb)
+    $hmac = switch ($alg) {
+        'SHA256' { [System.Security.Cryptography.HMACSHA256]::new($key) }
+        'SHA512' { [System.Security.Cryptography.HMACSHA512]::new($key) }
+        default { [System.Security.Cryptography.HMACSHA1]::new($key) }
+    }
+    $h = $hmac.ComputeHash($cb)
+    $o = $h[$h.Length - 1] -band 0x0f
+    $bin = (($h[$o] -band 0x7f) -shl 24) -bor (($h[$o + 1] -band 0xff) -shl 16) -bor `
+    (($h[$o + 2] -band 0xff) -shl 8) -bor ($h[$o + 3] -band 0xff)
+    ($bin % [int][math]::Pow(10, $digits)).ToString().PadLeft($digits, '0')
+}
+
+# SendKeys reads +^%~(){}[] as modifiers and grouping, so an address holding one of
+# them would be typed as something else entirely.
+function Protect-SendKeys([string]$s) {
+    -join ($s.ToCharArray() | ForEach-Object { if ('+^%~(){}[]'.Contains($_)) { "{$_}" } else { "$_" } })
+}
+
+$cs = @(
+    'using System; using System.Runtime.InteropServices;'
+    'public static class M {'
+    '  [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);'
+    '  [DllImport("user32.dll")] static extern void mouse_event(uint f, uint x, uint y, uint d, IntPtr e);'
+    '  static void Down() { mouse_event(2, 0, 0, 0, IntPtr.Zero); mouse_event(4, 0, 0, 0, IntPtr.Zero); }'
+    '  public static void Double(int x, int y) { SetCursorPos(x, y); System.Threading.Thread.Sleep(300); Down(); System.Threading.Thread.Sleep(80); Down(); }'
+    '}'
+) -join "`n"
+Add-Type -TypeDefinition $cs
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes
+
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$kids = [System.Windows.Automation.TreeScope]::Children
+$any = [System.Windows.Automation.Condition]::TrueCondition
+
+# Screenshots are the obvious diagnostic and are deliberately not taken: a build
+# artifact of a public repository is public, and the login form holds the address.
+function Show-TopLevel([string]$when) {
+    Write-Host "--- top-level windows ($when) ---"
+    foreach ($e in $root.FindAll($kids, $any)) {
+        Write-Host "  [$($e.Current.ClassName)] '$($e.Current.Name)' pid=$($e.Current.ProcessId)"
+    }
+}
+
+$proc = Start-Process -FilePath $Exe -PassThru
+Start-Sleep -Seconds 25
+if ($proc.HasExited) { throw "SimplySign Desktop exited immediately (code $($proc.ExitCode))" }
+
+$b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+Write-Host "desktop is $($b.Width)x$($b.Height), tray icon expected at $IconX,$IconY"
+if ($b.Width -ne 1024 -or $b.Height -ne 768) {
+    Write-Host "::warning::the icon coordinate was measured at 1024x768; this desktop differs, so the click may miss"
+}
+
+# The icon is visible rather than folded behind the chevron, and a double-click is
+# the gesture that opens the login window.
+[M]::Double($IconX, $IconY)
+Start-Sleep -Seconds 6
+Show-TopLevel 'after the tray click'
+
+$dlg = $root.FindAll($kids, $any) | Where-Object { $_.Current.ProcessId -eq $proc.Id } | Select-Object -First 1
+if (-not $dlg) { throw "the tray click opened no window: nothing to log into (is $IconX,$IconY still the icon?)" }
+Write-Host "login window: [$($dlg.Current.ClassName)] '$($dlg.Current.Name)'"
+
+# A code minted in the last seconds of its period expires while it is being typed.
+$left = $period - ([DateTimeOffset]::UtcNow.ToUnixTimeSeconds() % $period)
+if ($left -lt 5) { Start-Sleep -Seconds ($left + 1) }
+$otp = Get-Otp
+Write-Host "::add-mask::$otp"
+
+$wshell = New-Object -ComObject WScript.Shell
+[void]$wshell.AppActivate($proc.Id)
+Start-Sleep -Milliseconds 800
+$wshell.SendKeys("$(Protect-SendKeys $env:CERTUM_EMAIL){TAB}$otp{ENTER}")
+
+# The virtual card appears in the user's store within seconds of a good login.
+$deadline = (Get-Date).AddSeconds(90)
+do {
+    Start-Sleep -Seconds 5
+    $cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object Thumbprint -eq $Thumbprint
+} while (-not $cert -and (Get-Date) -lt $deadline)
+
+if (-not $cert) {
+    Show-TopLevel 'after typing'
+    Write-Host "certificates in the store: $((Get-ChildItem Cert:\CurrentUser\My).Thumbprint -join ', ')"
+    throw "$Thumbprint never appeared: the login was refused, or the code was wrong"
+}
+if (-not $cert.HasPrivateKey) { throw 'the certificate arrived without its private key: signing would fail' }
+Write-Host "::notice::signed in to SimplySign as $($cert.Subject)"


### PR DESCRIPTION
Release signing now uses a Certum Open Source certificate, which publishes under Xavier's own name and works with a stock signtool. The earlier signing wiring, which never went live, comes out.

It gets its own tags-only job behind the `signing` environment's approval, because a GitHub environment gates a whole job and putting signing in the build job would make every pull request wait for a click. Two things the diff does not make obvious: every signature is asserted against the certificate thumbprint rather than against `Valid`, which any certificate at all satisfies, and the installer is rebuilt from the signed binaries because Inno packs them as opaque bytes. The ISCC call and the smoke test became composite actions under `.github/actions/`, since both jobs now run them.

The signing half cannot run on a pull request, so nothing here exercises it; the mechanics were proven on a runner in a throwaway spike. `workflow_dispatch` grows a `sign` input so it can be rehearsed from master before a release rather than discovered on release day.