### PR TITLE
Ship the VC++ runtime app-local instead of bundling the redistributable

### DIFF
--- a/.github/actions/build-installer/action.yml
+++ b/.github/actions/build-installer/action.yml
@@ -71,22 +71,6 @@ runs:
         $verid = $Matches[1]
         Write-Host "version = $ver ($verid), arch = $arch"
 
-        # The VC++ runtime, bundled so a clean machine can actually start the app.
-        # vs/17 is the VS2022 line (14.4x). NOT vs/18: the 14.5x redistributable
-        # refuses to install on Windows 7, which is still our floor.
-        $redist = "$PWD\vc_redist.$arch.exe"
-        Invoke-WebRequest "https://aka.ms/vs/17/release/vc_redist.$arch.exe" -OutFile $redist
-        if ((Get-Item $redist).Length -lt 1MB) { throw 'vc_redist download looks wrong' }
-
-        # Bundled into a signed installer and run elevated, so verify who produced the
-        # bytes: aka.ms redirects, and TLS only authenticates the host we fetched from.
-        $sig = Get-AuthenticodeSignature $redist
-        if ($sig.Status -ne 'Valid') { throw "vc_redist signature is $($sig.Status)" }
-        if ($sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
-          throw "vc_redist signed by an unexpected party: $($sig.SignerCertificate.Subject)"
-        }
-        Write-Host "vc_redist signer verified: $($sig.SignerCertificate.Subject)"
-
         $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
         if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress | Out-Null }
         if (-not (Test-Path $iscc)) { throw 'Inno Setup is not available' }
@@ -95,7 +79,7 @@ runs:
           '/Q'
           "/DArch=$arch", "/DAppVersion=$ver", "/DAppVersionNumeric=$verid"
           "/DPayloadDir=$env:PAYLOAD_DIR", "/DEngineDir=$env:ENGINE_DIR", "/DGuiDir=$env:GUI_DIR"
-          "/DRedistFile=$redist", "/DOutDir=$env:OUT_DIR"
+          "/DOutDir=$env:OUT_DIR"
         )
         if ($env:SIGN -eq 'true') {
           if ($env:THUMBPRINT -notmatch '^[0-9A-Fa-f]{40}$') { throw "a 40-hex thumbprint is needed to sign, got '$env:THUMBPRINT'" }
@@ -106,8 +90,6 @@ runs:
           $iargs += ("/Scertum=signtool.exe sign /sha1 $env:THUMBPRINT /fd sha256 /tr http://time.certum.pl /td sha256 " + '$f')
         }
 
-        # ISCC fails if any Source: is missing, so a clean compile also proves the
-        # redistributable really is in the package.
         & $iscc @iargs (Join-Path $env:GUI_DIR 'InnoSetup\httrack.iss')
         if ($LASTEXITCODE -ne 0) { throw "ISCC failed ($LASTEXITCODE)" }
 

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -22,6 +22,9 @@ inputs:
   check-crash-report:
     description: "'false' to skip the crash-report chain, which needs the shipped PDB to resolve."
     default: 'true'
+  vendored-list:
+    description: runtime-vendored.txt from the payload, naming the DLLs that stay signed by Microsoft.
+    default: ''
   install-dir:
     description: Where to install.
     default: C:\WinHTTrackTest
@@ -37,6 +40,7 @@ runs:
         REQUIRE_SIG: ${{ inputs.require-signature }}
         CHECK_CRASH: ${{ inputs.check-crash-report }}
         INSTALL_DIR: ${{ inputs.install-dir }}
+        VENDORED_LIST: ${{ inputs.vendored-list }}
       run: |
         $setup = Get-Item $env:SETUP
         $dir = $env:INSTALL_DIR
@@ -82,7 +86,25 @@ runs:
           $pes = @(Get-ChildItem $dir -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll' })
           Write-Host "--- signatures on the $($pes.Count) installed binaries ---"
           if ($pes.Count -lt 5) { throw "only $($pes.Count) binaries were installed: the check below would prove nothing" }
-          $bad = @($pes | ForEach-Object { Test-Signature $_.FullName } | Where-Object { $_ })
+          # The app-local runtime stays signed by Microsoft, so check it against them. By
+          # name from the manifest: the file cannot say whether it was wrongly re-signed.
+          $vendored = @{}
+          if ($env:VENDORED_LIST) {
+            if (-not (Test-Path $env:VENDORED_LIST)) { throw "no vendored list at $env:VENDORED_LIST" }
+            Get-Content $env:VENDORED_LIST | Where-Object { $_.Trim() } | ForEach-Object { $vendored[$_.Trim()] = $true }
+          }
+          foreach ($n in 'WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll') {
+            if ($vendored.ContainsKey($n)) { throw "$n is listed as vendored: the manifest is wrong" }
+          }
+          $bad = @()
+          foreach ($f in $pes) {
+            if (-not $vendored.ContainsKey($f.Name)) { $bad += Test-Signature $f.FullName; continue }
+            $sig = Get-AuthenticodeSignature $f.FullName
+            if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+              $bad += "$($f.Name) is vendored but carries no valid Microsoft signature ($($sig.Status))"
+            }
+          }
+          $bad = @($bad | Where-Object { $_ })
           if ($bad) { throw ($bad -join "`n") }
         }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -440,9 +440,68 @@ jobs:
               Select-String -Pattern '^\s{4}(\S+\.dll)$' |
               ForEach-Object { $_.Matches[0].Groups[1].Value.ToLower() }
           }
-          # Supplied by Windows itself, or by the VC++ redist (see the README below).
-          $provided = '^(api-ms-win-|kernel32|user32|advapi32|shell32|comctl32|ole32|oleaut32|ws2_32|winmm|gdi32|ucrtbase|vcruntime|msvcp|mfc)'
-          $needed = @(Deps "$bin\WinHTTrack.exe") + @(Deps "$bin\libhttrack.dll") |
+          # CRT, MFC and UCRT ship beside the exe instead of through the 25 MB
+          # redistributable. The UCRT comes too: Windows 10 has it, Windows 7 SP1 only
+          # gets it from KB2999226.
+          $rarch = if ('${{ matrix.platform }}' -eq 'x64') { 'x64' } else { 'x86' }
+          # Matched to the toolset that compiled the binaries rather than to whatever is
+          # newest on the runner: 14.5x is where Windows 7 support ends.
+          $tv = [version]$tools.Name
+          if ($tv -ge [version]'14.50') { throw "toolset $($tools.Name) is past the 14.4x line, which still supports Windows 7" }
+          $vcline = '{0}.{1}.' -f $tv.Major, $tv.Minor
+          $vcver = @(Get-ChildItem "$vs\VC\Redist\MSVC" -Directory |
+            Where-Object { $_.Name.StartsWith($vcline) } | Sort-Object { [version]$_.Name }) | Select-Object -Last 1
+          if (-not $vcver) { throw "no VC++ redist on the $vcline line to match toolset $($tools.Name)" }
+          $vcr = @(Get-ChildItem "$($vcver.FullName)\$rarch" -Directory |
+            Where-Object { $_.Name -match '^Microsoft\.VC\d+\.(CRT|MFC)$' })
+          if ($vcr.Count -lt 2) { throw "no VC++ CRT/MFC redist under $($vcver.FullName)\$rarch" }
+          # Both SDK layouts: Redist\ucrt\DLLs\<arch> and Redist\<sdkver>\ucrt\DLLs\<arch>.
+          # Newest wins -- merging every installed SDK would ship whichever enumerated last,
+          # and the unversioned legacy path sorts first.
+          $ucrt = @(Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Redist" -Directory -Recurse -Filter $rarch -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\ucrt\\DLLs\\' } |
+            Sort-Object { if ($_.FullName -match '\\Redist\\(\d+(\.\d+){3})\\') { [version]$Matches[1] } else { [version]'0.0.0.0' } }) |
+            Select-Object -Last 1
+          if (-not $ucrt) { throw 'no UCRT redist in the Windows SDK' }
+          $pool = @{}
+          foreach ($d in @($vcr) + @($ucrt)) {
+            Get-ChildItem $d.FullName -Filter *.dll | ForEach-Object { $pool[$_.Name] = $_.FullName }
+          }
+          # Seeded from everything already staged, not just our three binaries: OpenSSL and
+          # friends are built against the same CRT, so their imports are in the closure too.
+          $todo = [Collections.Queue]::new()
+          Get-ChildItem $bin -File | Where-Object { $_.Extension -in '.exe', '.dll' } |
+            ForEach-Object { $todo.Enqueue($_.Name) }
+          # The api-ms-win-crt stubs forward to ucrtbase instead of importing it, so no
+          # dependency walk ever names it.
+          if (-not $pool.ContainsKey('ucrtbase.dll')) { throw 'the SDK UCRT redist has no ucrtbase.dll' }
+          $todo.Enqueue('ucrtbase.dll')
+          $seen = @{}
+          $staged = @{}
+          while ($todo.Count) {
+            $n = $todo.Dequeue()
+            if ($seen.ContainsKey($n)) { continue }
+            $seen[$n] = $true
+            $here = Join-Path $bin $n
+            if (-not (Test-Path $here)) {
+              # Ours to ship if the redist has it; anything else Windows supplies.
+              if (-not $pool.ContainsKey($n)) { continue }
+              Copy-Item $pool[$n] $bin
+              $staged[$n] = $true
+            }
+            Deps $here | ForEach-Object { $todo.Enqueue($_) }
+          }
+          if (-not $staged.Count) { throw 'no runtime DLL was staged: the redist layout moved' }
+          if (-not (Test-Path (Join-Path $bin 'ucrtbase.dll'))) { throw 'ucrtbase.dll was not staged' }
+          Write-Host "--- app-local runtime: $($staged.Count) DLLs from $($vcver.Name) ---"
+          # What the sign job must leave alone. It cannot infer this from signature status:
+          # a Microsoft DLL that fails to verify on the runner would land in our bucket.
+          Set-Content (Join-Path $bin 'runtime-vendored.txt') ($staged.Keys | Sort-Object)
+
+          # Supplied by Windows itself. The CRT names are gone from this list on purpose:
+          # they are ours to ship now, so the check below catches a staging regression.
+          $provided = '^(api-ms-win-(?!crt-)|kernel32|user32|advapi32|shell32|comctl32|ole32|oleaut32|ws2_32|winmm|gdi32)'
+          $needed = @(Deps "$bin\WinHTTrack.exe") + @(Deps "$bin\httrack.exe") + @(Deps "$bin\libhttrack.dll") |
             Where-Object { $_ -notmatch $provided } | Sort-Object -Unique
           Write-Host "--- must ship: $($needed -join ', ') ---"
           foreach ($d in $needed) {
@@ -467,15 +526,13 @@ jobs:
             Write-Host "::warning::no libhttrack.pdb: engine frames will not resolve"
           }
 
-          # mfc140/vcruntime140/msvcp140 are NOT shipped here; they come from the
-          # VC++ redist. Say so, so nobody wonders why a clean box will not run it.
           Set-Content (Join-Path $bin 'README-artifact.txt') @'
           This is a CI build of WinHTTrack, not an installer.
 
-          It needs the Microsoft Visual C++ 2015-2022 redistributable (x64 or x86 to
-          match), which supplies mfc140.dll, vcruntime140.dll and msvcp140.dll. Those
-          are deliberately not bundled here. Everything else it needs is in this
-          folder: libhttrack.dll, OpenSSL, zlib, and lang/.
+          Everything it needs is in this folder, including the Microsoft Visual C++
+          runtime and the UCRT, so there is no redistributable to install first.
+          Windows 7 SP1 is the exception: the runtime also needs KB2533623, which
+          only Windows Update can supply.
 
           httrack.exe is the command-line version, against the same libhttrack.dll.
           '@
@@ -683,11 +740,28 @@ jobs:
             # Sign what is there rather than a fixed list: OpenSSL is libssl-3.dll on
             # x86 but libssl-3-x64.dll on x64. Recursive because the installer packs
             # subdirectories, so a PE below the top level would otherwise ship unsigned.
-            $pes = @(Get-ChildItem $d.FullName -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+            $all = @(Get-ChildItem $d.FullName -Recurse -File | Where-Object { $_.Extension -in '.exe', '.dll' })
+            # Whose file it is comes from the build job's manifest, never from whether a
+            # signature verifies here: signtool REPLACES, so an unverifiable Microsoft DLL
+            # would come back carrying our certificate.
+            $manifest = Join-Path $d.FullName 'runtime-vendored.txt'
+            if (-not (Test-Path $manifest)) { throw "$($d.Name) has no runtime-vendored.txt" }
+            $vendored = @{}
+            Get-Content $manifest | Where-Object { $_.Trim() } | ForEach-Object { $vendored[$_.Trim()] = $true }
+            if (-not $vendored.Count) { throw "$($d.Name): runtime-vendored.txt is empty" }
+            $pes = @()
+            foreach ($f in $all) {
+              if (-not $vendored.ContainsKey($f.Name)) { $pes += $f; continue }
+              # Theirs, and it has to still say so: packaging must not have stripped it.
+              $sig = Get-AuthenticodeSignature $f.FullName
+              if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+                throw "$($f.Name) is vendored but carries no valid Microsoft signature ($($sig.Status))"
+              }
+            }
             foreach ($f in 'WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll') {
               if ($f -notin $pes.Name) { throw "$($d.Name) has no $f to sign" }
             }
-            Write-Host "--- $($d.Name): $($pes.Count) binaries ---"
+            Write-Host "--- $($d.Name): $($pes.Count) to sign, $($vendored.Count) vendored ---"
             foreach ($f in $pes) {
               # Every file is a fresh call to the timestamp server; one hiccup should
               # not cost a release.
@@ -786,6 +860,7 @@ jobs:
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
           check-crash-report: 'false'
+          vendored-list: ${{ github.workspace }}\payload\WinHTTrack-x64-Release\runtime-vendored.txt
 
       - name: Install it, run it, uninstall it (x86)
         uses: ./httrack-windows/.github/actions/smoke-test
@@ -795,4 +870,5 @@ jobs:
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
           check-crash-report: 'false'
+          vendored-list: ${{ github.workspace }}\payload\WinHTTrack-Win32-Release\runtime-vendored.txt
 

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -6,7 +6,7 @@
 ;   ISCC /DArch=x64 /DAppVersion=3.49-12 ^
 ;        /DPayloadDir=...\WinHTTrack\bin\x64\Release ^
 ;        /DEngineDir=...\httrack /DGuiDir=...\httrack-windows ^
-;        /DRedistFile=...\vc_redist.x64.exe /DOutDir=...\out ^
+;        /DOutDir=...\out ^
 ;        InnoSetup\httrack.iss
 ;
 ; Signing is opt-in (/DSign) and off by default, so an ordinary CI build needs no
@@ -45,8 +45,8 @@ AllowNoIcons=yes
 LicenseFile={#GuiDir}\setup_license.txt
 AppMutex=WinHTTrack_RUN
 ; Windows 7 SP1 is the floor on purpose: HTTrack is still used on very old machines.
-; It is also why the bundled runtime must stay on the 14.4x (VS2022) line -- the
-; 14.5x redistributable refuses to install here.
+; It is also why the app-local runtime must stay on the 14.4x (VS2022) line: 14.5x
+; dropped Windows 7.
 MinVersion=6.1sp1
 PrivilegesRequired=admin
 OutputBaseFilename=httrack_{#Arch}_{#AppVersion}
@@ -72,11 +72,11 @@ Name: "desktopicon"; Description: "Create a &desktop icon"; GroupDescription: "A
 Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescription: "Additional icons:"; Flags: unchecked
 
 [Files]
-; The program: exe, libhttrack.dll, the OpenSSL/zlib DLLs it imports, and lang/ and
-; templates/. This is the same staged directory CI publishes, so what gets tested is
+; The program: exe, libhttrack.dll, the OpenSSL/zlib and VC++ runtime DLLs it imports,
+; and lang/ and templates/. This is the same staged directory CI publishes, so what gets tested is
 ; what gets shipped. The PDBs ship too: without them a crash report names no function and
 ; no line, and we already ship the sources they point into.
-Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt"; Flags: recursesubdirs ignoreversion
+Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt,runtime-vendored.txt"; Flags: recursesubdirs ignoreversion
 
 ; Documentation that actually exists. The old script also listed readme, copying and
 ; file_id.diz, none of which are in the tree any more.
@@ -94,13 +94,7 @@ Source: "{#EngineDir}\gpl-fr.txt"; DestDir: "{app}"; Flags: ignoreversion skipif
 Source: "{#EngineDir}\src\*"; DestDir: "{app}\src"; Excludes: "*.obj,*.pdb,*.lib,*.exp,*.dll,*.exe,*.iobj,*.ipdb,*.tlog,\x64\*,\Win32\*,\vcpkg_installed\*,\.vs\*"; Flags: recursesubdirs ignoreversion
 Source: "{#GuiDir}\WinHTTrack\*"; DestDir: "{app}\src_win"; Excludes: "*.obj,*.pdb,*.lib,*.exp,*.dll,*.exe,*.iobj,*.ipdb,*.tlog,\bin\*,\x64\*,\Win32\*,\vcpkg_installed\*,\.vs\*"; Flags: recursesubdirs ignoreversion
 
-; The Visual C++ runtime, bundled rather than assumed. The app links the dynamic CRT
-; and shared MFC, so on a machine without it the exe simply refuses to start, with a
-; message that tells the user nothing useful.
-Source: "{#RedistFile}"; DestDir: "{tmp}"; Flags: deleteafterinstall
-
 [Run]
-Filename: "{tmp}\{#ExtractFileName(RedistFile)}"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing the Visual C++ runtime..."; Flags: waituntilterminated
 Filename: "{app}\WinHTTrack.exe"; Description: "Launch WinHTTrack Website Copier"; Flags: nowait postinstall skipifsilent
 Filename: "{win}\notepad.exe"; Parameters: "{app}\history.txt"; WorkingDir: "{app}"; Description: "View history.txt file"; Flags: nowait postinstall skipifsilent
 


### PR DESCRIPTION
The x64 installer is 33 MB, and 23.7 MB of that is Microsoft's redistributable. It arrives already compressed, so the installer's LZMA gets almost nothing back. Staging the CRT, MFC and UCRT DLLs next to the exe carries the same runtime for about 1.8 MB and brings the installer to roughly 11 MB. The set comes from a transitive dumpbin walk over the package rather than a hardcoded list, seeded with `ucrtbase.dll` because the `api-ms-win-crt-*` stubs forward to it instead of importing it, so nothing would otherwise name it. The redist is matched to the toolset that built the binaries and refuses the 14.5x line, which dropped Windows 7. Windows 7 SP1 also needs KB2533623 before the runtime will load; that one is an OS update and no app-local file replaces it, so the artifact README points at Windows Update rather than at the redistributable.

The sign job needed a guard in the same change. It signs every PE in the payload, and signtool replaces a signature rather than appending one, so Microsoft's DLLs would have shipped carrying our certificate. Staging now records what it took from the redist, and the sign job and the install smoke test both partition on that manifest. Inferring it from signature status instead would drop any Microsoft DLL that failed to verify on the runner into our bucket, and the smoke test could not then tell that apart from a correctly signed binary of ours.

One thing CI structurally cannot catch: the runner has the redistributable installed system-wide, so a DLL missing from the app directory still resolves from System32 and the build stays green. The guards that bite are the filesystem checks against the staged directory.
