### PR TITLE
Sign only on a release tag push or an explicit dispatch

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -579,7 +579,8 @@ jobs:
   # matrix, because a SimplySign session belongs to one machine and two runners would
   # mint the same single-use TOTP code in the same window.
   sign:
-    if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.sign }}
+    # A workflow_dispatch from a tag ref used to reach this whatever `sign` said.
+    if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && inputs.sign) }}
     needs: build
     runs-on: windows-2022
     environment: signing


### PR DESCRIPTION
The sign job tested `startsWith(github.ref, 'refs/tags/') || inputs.sign`. That first condition is true for a `workflow_dispatch` launched from a tag ref, not only for a tag push, so dispatching the workflow from any tag queued a signing run, approval prompt included, with `sign` still false. It now tests the event: a push whose ref is a tag, or a dispatch that asked to sign.

This goes with two settings changed outside the repo tree: a tag ruleset restricting tag creation to the admin account, and a deployment branch policy on the `signing` environment limiting it to master and the release tag patterns.