### PR TITLE
Capture the documentation screenshots by driving the GUI

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,6 +1,6 @@
-# Does a hosted Windows runner give us a desktop the GUI actually draws on? If it
-# does, the documentation screenshots can be captured here instead of in a VM.
-# Manual only: it drives the app, which the build gate has no reason to wait for.
+# Documentation screenshots: drive the GUI on a runner and capture every screen.
+# Manual, and deliberately not part of the build gate -- run it after adding or
+# changing an option page, and the artifact is the new set of shots.
 name: screenshots
 
 on:
@@ -9,11 +9,17 @@ on:
   push:
     paths:
       - '.github/workflows/screenshots.yml'
-      - 'tools/screenshot-probe.py'
+      - 'tools/screenshot-*.py'
+      - 'tools/wincapture.py'
   workflow_dispatch:
     inputs:
+      mode:
+        description: 'walk (every screen) or probe (can this machine render at all)'
+        type: choice
+        options: [walk, probe]
+        default: walk
       run-id:
-        description: 'windows-build run to take the binaries from (default: latest green master run)'
+        description: 'windows-build run to take the binaries from (default: this branch, else master)'
         required: false
 
 permissions:
@@ -22,40 +28,54 @@ permissions:
   actions: read
 
 jobs:
-  probe:
+  capture:
     runs-on: windows-2022
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The staged build artifact already runs as-is (lang.def, lang/, html/, the
-      # engine DLLs and the app-local CRT), so the probe needs no installer.
+      # The staged build artifact runs as-is (lang.def, lang/, html/, the engine DLLs
+      # and the app-local CRT), so this needs no build and no installer.
       - name: Fetch the built app
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ inputs.run-id }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           $id = $env:RUN_ID
+          $from = 'the run given'
           if (-not $id) {
-            $id = gh run list --workflow windows-build.yml --branch master --status success `
-                    --limit 1 --json databaseId -q '.[0].databaseId'
+            foreach ($b in @($env:BRANCH, 'master') | Select-Object -Unique) {
+              $id = gh run list --workflow windows-build.yml --branch $b --status success `
+                      --limit 1 --json databaseId -q '.[0].databaseId'
+              if ($id) { $from = $b; break }
+            }
           }
           if (-not $id) { throw 'no green windows-build run to take binaries from' }
-          Write-Host "taking binaries from run $id"
+          Write-Host "binaries from run $id ($from)"
+          # The walk reads control IDs out of the checked-out resource.h, so binaries
+          # built from another branch can disagree with it.
+          if ($from -ne $env:BRANCH -and $from -ne 'the run given') {
+            Write-Warning "no build for $($env:BRANCH): these are $from's binaries, which may not match this checkout"
+          }
           gh run download $id --name WinHTTrack-x64-Release --dir app
           if (-not (Test-Path app\WinHTTrack.exe)) { throw 'artifact has no WinHTTrack.exe' }
 
-      - name: Probe
+      - name: Capture
         shell: pwsh
+        env:
+          MODE: ${{ inputs.mode }}
         run: |
           python -m pip install --quiet pywin32 pillow pywinauto
-          python tools\screenshot-probe.py --exe app\WinHTTrack.exe --out shots
+          $script = if ($env:MODE -eq 'probe') { 'screenshot-probe.py' } else { 'screenshot-walk.py' }
+          Write-Host "running $script"
+          python "tools\$script" --exe app\WinHTTrack.exe --out shots
 
-      - name: Upload the captures
+      - name: Upload the screens
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: screenshot-probe
+          name: screenshots
           path: shots
           if-no-files-found: error

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,61 @@
+# Does a hosted Windows runner give us a desktop the GUI actually draws on? If it
+# does, the documentation screenshots can be captured here instead of in a VM.
+# Manual only: it drives the app, which the build gate has no reason to wait for.
+name: screenshots
+
+on:
+  # A push trigger as well as the button: workflow_dispatch is only offered for
+  # workflows that already exist on the default branch.
+  push:
+    paths:
+      - '.github/workflows/screenshots.yml'
+      - 'tools/screenshot-probe.py'
+  workflow_dispatch:
+    inputs:
+      run-id:
+        description: 'windows-build run to take the binaries from (default: latest green master run)'
+        required: false
+
+permissions:
+  contents: read
+  # Downloading another workflow run's artifact goes through the Actions API.
+  actions: read
+
+jobs:
+  probe:
+    runs-on: windows-2022
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The staged build artifact already runs as-is (lang.def, lang/, html/, the
+      # engine DLLs and the app-local CRT), so the probe needs no installer.
+      - name: Fetch the built app
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run-id }}
+        run: |
+          $id = $env:RUN_ID
+          if (-not $id) {
+            $id = gh run list --workflow windows-build.yml --branch master --status success `
+                    --limit 1 --json databaseId -q '.[0].databaseId'
+          }
+          if (-not $id) { throw 'no green windows-build run to take binaries from' }
+          Write-Host "taking binaries from run $id"
+          gh run download $id --name WinHTTrack-x64-Release --dir app
+          if (-not (Test-Path app\WinHTTrack.exe)) { throw 'artifact has no WinHTTrack.exe' }
+
+      - name: Probe
+        shell: pwsh
+        run: |
+          python -m pip install --quiet pywin32 pillow pywinauto
+          python tools\screenshot-probe.py --exe app\WinHTTrack.exe --out shots
+
+      - name: Upload the captures
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: screenshot-probe
+          path: shots
+          if-no-files-found: error

--- a/tools/screenshot-probe.py
+++ b/tools/screenshot-probe.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Can a hosted Windows runner render and capture the GUI?
+
+Launches WinHTTrack, captures every top-level window it opens both off the screen
+and via PrintWindow, and measures how much of each image is not black. Notepad gets
+the same treatment as a control: black everywhere means the session has no rendering
+desktop, black for WinHTTrack alone means the app is what fails to draw.
+"""
+
+import argparse
+import ctypes
+import os
+import re
+import subprocess
+import sys
+import time
+
+import win32gui
+import win32process
+import win32ui
+from PIL import Image, ImageGrab
+
+user32 = ctypes.windll.user32
+kernel32 = ctypes.windll.kernel32
+PW_RENDERFULLCONTENT = 2
+
+
+def describe_session():
+    """Session 0 is the service session and has no desktop to draw on."""
+    sid = ctypes.c_ulong()
+    kernel32.ProcessIdToSessionId(os.getpid(), ctypes.byref(sid))
+    try:
+        dpi = user32.GetDpiForSystem()
+    except AttributeError:
+        dpi = "?"
+    print(f"session={sid.value} screen={user32.GetSystemMetrics(0)}x{user32.GetSystemMetrics(1)} dpi={dpi}")
+    print(f"desktop window={user32.GetDesktopWindow():#x} foreground={user32.GetForegroundWindow():#x}")
+
+
+def top_level_windows(pid):
+    found = []
+
+    def visit(hwnd, _):
+        if win32gui.IsWindowVisible(hwnd) and win32process.GetWindowThreadProcessId(hwnd)[1] == pid:
+            found.append(hwnd)
+        return True
+
+    win32gui.EnumWindows(visit, None)
+    return found
+
+
+def controls(hwnd):
+    """Descendant control IDs and classes -- what a pywinauto walk would navigate by."""
+    out = []
+
+    def visit(child, _):
+        out.append((win32gui.GetDlgCtrlID(child), win32gui.GetClassName(child),
+                    win32gui.GetWindowText(child)[:40]))
+        return True
+
+    win32gui.EnumChildWindows(hwnd, visit, None)
+    return out
+
+
+def print_window(hwnd):
+    """Render into a memory DC: unlike a screen grab this survives occlusion."""
+    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+    w, h = right - left, bottom - top
+    if w <= 0 or h <= 0:
+        return None, 0
+    src = win32gui.GetWindowDC(hwnd)
+    dc = win32ui.CreateDCFromHandle(src)
+    mem = dc.CreateCompatibleDC()
+    bmp = win32ui.CreateBitmap()
+    bmp.CreateCompatibleBitmap(dc, w, h)
+    mem.SelectObject(bmp)
+    ok = user32.PrintWindow(hwnd, mem.GetSafeHdc(), PW_RENDERFULLCONTENT)
+    img = Image.frombuffer("RGB", (w, h), bmp.GetBitmapBits(True), "raw", "BGRX", 0, 1)
+    win32gui.DeleteObject(bmp.GetHandle())
+    mem.DeleteDC()
+    dc.DeleteDC()
+    win32gui.ReleaseDC(hwnd, src)
+    return img, ok
+
+
+def grab_screen(hwnd):
+    try:
+        return ImageGrab.grab(bbox=win32gui.GetWindowRect(hwnd), all_screens=True)
+    except Exception as e:  # a headless session can refuse the desktop DC outright
+        print(f"    screen grab failed: {e}")
+        return None
+
+
+def liveness(img):
+    """Distinct colours and non-black fraction; a dead capture is uniformly black."""
+    hist = img.convert("L").histogram()
+    n = img.width * img.height
+    colors = img.convert("RGB").getcolors(1 << 18)
+    return (len(colors) if colors else -1), 1.0 - sum(hist[:16]) / n
+
+
+def capture(hwnd, tag, outdir, results):
+    cls = win32gui.GetClassName(hwnd)
+    title = win32gui.GetWindowText(hwnd)
+    print(f"  {hwnd:#x} class={cls!r} title={title!r} rect={win32gui.GetWindowRect(hwnd)}")
+    try:
+        user32.SetForegroundWindow(hwnd)
+    except Exception:
+        pass
+    time.sleep(0.3)
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", f"{tag}_{cls}_{title}").strip("_")[:60]
+    printed, ok = print_window(hwnd)
+    for how, img in (("printwindow", printed), ("screen", grab_screen(hwnd))):
+        if img is None:
+            print(f"    {how}: no image")
+            continue
+        path = os.path.join(outdir, f"{slug}_{how}.png")
+        img.save(path)
+        colors, nonblack = liveness(img)
+        print(f"    {how}: {img.width}x{img.height} colors={colors} nonblack={nonblack:.3f}"
+              f"{f' PrintWindow={ok}' if how == 'printwindow' else ''} -> {os.path.basename(path)}")
+        results.setdefault((tag, how), []).append(nonblack)
+
+
+def walk(exe, tag, outdir, checkpoints, results):
+    print(f"\n=== {tag}: {exe} ===")
+    proc = subprocess.Popen([exe])
+    seen = set()
+    try:
+        for t in checkpoints:
+            time.sleep(t)
+            for hwnd in top_level_windows(proc.pid):
+                if hwnd in seen:
+                    continue
+                seen.add(hwnd)
+                capture(hwnd, tag, outdir, results)
+                for cid, cls, text in controls(hwnd)[:40]:
+                    print(f"      id={cid} {cls!r} {text!r}")
+        if not seen:
+            print(f"  {tag} opened no visible top-level window (exit code {proc.poll()})")
+    finally:
+        subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return bool(seen)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--exe", required=True)
+    ap.add_argument("--out", default="shots")
+    args = ap.parse_args()
+    os.makedirs(args.out, exist_ok=True)
+
+    describe_session()
+    try:
+        import pywinauto
+        print(f"pywinauto {pywinauto.__version__}")
+    except Exception as e:
+        print(f"pywinauto unavailable: {e}")
+
+    results = {}
+    got_app = walk(os.path.abspath(args.exe), "app", args.out, [6, 6, 8], results)
+    walk(os.path.join(os.environ["WINDIR"], "system32", "notepad.exe"), "notepad",
+         args.out, [4], results)
+
+    print("\n=== verdict ===")
+    for (tag, how), values in sorted(results.items()):
+        best = max(values)
+        print(f"{tag}/{how}: best nonblack={best:.3f} -> {'renders' if best > 0.02 else 'BLANK'}")
+    if not got_app:
+        print("the app never showed a window: the walk cannot be built on this runner")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/screenshot-probe.py
+++ b/tools/screenshot-probe.py
@@ -1,143 +1,70 @@
 #!/usr/bin/env python3
-"""Can a hosted Windows runner render and capture the GUI?
+"""Can this machine render and capture the GUI at all?
 
-Launches WinHTTrack, captures every top-level window it opens both off the screen
-and via PrintWindow, and measures how much of each image is not black. Notepad gets
-the same treatment as a control: black everywhere means the session has no rendering
-desktop, black for WinHTTrack alone means the app is what fails to draw.
+Launches WinHTTrack, captures every window it opens both off the screen and via
+PrintWindow, and measures how much of each image is not black. Notepad gets the same
+treatment as a control: black everywhere means no rendering desktop, black for
+WinHTTrack alone means the app is what fails to draw. Run this when the runner image
+changes or when moving the walk to a VM; the walk itself diagnoses its own failures.
 """
 
 import argparse
 import ctypes
 import os
-import re
 import subprocess
 import sys
 import time
 
 import win32gui
-import win32process
-import win32ui
-from PIL import Image, ImageGrab
+from PIL import ImageGrab
+
+from wincapture import capture, controls, slug, top_level_windows
 
 user32 = ctypes.windll.user32
 kernel32 = ctypes.windll.kernel32
-PW_RENDERFULLCONTENT = 2
 
 
 def describe_session():
     """Session 0 is the service session and has no desktop to draw on."""
     sid = ctypes.c_ulong()
     kernel32.ProcessIdToSessionId(os.getpid(), ctypes.byref(sid))
-    try:
-        dpi = user32.GetDpiForSystem()
-    except AttributeError:
-        dpi = "?"
+    dpi = user32.GetDpiForSystem() if hasattr(user32, "GetDpiForSystem") else "?"
     print(f"session={sid.value} screen={user32.GetSystemMetrics(0)}x{user32.GetSystemMetrics(1)} dpi={dpi}")
-    print(f"desktop window={user32.GetDesktopWindow():#x} foreground={user32.GetForegroundWindow():#x}")
 
 
-def top_level_windows(pid):
-    found = []
-
-    def visit(hwnd, _):
-        if win32gui.IsWindowVisible(hwnd) and win32process.GetWindowThreadProcessId(hwnd)[1] == pid:
-            found.append(hwnd)
-        return True
-
-    win32gui.EnumWindows(visit, None)
-    return found
+def screen_grab(hwnd, path):
+    """The naive route, kept for comparison: it also picks up whatever overlaps."""
+    img = ImageGrab.grab(bbox=win32gui.GetWindowRect(hwnd), all_screens=True)
+    img.save(path)
+    return 1.0 - sum(img.convert("L").histogram()[:16]) / (img.width * img.height)
 
 
-def controls(hwnd):
-    """Descendant control IDs and classes -- what a pywinauto walk would navigate by."""
-    out = []
-
-    def visit(child, _):
-        out.append((win32gui.GetDlgCtrlID(child), win32gui.GetClassName(child),
-                    win32gui.GetWindowText(child)[:40]))
-        return True
-
-    win32gui.EnumChildWindows(hwnd, visit, None)
-    return out
-
-
-def print_window(hwnd):
-    """Render into a memory DC: unlike a screen grab this survives occlusion."""
-    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
-    w, h = right - left, bottom - top
-    if w <= 0 or h <= 0:
-        return None, 0
-    src = win32gui.GetWindowDC(hwnd)
-    dc = win32ui.CreateDCFromHandle(src)
-    mem = dc.CreateCompatibleDC()
-    bmp = win32ui.CreateBitmap()
-    bmp.CreateCompatibleBitmap(dc, w, h)
-    mem.SelectObject(bmp)
-    ok = user32.PrintWindow(hwnd, mem.GetSafeHdc(), PW_RENDERFULLCONTENT)
-    img = Image.frombuffer("RGB", (w, h), bmp.GetBitmapBits(True), "raw", "BGRX", 0, 1)
-    win32gui.DeleteObject(bmp.GetHandle())
-    mem.DeleteDC()
-    dc.DeleteDC()
-    win32gui.ReleaseDC(hwnd, src)
-    return img, ok
-
-
-def grab_screen(hwnd):
-    try:
-        return ImageGrab.grab(bbox=win32gui.GetWindowRect(hwnd), all_screens=True)
-    except Exception as e:  # a headless session can refuse the desktop DC outright
-        print(f"    screen grab failed: {e}")
-        return None
-
-
-def liveness(img):
-    """Distinct colours and non-black fraction; a dead capture is uniformly black."""
-    hist = img.convert("L").histogram()
-    n = img.width * img.height
-    colors = img.convert("RGB").getcolors(1 << 18)
-    return (len(colors) if colors else -1), 1.0 - sum(hist[:16]) / n
-
-
-def capture(hwnd, tag, outdir, results):
-    cls = win32gui.GetClassName(hwnd)
-    title = win32gui.GetWindowText(hwnd)
-    print(f"  {hwnd:#x} class={cls!r} title={title!r} rect={win32gui.GetWindowRect(hwnd)}")
-    try:
-        user32.SetForegroundWindow(hwnd)
-    except Exception:
-        pass
-    time.sleep(0.3)
-    slug = re.sub(r"[^A-Za-z0-9]+", "_", f"{tag}_{cls}_{title}").strip("_")[:60]
-    printed, ok = print_window(hwnd)
-    for how, img in (("printwindow", printed), ("screen", grab_screen(hwnd))):
-        if img is None:
-            print(f"    {how}: no image")
-            continue
-        path = os.path.join(outdir, f"{slug}_{how}.png")
-        img.save(path)
-        colors, nonblack = liveness(img)
-        print(f"    {how}: {img.width}x{img.height} colors={colors} nonblack={nonblack:.3f}"
-              f"{f' PrintWindow={ok}' if how == 'printwindow' else ''} -> {os.path.basename(path)}")
-        results.setdefault((tag, how), []).append(nonblack)
-
-
-def walk(exe, tag, outdir, checkpoints, results):
+def probe(exe, tag, outdir, checkpoints, results):
     print(f"\n=== {tag}: {exe} ===")
     proc = subprocess.Popen([exe])
     seen = set()
     try:
-        for t in checkpoints:
-            time.sleep(t)
-            for hwnd in top_level_windows(proc.pid):
-                if hwnd in seen:
-                    continue
+        for pause in checkpoints:
+            time.sleep(pause)
+            for hwnd in [h for h in top_level_windows(proc.pid) if h not in seen]:
                 seen.add(hwnd)
-                capture(hwnd, tag, outdir, results)
-                for cid, cls, text in controls(hwnd)[:40]:
-                    print(f"      id={cid} {cls!r} {text!r}")
+                cls, title = win32gui.GetClassName(hwnd), win32gui.GetWindowText(hwnd)
+                print(f"  {hwnd:#x} class={cls!r} title={title!r} rect={win32gui.GetWindowRect(hwnd)}")
+                user32.SetForegroundWindow(hwnd)
+                time.sleep(0.3)
+                name = slug(f"{tag}_{cls}_{title}")[:60]
+                for how, shoot in (("printwindow", capture), ("screen", screen_grab)):
+                    try:
+                        nonblack = shoot(hwnd, os.path.join(outdir, f"{name}_{how}.png"))
+                    except Exception as e:
+                        print(f"    {how}: failed: {e}")
+                        continue
+                    print(f"    {how}: nonblack={nonblack:.3f}")
+                    results.setdefault((tag, how), []).append(nonblack)
+                for _, cid, cls, text in controls(hwnd)[:40]:
+                    print(f"      id={cid} {cls!r} {text[:40]!r}")
         if not seen:
-            print(f"  {tag} opened no visible top-level window (exit code {proc.poll()})")
+            print(f"  {tag} opened no visible window (exit code {proc.poll()})")
     finally:
         subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)],
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -152,23 +79,17 @@ def main():
     os.makedirs(args.out, exist_ok=True)
 
     describe_session()
-    try:
-        import pywinauto
-        print(f"pywinauto {pywinauto.__version__}")
-    except Exception as e:
-        print(f"pywinauto unavailable: {e}")
-
     results = {}
-    got_app = walk(os.path.abspath(args.exe), "app", args.out, [6, 6, 8], results)
-    walk(os.path.join(os.environ["WINDIR"], "system32", "notepad.exe"), "notepad",
-         args.out, [4], results)
+    started = probe(os.path.abspath(args.exe), "app", args.out, [6, 6, 8], results)
+    probe(os.path.join(os.environ["WINDIR"], "system32", "notepad.exe"), "notepad",
+          args.out, [4], results)
 
     print("\n=== verdict ===")
     for (tag, how), values in sorted(results.items()):
         best = max(values)
         print(f"{tag}/{how}: best nonblack={best:.3f} -> {'renders' if best > 0.02 else 'BLANK'}")
-    if not got_app:
-        print("the app never showed a window: the walk cannot be built on this runner")
+    if not started:
+        print("the app never showed a window: the walk cannot run here")
         return 1
     return 0
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -119,7 +119,8 @@ def options(main, pid, ids, shots):
     """The eleven option tabs, switched through the sheet rather than by clicking the
     tab control, so a two-row tab layout cannot put a tab under the mouse of another."""
     before = set(top_level_windows(pid))
-    click(find(main, control_id=ids["ID_setopt"]))
+    # By class too: ID_setopt is 3, which is also IDABORT, so a bare ID is not distinctive.
+    click(find(main, control_id=ids["ID_setopt"], class_name="Button"))
     sheet = wait(lambda: next((h for h in top_level_windows(pid) if h not in before), None),
                  "the options sheet", 30)
     tabs = wait(lambda: find(sheet, class_name="SysTabControl32"), "the option tabs", 15)
@@ -143,7 +144,7 @@ def run(pid, ids, shots, url, base_path):
         combo = ComboBoxWrapper(find(lang, control_id=ids["IDC_lang"]))
         print(f"  languages: {combo.selected_text()!r} of {len(combo.item_texts())}")
         combo.select("English")
-        click(find(lang, control_id=IDOK))
+        click(find(lang, control_id=IDOK, class_name="Button"))
     except Timeout:
         print("  no language dialog: not a first run")
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Capture every documentation screen of WinHTTrack.
+
+Drives the wizard end to end -- project, URL, the option tabs, then a real crawl of a
+site this process serves -- and writes one PNG per screen. Controls are located by
+resource ID read from WinHTTrack/resource.h, so a relabelled or resized dialog still
+walks and a renumbered one fails loudly instead of shooting the wrong window.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import win32gui
+from pywinauto.controls.common_controls import TabControlWrapper
+from pywinauto.controls.win32_controls import ComboBoxWrapper
+
+from wincapture import (Timeout, capture, click, controls, find, set_text, slug,
+                        top_level_windows, wait, window_titled)
+
+# MFC's wizard buttons and the property-sheet page selector are standard.
+ID_WIZBACK, ID_WIZNEXT, ID_WIZFINISH = 0x3023, 0x3024, 0x3025
+IDOK, IDCANCEL = 1, 2
+PSM_SETCURSEL = 0x0465
+TCM_GETITEMCOUNT = 0x1304
+
+PROJECT = "Demo Project"
+NEEDED = ("IDC_lang", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath", "IDC_URL",
+          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend")
+
+
+class Site(BaseHTTPRequestHandler):
+    """Interlinked pages served slowly, so the crawl is still running with real numbers
+    on it when the progress screen is captured."""
+
+    pages = 24
+    delay = 0.35
+    filler = "HTTrack copies a site by following its links, page by page. " * 90
+
+    def body(self):
+        if self.path == "/":
+            links = "".join(f'<li><a href="page{i}.html">Page {i}</a></li>'
+                            for i in range(1, self.pages + 1))
+            return ("<html><head><title>Demo site</title></head><body>"
+                    f"<h1>Demo site</h1><ul>{links}</ul></body></html>")
+        m = re.fullmatch(r"/page(\d+)\.html", self.path)
+        if not m or not 1 <= int(m.group(1)) <= self.pages:
+            return None
+        n = int(m.group(1))
+        nxt = n % self.pages + 1
+        return (f"<html><head><title>Page {n}</title></head><body><h1>Page {n}</h1>"
+                f'<p>{self.filler}</p><a href="page{nxt}.html">next</a> <a href="/">home</a>'
+                "</body></html>")
+
+    def do_GET(self):
+        time.sleep(self.delay)
+        body = self.body()
+        if body is None:
+            self.send_error(404)
+            return
+        raw = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *_):
+        pass
+
+
+def serve(port):
+    server = ThreadingHTTPServer(("127.0.0.1", port), Site)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def resource_ids(path):
+    ids = {}
+    for line in open(path, encoding="utf-8"):
+        m = re.match(r"#define\s+(\w+)\s+(\d+)", line)
+        if m:
+            ids.setdefault(m.group(1), int(m.group(2)))
+    missing = [n for n in NEEDED if n not in ids]
+    if missing:
+        raise SystemExit(f"{path} defines none of: {', '.join(missing)}")
+    return ids
+
+
+class Shots:
+    def __init__(self, outdir):
+        self.outdir = outdir
+        self.taken = []
+
+    def take(self, hwnd, name):
+        path = os.path.join(self.outdir, f"{name}.png")
+        nonblack = capture(hwnd, path)
+        print(f"  {name}.png  {nonblack:.3f} non-black")
+        # A window that is up but has not painted captures as a black rectangle, which
+        # looks like a successful shot until someone opens the artifact.
+        if nonblack < 0.02:
+            raise RuntimeError(f"{name}.png came out blank")
+        self.taken.append(path)
+
+
+def pane(main, anchor, what, timeout=30):
+    """Wait for a wizard pane: its own anchor control turns visible only once the page
+    is on screen, since the sheet keeps every page's controls alive from the start."""
+    return wait(lambda: find(main, control_id=anchor), what, timeout)
+
+
+def options(main, pid, ids, shots):
+    """The eleven option tabs, switched through the sheet rather than by clicking the
+    tab control, so a two-row tab layout cannot put a tab under the mouse of another."""
+    before = set(top_level_windows(pid))
+    click(find(main, control_id=ids["ID_setopt"]))
+    sheet = wait(lambda: next((h for h in top_level_windows(pid) if h not in before), None),
+                 "the options sheet", 30)
+    tabs = wait(lambda: find(sheet, class_name="SysTabControl32"), "the option tabs", 15)
+    count = win32gui.SendMessage(tabs, TCM_GETITEMCOUNT, 0, 0)
+    captions = TabControlWrapper(tabs)
+    print(f"  options sheet {sheet:#x}: {count} tabs")
+    for i in range(count):
+        win32gui.SendMessage(sheet, PSM_SETCURSEL, i, 0)
+        time.sleep(0.6)
+        shots.take(sheet, f"{4 + i:02d}_options_{slug(captions.get_tab_text(i))}")
+    click(find(sheet, control_id=IDCANCEL))
+    wait(lambda: sheet not in top_level_windows(pid), "the options sheet to close", 15)
+
+
+def run(pid, ids, shots, url, base_path):
+    # Only a first run offers the language, so a VM replay skips this shot rather than
+    # failing on it.
+    try:
+        lang = wait(lambda: window_titled(pid, "About WinHTTrack"), "the language dialog", 25)
+        shots.take(lang, "00_language_preference")
+        combo = ComboBoxWrapper(find(lang, control_id=ids["IDC_lang"]))
+        print(f"  languages: {combo.selected_text()!r} of {len(combo.item_texts())}")
+        combo.select("English")
+        click(find(lang, control_id=IDOK))
+    except Timeout:
+        print("  no language dialog: not a first run")
+
+    main = wait(lambda: window_titled(pid, r"WinHTTrack Website Copier - \["), "the main window", 60)
+
+    pane(main, ids["IDC_STATIC_welcome"], "the welcome pane")
+    shots.take(main, "01_startup")
+    click(find(main, control_id=ID_WIZNEXT))
+
+    pane(main, ids["IDC_projname"], "the project pane")
+    set_text(find(main, control_id=ids["IDC_projname"]), PROJECT)
+    set_text(find(main, control_id=ids["IDC_projpath"]), base_path)
+    shots.take(main, "02_project_name")
+    click(find(main, control_id=ID_WIZNEXT))
+
+    pane(main, ids["IDC_URL"], "the URL pane")
+    set_text(find(main, control_id=ids["IDC_URL"]), url)
+    shots.take(main, "03_project_setup")
+
+    options(main, pid, ids, shots)
+
+    click(find(main, control_id=ID_WIZNEXT))
+    pane(main, ids["IDC_select_start"], "the ready-to-start pane")
+    shots.take(main, "15_ready_to_start")
+
+    click(find(main, control_id=ID_WIZFINISH))
+    pane(main, ids["IDC_inforun"], "the progress pane", timeout=60)
+    time.sleep(6)  # let the counters fill, or the shot is a screen of zeros
+    shots.take(main, "16_mirror_progress")
+
+    pane(main, ids["IDC_infoend"], "the finished pane", timeout=300)
+    time.sleep(1)
+    shots.take(main, "17_mirror_finished")
+
+
+def diagnose(pid, outdir):
+    """On failure, shoot and dump every window the app has open: which one it is stuck
+    on, and what is on it, is the whole diagnosis."""
+    print("--- diagnostics ---")
+    for hwnd in top_level_windows(pid):
+        print(f"  {hwnd:#x} {win32gui.GetClassName(hwnd)!r} {win32gui.GetWindowText(hwnd)!r}")
+        try:
+            capture(hwnd, os.path.join(outdir, f"diag_{hwnd:#x}.png"))
+        except Exception as e:
+            print(f"    capture failed: {e}")
+        for child, cid, cls, text in controls(hwnd):
+            if win32gui.IsWindowVisible(child) and (text or cls != "Static"):
+                print(f"    id={cid} {cls!r} {text[:50]!r}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--exe", required=True)
+    ap.add_argument("--out", default="shots")
+    ap.add_argument("--resource-h", default=os.path.join("WinHTTrack", "resource.h"))
+    ap.add_argument("--port", type=int, default=8099)
+    ap.add_argument("--base-path", default=r"C:\shots-mirror")
+    args = ap.parse_args()
+
+    ids = resource_ids(args.resource_h)
+    os.makedirs(args.out, exist_ok=True)
+    # An existing mirror finishes from cache in no time, which turns the progress shot
+    # into a second copy of the finished screen.
+    shutil.rmtree(args.base_path, ignore_errors=True)
+    serve(args.port)
+
+    shots = Shots(args.out)
+    exe = os.path.abspath(args.exe)
+    proc = subprocess.Popen([exe], cwd=os.path.dirname(exe))
+    try:
+        run(proc.pid, ids, shots, f"http://127.0.0.1:{args.port}/", args.base_path)
+    except Exception as e:
+        print(f"FAILED: {e}")
+        diagnose(proc.pid, args.out)
+        return 1
+    finally:
+        subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    print(f"\n{len(shots.taken)} screens captured in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -1,0 +1,43 @@
+# Documentation screenshots
+
+`screenshot-walk.py` drives the GUI and captures one PNG per documentation screen:
+the first-run language dialog, the welcome, project and URL panes, all eleven option
+tabs, the ready-to-start pane, and a mirror in progress and finished. The crawl is
+real — the script serves a small site to itself, so the progress screen carries live
+counters rather than zeros.
+
+## Replay
+
+Run the **screenshots** workflow (Actions → Run workflow) and download the
+`screenshots` artifact. It takes the binaries from the last green `windows-build` on
+the branch you dispatch it from, falling back to master, so a new option page is shot
+from the build that added it. `run-id` overrides that; `mode: probe` runs
+`screenshot-probe.py` instead, which only answers whether the machine renders and
+captures at all — reach for it when the runner image changes or when moving to a VM.
+
+On a Windows box or VM, against any staged build directory:
+
+```
+pip install pywin32 pillow pywinauto
+python tools\screenshot-walk.py --exe path\to\WinHTTrack.exe --out shots
+```
+
+## Adding an option page
+
+Nothing to edit: the tabs are enumerated from the sheet and named after their caption,
+so a new page appears in the set on the next run. A new *wizard* pane does need a line
+in `run()`, anchored on a control ID from that pane's dialog.
+
+## Traps
+
+- Controls come from `WinHTTrack/resource.h` at run time, so the checkout and the
+  binaries have to be the same version; the workflow warns when it falls back to
+  another branch's build.
+- A pane is only shot once its own anchor control is *visible*. The property sheet
+  creates every page up front, so the controls of a page that is not on screen exist
+  and would otherwise satisfy the wait.
+- An existing mirror at the base path finishes from cache in no time, which turns the
+  progress shot into a second copy of the finished screen. The script wipes it first.
+- Shots of the main window include the file tree, so on a runner they show that
+  machine's `C:\`. A VM with a tidy drive gives nicer full-window shots; the option
+  tabs are separate dialogs and carry none of it.

--- a/tools/wincapture.py
+++ b/tools/wincapture.py
@@ -1,0 +1,114 @@
+"""Win32 helpers shared by the screenshot tools: find a window, its controls, capture it."""
+
+import ctypes
+import re
+import time
+
+import win32gui
+import win32process
+import win32ui
+from PIL import Image
+
+user32 = ctypes.windll.user32
+PW_RENDERFULLCONTENT = 2
+WM_SETTEXT = 0x000C
+BM_CLICK = 0x00F5
+
+
+class Timeout(Exception):
+    pass
+
+
+def wait(fn, what, timeout=30, poll=0.4):
+    """Poll fn until it returns something truthy, or give up with a named error."""
+    deadline = time.monotonic() + timeout
+    while True:
+        value = fn()
+        if value:
+            return value
+        if time.monotonic() > deadline:
+            raise Timeout(f"timed out after {timeout}s waiting for {what}")
+        time.sleep(poll)
+
+
+def top_level_windows(pid):
+    found = []
+
+    def visit(hwnd, _):
+        if win32gui.IsWindowVisible(hwnd) and win32process.GetWindowThreadProcessId(hwnd)[1] == pid:
+            found.append(hwnd)
+        return True
+
+    win32gui.EnumWindows(visit, None)
+    return found
+
+
+def window_titled(pid, pattern):
+    """The process's visible top-level window whose title matches, if it is up yet."""
+    for hwnd in top_level_windows(pid):
+        if re.search(pattern, win32gui.GetWindowText(hwnd)):
+            return hwnd
+    return None
+
+
+def controls(hwnd):
+    """Every descendant, as (hwnd, control id, class, text)."""
+    out = []
+
+    def visit(child, _):
+        out.append((child, win32gui.GetDlgCtrlID(child), win32gui.GetClassName(child),
+                    win32gui.GetWindowText(child)))
+        return True
+
+    win32gui.EnumChildWindows(hwnd, visit, None)
+    return out
+
+
+def find(parent, control_id=None, class_name=None, visible=True):
+    """First matching descendant. Visible by default: a property sheet keeps the
+    controls of every page alive, so existence alone does not mean it is on screen."""
+    for hwnd, cid, cls, _ in controls(parent):
+        if control_id is not None and cid != control_id:
+            continue
+        if class_name is not None and cls != class_name:
+            continue
+        if visible and not win32gui.IsWindowVisible(hwnd):
+            continue
+        return hwnd
+    return None
+
+
+def click(hwnd):
+    """Posted, not sent: a button that opens a modal dialog would block a SendMessage."""
+    win32gui.PostMessage(hwnd, BM_CLICK, 0, 0)
+
+
+def set_text(hwnd, text):
+    win32gui.SendMessage(hwnd, WM_SETTEXT, 0, text)
+
+
+def capture(hwnd, path):
+    """PrintWindow into a memory DC, so the shot carries no taskbar and nothing that
+    happens to overlap. Returns the fraction of the image that is not black."""
+    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+    w, h = right - left, bottom - top
+    if w <= 0 or h <= 0:
+        raise ValueError(f"window {hwnd:#x} has no area")
+    src = win32gui.GetWindowDC(hwnd)
+    dc = win32ui.CreateDCFromHandle(src)
+    mem = dc.CreateCompatibleDC()
+    bmp = win32ui.CreateBitmap()
+    bmp.CreateCompatibleBitmap(dc, w, h)
+    mem.SelectObject(bmp)
+    user32.PrintWindow(hwnd, mem.GetSafeHdc(), PW_RENDERFULLCONTENT)
+    img = Image.frombuffer("RGB", (w, h), bmp.GetBitmapBits(True), "raw", "BGRX", 0, 1)
+    win32gui.DeleteObject(bmp.GetHandle())
+    mem.DeleteDC()
+    dc.DeleteDC()
+    win32gui.ReleaseDC(hwnd, src)
+    img.save(path)
+    return 1.0 - sum(img.convert("L").histogram()[:16]) / (w * h)
+
+
+def slug(text):
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")


### PR DESCRIPTION
The Android side generates its documentation screenshots by driving the app on an emulator, and this does the same for the GUI. `tools/screenshot-walk.py` walks the wizard end to end (language dialog, welcome, project, URL, the eleven option tabs, then a real crawl of a site it serves to itself) and writes one PNG per screen. The `screenshots` workflow runs it on a hosted runner in about two minutes: it takes the binaries from the last green `windows-build` rather than building its own, and defaults to the branch it is dispatched from, so a new option page is shot from the build that added it.

Controls are located by resource ID read from `resource.h` at run time, so a resized or relabelled dialog still walks, and the option tabs are enumerated from the sheet, which means adding an option page needs no edit here. It stays outside `windows-build` on purpose: it touches no signing-privileged file and adds nothing to the build gate. It has run green twice, 18 screens each; `tools/screenshots.md` has the replay steps and the traps.