### PR TITLE
Give the GUI its own version, and set it to 3.50-beta-1

### DIFF
--- a/.github/actions/build-installer/action.yml
+++ b/.github/actions/build-installer/action.yml
@@ -29,8 +29,11 @@ inputs:
 
 outputs:
   version:
-    description: HTTRACK_VERSION, read from the engine header.
+    description: WINHTTRACK_VERSION, read from the GUI header. What the installer is stamped with.
     value: ${{ steps.iscc.outputs.version }}
+  engine-version:
+    description: HTTRACK_VERSION, read from the engine header. What httrack.exe and libhttrack.dll report.
+    value: ${{ steps.iscc.outputs.engine-version }}
   setup:
     description: Full path of the installer that was built.
     value: ${{ steps.iscc.outputs.setup }}
@@ -62,14 +65,19 @@ runs:
           throw ('the payload WinHTTrack.exe is machine 0x{0:x}, not the 0x{1:x} an {2} installer needs' -f $machine, $want, $arch)
         }
 
-        # Single source of truth for the version: the engine's own header.
+        # What the installer is stamped with is the GUI's version, not the engine's:
+        # WinHTTrack ships as the 3.50 beta over a 3.49 engine.
+        $vh = Get-Content (Join-Path $env:GUI_DIR 'WinHTTrack\version.h') -Raw
+        if ($vh -notmatch '#define\s+WINHTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSION' }
+        $ver = $Matches[1]
+        # Inno stamps 0.0.0.0 unless it gets a valid version number, and "3.50-beta-1" is not one.
+        if ($vh -notmatch '#define\s+WINHTTRACK_VERSIONID\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSIONID' }
+        $verid = $Matches[1]
+        # Reported alongside for the smoke test, which holds httrack.exe to it.
         $hg = Get-Content (Join-Path $env:ENGINE_DIR 'src\htsglobal.h') -Raw
         if ($hg -notmatch '#define\s+HTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSION' }
-        $ver = $Matches[1]
-        # Inno stamps 0.0.0.0 unless it gets a valid version number, and "3.49-12" is not one.
-        if ($hg -notmatch '#define\s+HTTRACK_VERSIONID\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSIONID' }
-        $verid = $Matches[1]
-        Write-Host "version = $ver ($verid), arch = $arch"
+        $engver = $Matches[1]
+        Write-Host "version = $ver ($verid), engine = $engver, arch = $arch"
 
         $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
         if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress | Out-Null }
@@ -109,4 +117,5 @@ runs:
         if ($pv -ne $ver) { throw "the installer is version '$pv', not '$ver'" }
 
         "version=$ver" | Out-File -Append $env:GITHUB_OUTPUT
+        "engine-version=$engver" | Out-File -Append $env:GITHUB_OUTPUT
         "setup=$($setup.FullName)" | Out-File -Append $env:GITHUB_OUTPUT

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -11,7 +11,10 @@ inputs:
     description: The installer to test.
     required: true
   version:
-    description: The version every binary must report.
+    description: The version WinHTTrack.exe and the installer must report.
+    required: true
+  engine-version:
+    description: The version httrack.exe must report, which trails the GUI's.
     required: true
   thumbprint:
     description: When set, every signature must be valid, timestamped, and this certificate's.
@@ -36,6 +39,7 @@ runs:
       env:
         SETUP: ${{ inputs.setup }}
         APPVER: ${{ inputs.version }}
+        ENGINEVER: ${{ inputs.engine-version }}
         THUMBPRINT: ${{ inputs.thumbprint }}
         REQUIRE_SIG: ${{ inputs.require-signature }}
         CHECK_CRASH: ${{ inputs.check-crash-report }}
@@ -47,6 +51,7 @@ runs:
         # Without this, an empty version would make [regex]::Escape('') = '' and
         # `-notmatch ''` false: every version assertion below would stop asserting.
         if ([string]::IsNullOrWhiteSpace($env:APPVER)) { throw 'no version was passed: the version checks would be vacuous' }
+        if ([string]::IsNullOrWhiteSpace($env:ENGINEVER)) { throw 'no engine version was passed: the CLI version check would be vacuous' }
         # Skipping the signature checks is the normal shape on every unsigned build,
         # so the release path has to say out loud that it expects them.
         if ($env:REQUIRE_SIG -eq 'true' -and -not $env:THUMBPRINT) { throw 'signatures were required but no thumbprint was passed' }
@@ -167,7 +172,7 @@ runs:
         }
 
         # The CLI is a separate binary against the same DLL: it can be broken while the
-        # GUI is fine. -#h prints the version and exits 0.
+        # GUI is fine. -#h prints the version -- the engine's, which stamps it -- and exits 0.
         $cli = Join-Path $dir 'httrack.exe'
         if (-not (Test-Path $cli)) { throw "the installer did not lay down httrack.exe" }
         $p = Start-Process $cli -ArgumentList '-#h' -Wait -PassThru `
@@ -176,11 +181,11 @@ runs:
         $co1 = ("$co".Trim() -split "\r?\n" | Select-Object -First 1)
         Write-Host "httrack.exe -#h -> exit=$($p.ExitCode), output='$co1'"
         if ($p.ExitCode -ne 0) { throw "httrack.exe -#h exited $($p.ExitCode)" }
-        if ($co -notmatch [regex]::Escape($env:APPVER)) {
-          throw "httrack.exe reported no version, or the wrong one: expected $env:APPVER"
+        if ($co -notmatch [regex]::Escape($env:ENGINEVER)) {
+          throw "httrack.exe reported no version, or the wrong one: expected $env:ENGINEVER"
         }
 
-        Write-Host "::notice::WinHTTrack $env:APPVER installs, starts and runs ($($setup.Name))."
+        Write-Host "::notice::WinHTTrack $env:APPVER (engine $env:ENGINEVER) installs, starts and runs ($($setup.Name))."
 
         $unins = Get-ChildItem "$dir\unins*.exe" | Select-Object -First 1
         $p = Start-Process $unins.FullName -Wait -PassThru -ArgumentList '/VERYSILENT','/NORESTART'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -8,8 +8,8 @@ name: windows-build
 on:
   push:
     branches: [master]
-    # The engine tags releases bare: 3.49.12, 3.49.8-2. Match that, and 'v' too in
-    # case anyone reaches for it. A 'v*'-only filter would silently never fire.
+    # Releases are tagged bare, like the engine's: 3.49.12, 3.50-beta-1. Match that,
+    # and 'v' too in case anyone reaches for it: a 'v*'-only filter never fires.
     tags: ['[0-9]*', 'v*']
   pull_request:
   workflow_dispatch:
@@ -621,29 +621,43 @@ jobs:
           }
           Write-Host '::notice::crash report resolves function, file and line'
 
-      # Self-imposed now that no CA enforces it: every shipped binary and the
-      # installer must agree on product name and version. Cheap to catch here.
+      # Self-imposed now that no CA enforces it: every shipped binary must carry the
+      # product name and the version of the tree that stamped it. The GUI has its own
+      # now, so it is held to version.h and the engine's two binaries to htsglobal.h.
       - name: Check the binaries agree on product name and version
         shell: pwsh
         run: |
           $bin = "httrack-windows\WinHTTrack\bin\${{ matrix.platform }}\${{ matrix.configuration }}"
           $hg = Get-Content 'httrack\src\htsglobal.h' -Raw
           if ($hg -notmatch '#define\s+HTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read HTTRACK_VERSION' }
-          $want = $Matches[1]
+          $engine = $Matches[1]
+          $vh = Get-Content 'httrack-windows\WinHTTrack\version.h' -Raw
+          if ($vh -notmatch '#define\s+WINHTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSION' }
+          $gui = $Matches[1]
           $name = 'HTTrack Website Copier'
 
           $bad = @()
-          foreach ($f in @('WinHTTrack.exe', 'httrack.exe', 'libhttrack.dll')) {
-            $v = (Get-Item (Join-Path $bin $f)).VersionInfo
+          foreach ($f in @(@{n='WinHTTrack.exe'; v=$gui}, @{n='httrack.exe'; v=$engine}, @{n='libhttrack.dll'; v=$engine})) {
+            $v = (Get-Item (Join-Path $bin $f.n)).VersionInfo
             # Trim: resource compilers pad these fields, and Inno certainly does.
             $pn = "$($v.ProductName)".Trim()
             $pv = "$($v.ProductVersion)".Trim()
-            Write-Host "  $f : ProductName='$pn' ProductVersion='$pv'"
-            if ($pn -ne $name) { $bad += "$f names the product '$pn', not '$name'" }
-            if ($pv -ne $want) { $bad += "$f is version '$pv', not '$want'" }
+            Write-Host "  $($f.n) : ProductName='$pn' ProductVersion='$pv'"
+            if ($pn -ne $name) { $bad += "$($f.n) names the product '$pn', not '$name'" }
+            if ($pv -ne $f.v) { $bad += "$($f.n) is version '$pv', not '$($f.v)'" }
           }
           if ($bad) { throw ($bad -join "`n") }
-          Write-Host "::notice::all three binaries report $name $want"
+
+          # The .rc takes its version string and its comma form from two macros, so a
+          # bump that edits one and not the other ships a file disagreeing with itself.
+          if ($vh -notmatch '#define\s+WINHTTRACK_VERSIONID\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSIONID' }
+          $verid = $Matches[1]
+          $fv = (Get-Item (Join-Path $bin 'WinHTTrack.exe')).VersionInfo
+          $num = "$($fv.FileMajorPart).$($fv.FileMinorPart).$($fv.FileBuildPart).$($fv.FilePrivatePart)"
+          if ($num -ne $verid) { throw "WinHTTrack.exe is numbered $num, but WINHTTRACK_VERSIONID says $verid" }
+          if ("$($fv.FileVersion)".Trim() -ne $verid) { throw "WinHTTrack.exe FileVersion is '$($fv.FileVersion)', not '$verid'" }
+
+          Write-Host "::notice::all three binaries report $name, the GUI at $gui and the engine at $engine"
 
       # vcpkg is invisible to Dependabot alerts, CodeQL and the dependency graph, so
       # this is the only thing between a stale OpenSSL and a signed installer. Advisory
@@ -686,6 +700,7 @@ jobs:
         with:
           setup: ${{ steps.installer.outputs.setup }}
           version: ${{ steps.installer.outputs.version }}
+          engine-version: ${{ steps.installer.outputs.engine-version }}
 
       - name: Upload the installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -938,6 +953,7 @@ jobs:
         with:
           setup: ${{ steps.x64.outputs.setup }}
           version: ${{ steps.x64.outputs.version }}
+          engine-version: ${{ steps.x64.outputs.engine-version }}
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
           check-crash-report: 'false'
@@ -948,6 +964,7 @@ jobs:
         with:
           setup: ${{ steps.x86.outputs.setup }}
           version: ${{ steps.x86.outputs.version }}
+          engine-version: ${{ steps.x86.outputs.engine-version }}
           thumbprint: ${{ env.THUMBPRINT }}
           require-signature: 'true'
           check-crash-report: 'false'

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -3,7 +3,7 @@
 ; Everything comes from the command line, so nothing is tied to one machine and CI
 ; can build this from the very artifact it already publishes:
 ;
-;   ISCC /DArch=x64 /DAppVersion=3.49-12 ^
+;   ISCC /DArch=x64 /DAppVersion=3.50-beta-1 ^
 ;        /DPayloadDir=...\WinHTTrack\bin\x64\Release ^
 ;        /DEngineDir=...\httrack /DGuiDir=...\httrack-windows ^
 ;        /DOutDir=...\out ^
@@ -20,7 +20,7 @@
   #error Arch must be set (x64 or x86)
 #endif
 #ifndef AppVersionNumeric
-  #error AppVersionNumeric must be set (dotted, e.g. 3.49.12)
+  #error AppVersionNumeric must be set (dotted, e.g. 3.49.99.1)
 #endif
 #ifndef AppVersion
   #error AppVersion must be set
@@ -28,6 +28,7 @@
 
 [Setup]
 AppName=WinHTTrack Website Copier
+; The GUI carries its own version (WinHTTrack/version.h); the engine is on its own.
 AppVersion={#AppVersion}
 AppVerName=WinHTTrack Website Copier {#AppVersion}
 VersionInfoProductName=HTTrack Website Copier

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -53,7 +53,7 @@ Right-click the installer, choose *Properties*, and open the *Digital Signatures
 from PowerShell:
 
 ```powershell
-Get-AuthenticodeSignature .\httrack_x64_3.49-14.exe |
+Get-AuthenticodeSignature .\httrack_x64_3.50-beta-1.exe |
   Format-List Status, SignerCertificate, TimeStamperCertificate
 ```
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -45,6 +45,7 @@ Please visit our Website: http://www.httrack.com
 #include "inprogress.h"
 
 #include "CrashReport.h"
+#include "version.h"
 
 // KB955045 (http://support.microsoft.com/kb/955045)
 // To execute an application using this function on earlier versions of Windows
@@ -263,7 +264,7 @@ BOOL CWinHTTrackApp::InitInstance()
   for (int i = 1; __argv != NULL && i < __argc; i++) {
     if (strcmp(__argv[i], "--version") == 0) {
       WhttEnsureConsole();
-      printf("WinHTTrack %s\n", HTTRACK_VERSION);
+      printf("WinHTTrack %s (engine %s)\n", WINHTTRACK_VERSION, HTTRACK_VERSION);
       fflush(stdout);
       ExitProcess(0);
     } else if (strcmp(__argv[i], "--selftest") == 0) {
@@ -450,7 +451,7 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       CrashReportLogException(reason);
     } END_CATCH_ALL
-    printf("WinHTTrack %s: startup ok\n", HTTRACK_VERSION);
+    printf("WinHTTrack %s: startup ok\n", WINHTTRACK_VERSION);
     fflush(stdout);
     ExitProcess(0);
   }

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
+#include "version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -748,8 +749,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,49,14,0
- PRODUCTVERSION 3,49,14,0
+ FILEVERSION WINHTTRACK_VERSION_NUM
+ PRODUCTVERSION WINHTTRACK_VERSION_NUM
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -767,13 +768,13 @@ BEGIN
             VALUE "Comments", "Website Copier [Offline Browser]"
             VALUE "CompanyName", "HTTrack"
             VALUE "FileDescription", "WinHTTrack Website Copier, Copy Websites to Your Computer"
-            VALUE "FileVersion", "3.49.14"
+            VALUE "FileVersion", WINHTTRACK_VERSIONID
             VALUE "InternalName", "WinHTTrack"
             VALUE "LegalCopyright", "Copyright (C) 1998-2026 Xavier Roche and other contributors"
             VALUE "LegalTrademarks", "This software is covered by the GNU General Public License version 3"
             VALUE "OriginalFilename", "WinHTTrack.exe"
             VALUE "ProductName", "HTTrack Website Copier"
-            VALUE "ProductVersion", "3.49-14"
+            VALUE "ProductVersion", WINHTTRACK_VERSION
         END
     END
     BLOCK "VarFileInfo"

--- a/WinHTTrack/WinHTTrack.vcxproj
+++ b/WinHTTrack/WinHTTrack.vcxproj
@@ -227,6 +227,7 @@
     <ClInclude Include="StdAfx.h" />
     <ClInclude Include="trans.h" />
     <ClInclude Include="TreeViewToolTip.h" />
+    <ClInclude Include="version.h" />
     <ClInclude Include="Wid1.h" />
     <ClInclude Include="WinHTTrack.h" />
     <ClInclude Include="WinHTTrackDoc.h" />

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -30,6 +30,7 @@ Please visit our Website: http://www.httrack.com
 #include "stdafx.h"
 #include "Shell.h"
 #include "about.h"
+#include "version.h"
 //#include "about_sh.h"
 
 #ifdef _DEBUG
@@ -145,7 +146,7 @@ BOOL Cabout::OnInitDialog()
 
 void Cabout::setlang() {
   const char* avail = hts_is_available();
-  CString info = "WinHTTrack Website Copier ";
+  CString info = "WinHTTrack Website Copier " WINHTTRACK_VERSION ", engine ";
   info+= _HTTRACK_VERSION;
   if (avail && *avail) {
     info+=" (";

--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -1,0 +1,47 @@
+/* ------------------------------------------------------------ */
+/*
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) 2026 Xavier Roche and other contributors
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Ethical use: we kindly ask that you NOT use this software to harvest email
+addresses or to collect any other private information about people. Doing so
+would dishonor our work and waste the many hours we have spent on it.
+
+Please visit our Website: http://www.httrack.com
+*/
+
+/* ------------------------------------------------------------ */
+/* File: WinHTTrack subroutines:                                */
+/*       GUI version, distinct from the engine's                */
+/* Author: Xavier Roche                                         */
+/* ------------------------------------------------------------ */
+
+#ifndef WINHTTRACK_VERSION_H
+#define WINHTTRACK_VERSION_H
+
+/* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
+   version. Bump it here only: the .rc, the installer and CI all read this file. */
+#define WINHTTRACK_VERSION "3.50-beta-1"
+
+/* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
+#define WINHTTRACK_VERSIONID "3.49.99.1"
+
+/* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 1
+
+#endif


### PR DESCRIPTION
WinHTTrack.exe and the installer now take their version from a new `WinHTTrack/version.h`, set to 3.50-beta-1. `httrack.exe` and `libhttrack.dll` still report what the engine stamped them with, currently 3.49-15, and CI holds each pair to the tree that built it instead of demanding one version across all four. The beta ships over a 3.49 engine, so the old rule would have forced the release to be called 3.49-15.

The numeric form is 3.49.99.1 rather than 3.50.0.1, so the eventual 3.50 release outranks its own betas. The installer becomes `httrack_x64_3.50-beta-1.exe`, the About box reads "WinHTTrack Website Copier 3.50-beta-1, engine 3.49-15", and `--version` prints both. Nothing in this repo tracks the engine version any more, so an engine bump can no longer turn master red here.