### PR TITLE
Shrink the installer: solid compression, no PDBs, no bundled sources

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "'true' to demand a thumbprint: signing must never be skipped just because one was not passed."
     default: 'false'
   check-crash-report:
-    description: "'false' to skip the crash-report chain, which needs the shipped PDB to resolve."
+    description: "'false' to skip the crash-report check entirely."
     default: 'true'
   vendored-list:
     description: runtime-vendored.txt from the payload, naming the DLLs that stay signed by Microsoft.
@@ -121,7 +121,10 @@ runs:
         # touched. That is exactly why a missing lang.def shipped. --selftest runs
         # the real startup, through LANG_INIT, and exits before showing a window.
         $report = Join-Path $env:TEMP 'WinHTTrack-exception.txt'
-        Remove-Item $report -ErrorAction SilentlyContinue
+        # -Force, then prove it: the report is opened for APPEND, so a leftover would be
+        # asserted against instead of this run.
+        Remove-Item $report -Force -ErrorAction SilentlyContinue
+        if (Test-Path $report) { throw "$report survived deletion" }
         $p = Start-Process $exe -ArgumentList '--selftest' -Wait -PassThru `
                -RedirectStandardOutput "$PWD\selftest.txt" -RedirectStandardError "$PWD\selftest.err"
         $so = (Get-Content "$PWD\selftest.txt" -Raw -ErrorAction SilentlyContinue)
@@ -148,22 +151,14 @@ runs:
           throw "selftest did not check the lang.indexes offset"
         }
 
-        # --selftest throws one exception on purpose. A crash report that resolves nothing
-        # is indistinguishable from a working one until someone needs it, so assert the
-        # whole chain here: first-chance hook -> shipped PDB -> function, file and line.
-        # Skipped on the signing run: symbols do not resolve there and why is still open,
-        # so it must not hold a release hostage. See the build job, which does check it.
+        # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
+        # ran and caught the throw stack; the build job checks resolution against staged.
+        # Skipped on the signing run: symbols do not resolve there and this must not gate a release.
         $trace = if (Test-Path $report) { Get-Content $report -Raw } else { '' }
         Write-Host "--- crash report ---`n$trace"
         if ($env:CHECK_CRASH -ne 'false') {
           if (-not $trace) { throw "no crash report written: the first-chance hook never ran" }
           if ($trace -notmatch 'throw site') { throw "report holds the handler stack, not the throw stack" }
-          # Anchored past the "throw site" header on purpose: CrashReportLogException is
-          # itself called from WinHTTrack.cpp, so an unanchored match would be satisfied by
-          # the fallback stack and would still be green with the hook dead.
-          if ($trace -notmatch 'throw site\)[\s\S]*WinHTTrack\.cpp:\d+') {
-            throw "no file:line on the throw stack: the shipped PDB carries no line info"
-          }
         }
 
         # The CLI is a separate binary against the same DLL: it can be broken while the

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -408,15 +408,18 @@ jobs:
       # than a failed build.
       - name: Stage a runnable package
         shell: pwsh
+        # Via env, not ${{ }} interpolation: a value containing $(...) would otherwise run.
+        env:
+          ENGINE_SHA: ${{ steps.provenance.outputs.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           $eng = "httrack\src\${{ matrix.platform }}\${{ matrix.configuration }}"
           Copy-Item "$eng\*.dll" $bin
           # The command-line httrack ships with the GUI.
           Copy-Item "$eng\httrack.exe" $bin
-          # Ship the PDBs: dbghelp resolves function and file:line from them at run time, so
-          # without them every frame of a user's crash report reads "unknown". The engine's
-          # is a bonus and is not ours to fix, so do not red the build over it.
+          # PDBs stay in the artifact, out of the installer: 2.2 MB to give a user's crash
+          # report file:line. The engine's is a bonus, not ours to fix; do not red the build.
           Copy-Item "$eng\*.pdb" $bin -ErrorAction SilentlyContinue
           # lang.def is a FILE at the engine root, not inside lang\. The GUI reads it
           # from the app directory at startup and refuses to run without it. The old
@@ -519,12 +522,42 @@ jobs:
           if (-not (Test-Path (Join-Path $bin 'httrack.exe'))) {
             throw "package is missing httrack.exe: the command-line version ships with the GUI"
           }
+          # Staged, not installed: the check below needs them, and they make the artifact debuggable.
           if (-not (Test-Path (Join-Path $bin 'WinHTTrack.pdb'))) {
-            throw "package is missing WinHTTrack.pdb: crash reports would name no function"
+            throw "package is missing WinHTTrack.pdb: the crash-symbol check would prove nothing"
           }
           if (-not (Test-Path (Join-Path $bin 'libhttrack.pdb'))) {
             Write-Host "::warning::no libhttrack.pdb: engine frames will not resolve"
           }
+
+          # src/ no longer ships; the GPL offer names the exact commits instead. coucal is
+          # a submodule, so a GitHub archive of the engine carries an empty src/coucal and
+          # naming it separately is what keeps the offer complete.
+          # On a pull_request HEAD is the ephemeral merge commit, whose URLs die with the
+          # PR; the head commit is the one that was built.
+          $guiSha = if ($env:PR_HEAD_SHA) { $env:PR_HEAD_SHA } else { (git -C httrack-windows rev-parse HEAD).Trim() }
+          $engSha = $env:ENGINE_SHA
+          $couSha = (git -C httrack/src/coucal rev-parse HEAD).Trim()
+          foreach ($p in @(@('gui', $guiSha), @('engine', $engSha), @('coucal', $couSha))) {
+            if ($p[1] -notmatch '^[0-9a-f]{40}$') { throw "cannot name the corresponding source: $($p[0])='$($p[1])'" }
+          }
+          Set-Content (Join-Path $bin 'source.txt') @"
+          WinHTTrack Website Copier is free software under the GNU GPL, version 3 or
+          later. See license.txt for the terms.
+
+          The complete corresponding source for this exact build:
+
+            Windows interface  https://github.com/xroche/httrack-windows/tree/$guiSha
+            Engine             https://github.com/xroche/httrack/tree/$engSha
+            coucal (in engine) https://github.com/xroche/coucal/tree/$couSha
+
+          Downloadable archives of those revisions. coucal has to be taken separately:
+          it is a submodule, so the engine archive carries an empty src/coucal.
+
+            https://github.com/xroche/httrack-windows/archive/$guiSha.tar.gz
+            https://github.com/xroche/httrack/archive/$engSha.tar.gz
+            https://github.com/xroche/coucal/archive/$couSha.tar.gz
+          "@
 
           Set-Content (Join-Path $bin 'README-artifact.txt') @'
           This is a CI build of WinHTTrack, not an installer.
@@ -538,6 +571,33 @@ jobs:
           '@
           Write-Host "--- package contents ---"
           Get-ChildItem $bin | ForEach-Object { Write-Host "  $($_.Name)" }
+
+      # Against the staged tree, where the PDBs live: the installed build can no longer
+      # resolve a line, so this is what still proves the whole crash-report chain works.
+      - name: Crash report resolves to function, file and line
+        shell: pwsh
+        run: |
+          $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
+          $report = Join-Path $env:TEMP 'WinHTTrack-exception.txt'
+          # -Force, then prove it: the report is opened for APPEND, so a leftover (or a
+          # read-only file planted at that path) would be asserted against instead.
+          Remove-Item $report -Force -ErrorAction SilentlyContinue
+          if (Test-Path $report) { throw "$report survived deletion: the check would read someone else's content" }
+          # --selftest throws one exception on purpose.
+          $p = Start-Process (Join-Path $bin 'WinHTTrack.exe') -ArgumentList '--selftest' -Wait -PassThru `
+                 -RedirectStandardOutput "$PWD\crash-st.txt" -RedirectStandardError "$PWD\crash-st.err"
+          if ($p.ExitCode -ne 0) { throw "--selftest exited $($p.ExitCode) from the staged tree" }
+          if (-not (Test-Path $report)) { throw 'no crash report written: the first-chance hook never ran' }
+          $trace = Get-Content $report -Raw
+          Write-Host "--- crash report ---`n$trace"
+          if ($trace -notmatch 'throw site') { throw 'report holds the handler stack, not the throw stack' }
+          # Tempered so the match cannot run past the throw-site record into a later one:
+          # CrashReportLogException is itself called from WinHTTrack.cpp, so the handler
+          # record would satisfy an unbounded match with the hook dead.
+          if ($trace -notmatch 'throw site\):(?:(?!Stack trace)[\s\S])*?WinHTTrack\.cpp:\d+') {
+            throw 'no file:line on the throw stack: the PDB carries no line info'
+          }
+          Write-Host '::notice::crash report resolves function, file and line'
 
       # Self-imposed now that no CA enforces it: every shipped binary and the
       # installer must agree on product name and version. Cheap to catch here.
@@ -667,9 +727,8 @@ jobs:
         with:
           path: httrack-windows
 
-      # The installer packs both source trees as well as the binaries (HTTrack is
-      # GPL), so the sign job needs the same two checkouts the build job had. At
-      # the exact commit that was built, not at whatever the ref resolves to now.
+      # The installer packs the engine's licence and history files, so the sign job needs
+      # the same two checkouts the build job had, at the exact commit that was built.
       - name: Checkout httrack engine (sibling)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -14,7 +14,7 @@
 ; sign tool the caller passes as /Scertum=signtool.exe sign ... $f.
 ;
 ; Replaces the old httrack.iss + httrack-x64.iss pair. They had drifted apart, and
-; both referenced files that no longer exist (readme, copying, file_id.diz, src_win).
+; both referenced files that no longer exist (readme, copying, file_id.diz).
 
 #ifndef Arch
   #error Arch must be set (x64 or x86)
@@ -44,6 +44,11 @@ DefaultGroupName=WinHTTrack
 AllowNoIcons=yes
 LicenseFile={#GuiDir}\setup_license.txt
 AppMutex=WinHTTrack_RUN
+; Solid is worth ~0.5 MB: per-file streams cannot dedupe the 41 near-identical
+; api-ms-win-crt stubs. The dictionary stays put -- 8 MiB is within 9 KB of 64 MiB at
+; this size, and lzma2 allocates it to DECOMPRESS, on the machines that are our floor.
+Compression=lzma2/max
+SolidCompression=yes
 ; Windows 7 SP1 is the floor on purpose: HTTrack is still used on very old machines.
 ; It is also why the app-local runtime must stay on the 14.4x (VS2022) line: 14.5x
 ; dropped Windows 7.
@@ -74,9 +79,9 @@ Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescri
 [Files]
 ; The program: exe, libhttrack.dll, the OpenSSL/zlib and VC++ runtime DLLs it imports,
 ; and lang/ and templates/. This is the same staged directory CI publishes, so what gets tested is
-; what gets shipped. The PDBs ship too: without them a crash report names no function and
-; no line, and we already ship the sources they point into.
-Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt,runtime-vendored.txt"; Flags: recursesubdirs ignoreversion
+; what gets shipped. PDBs are built but not shipped, so a user crash report names no
+; line; source.txt carries the GPL offer the src/ tree used to meet.
+Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.pdb,*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt,runtime-vendored.txt"; Flags: recursesubdirs ignoreversion
 
 ; Documentation that actually exists. The old script also listed readme, copying and
 ; file_id.diz, none of which are in the tree any more.
@@ -88,11 +93,11 @@ Source: "{#EngineDir}\COPYING"; DestDir: "{app}"; Flags: ignoreversion skipifsou
 Source: "{#EngineDir}\AUTHORS"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#EngineDir}\gpl-fr.txt"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
-; Sources, kept: HTTrack is GPL and shipping them is how that offer is met. The
-; excludes are load-bearing -- CI builds inside these trees, so without them the
-; installer would carry object files, import libs and vcpkg_installed as well.
-Source: "{#EngineDir}\src\*"; DestDir: "{app}\src"; Excludes: "*.obj,*.pdb,*.lib,*.exp,*.dll,*.exe,*.iobj,*.ipdb,*.tlog,\x64\*,\Win32\*,\vcpkg_installed\*,\.vs\*"; Flags: recursesubdirs ignoreversion
-Source: "{#GuiDir}\WinHTTrack\*"; DestDir: "{app}\src_win"; Excludes: "*.obj,*.pdb,*.lib,*.exp,*.dll,*.exe,*.iobj,*.ipdb,*.tlog,\bin\*,\x64\*,\Win32\*,\vcpkg_installed\*,\.vs\*"; Flags: recursesubdirs ignoreversion
+[InstallDelete]
+; Left by installers up to 3.49-14, which shipped both source trees and the PDBs.
+Type: filesandordirs; Name: "{app}\src"
+Type: filesandordirs; Name: "{app}\src_win"
+Type: files; Name: "{app}\*.pdb"
 
 [Run]
 Filename: "{app}\WinHTTrack.exe"; Description: "Launch WinHTTrack Website Copier"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Three cuts against the 12.3 MB x64 installer. Measured projection is about 8.7 MB.

`SolidCompression=yes` is the free one, since per-file streams cannot dedupe the 41 near-identical `api-ms-win-crt-*` stubs. The dictionary stays at `lzma2/max`: 8 MiB is within 9 KB of 64 MiB at this size, and lzma2 allocates the dictionary to *decompress*, on the old machines that are the reason Windows 7 is still the floor. PDBs (2.18 MB) and the `src/` trees (1.13 MB) leave the installer.

Neither removal could just be dropped. A new build-job step runs `--selftest` against the staged tree, where the PDBs still are, and asserts function, file and line, so the crash-report chain is still proven; the installed-tree check can now only assert that a report was written with the throw stack. For the sources, GPLv3 §6(d) is met by a `source.txt` naming the exact commits, coucal separately, because it is a submodule and a GitHub archive of the engine carries an empty `src/coucal`. §6(d) wants the directions next to the download, so this is not compliant until httrack-com carries the same links. That change is deliberately not in this PR.

Static MFC was in the first draft and is gone. `afx.h` refuses `/MD` with static MFC outright, and the static CRT it demands would put the exe on a different heap from `libhttrack.dll`, which is the exact crash the CRT-agreement check exists to prevent.
