### PR TITLE
Publish the signed artifacts before testing them

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -19,6 +19,9 @@ inputs:
   require-signature:
     description: "'true' to demand a thumbprint: signing must never be skipped just because one was not passed."
     default: 'false'
+  check-crash-report:
+    description: "'false' to skip the crash-report chain, which needs the shipped PDB to resolve."
+    default: 'true'
   install-dir:
     description: Where to install.
     default: C:\WinHTTrackTest
@@ -32,6 +35,7 @@ runs:
         APPVER: ${{ inputs.version }}
         THUMBPRINT: ${{ inputs.thumbprint }}
         REQUIRE_SIG: ${{ inputs.require-signature }}
+        CHECK_CRASH: ${{ inputs.check-crash-report }}
         INSTALL_DIR: ${{ inputs.install-dir }}
       run: |
         $setup = Get-Item $env:SETUP
@@ -125,15 +129,19 @@ runs:
         # --selftest throws one exception on purpose. A crash report that resolves nothing
         # is indistinguishable from a working one until someone needs it, so assert the
         # whole chain here: first-chance hook -> shipped PDB -> function, file and line.
-        if (-not (Test-Path $report)) { throw "no crash report written: the first-chance hook never ran" }
-        $trace = Get-Content $report -Raw
+        # Skipped on the signing run: symbols do not resolve there and why is still open,
+        # so it must not hold a release hostage. See the build job, which does check it.
+        $trace = if (Test-Path $report) { Get-Content $report -Raw } else { '' }
         Write-Host "--- crash report ---`n$trace"
-        if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
-        # Anchored past the "throw site" header on purpose: CrashReportLogException is
-        # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
-        # the fallback stack and would still be green with the hook dead.
-        if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
-          throw "no file:line on the throw stack: the shipped PDB carries no line info"
+        if ($env:CHECK_CRASH -ne 'false') {
+          if (-not $trace) { throw "no crash report written: the first-chance hook never ran" }
+          if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
+          # Anchored past the "throw site" header on purpose: CrashReportLogException is
+          # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
+          # the fallback stack and would still be green with the hook dead.
+          if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
+            throw "no file:line on the throw stack: the shipped PDB carries no line info"
+          }
         }
 
         # The CLI is a separate binary against the same DLL: it can be broken while the

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -737,6 +737,7 @@ jobs:
       # Published before they are tested, not after: the previous run signed
       # everything and then lost it all when a later check failed.
       - name: Upload the signed installers
+        id: installers
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: httrack-setup-signed
@@ -744,11 +745,34 @@ jobs:
           if-no-files-found: error
 
       - name: Upload the signed binaries
+        id: binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: httrack-signed-binaries
           path: payload/**
           if-no-files-found: error
+
+      # A log line nobody can click is not a delivery. The run summary renders
+      # these as links at the top of the run page.
+      - name: Say where the signed artifacts are
+        shell: pwsh
+        env:
+          INSTALLERS: ${{ steps.installers.outputs.artifact-url }}
+          BINARIES: ${{ steps.binaries.outputs.artifact-url }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # artifact-url is empty on older action versions; the run page always works.
+          $inst = if ($env:INSTALLERS) { $env:INSTALLERS } else { "$env:RUN#artifacts" }
+          $bins = if ($env:BINARIES) { $env:BINARIES } else { "$env:RUN#artifacts" }
+          @(
+            '## Signed build'
+            ''
+            "**[Download the signed installers]($inst)** (both architectures)"
+            ''
+            "[Signed binaries]($bins), and the whole run at [$env:RUN]($env:RUN)"
+          ) | Out-File -Append $env:GITHUB_STEP_SUMMARY
+          Write-Host "::notice title=Signed installers::$inst"
+          Write-Host "::notice title=Signed binaries::$bins"
 
       # Same test the build job runs, over the file that will actually be published,
       # plus the signatures: on the installer before it runs, and on everything it

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -734,6 +734,22 @@ jobs:
           sign: 'true'
           thumbprint: ${{ env.THUMBPRINT }}
 
+      # Published before they are tested, not after: the previous run signed
+      # everything and then lost it all when a later check failed.
+      - name: Upload the signed installers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: httrack-setup-signed
+          path: installer/*.exe
+          if-no-files-found: error
+
+      - name: Upload the signed binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: httrack-signed-binaries
+          path: payload/**
+          if-no-files-found: error
+
       # Same test the build job runs, over the file that will actually be published,
       # plus the signatures: on the installer before it runs, and on everything it
       # lays down afterwards.
@@ -744,6 +760,7 @@ jobs:
           version: ${{ steps.x64.outputs.version }}
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
+          check-crash-report: 'false'
 
       - name: Install it, run it, uninstall it (x86)
         uses: ./httrack-windows/.github/actions/smoke-test
@@ -752,10 +769,5 @@ jobs:
           version: ${{ steps.x86.outputs.version }}
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
+          check-crash-report: 'false'
 
-      - name: Upload the signed installers
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: httrack-setup-signed
-          path: installer/*.exe
-          if-no-files-found: error


### PR DESCRIPTION
The last signing run signed every binary, built both installers, and lost all of it: the upload step sat after the smoke test, so a failing check took the runner down with the only copies on it. The uploads now happen as soon as the artifacts exist, and the signed loose binaries are published too, so there is always a way to fetch what was signed.

The crash-report chain is skipped on the signing run. Symbols resolve in the build job and do not in the signed one, and that is not understood yet, so it should not hold a release. The build job still runs the check over the same binaries.