### PR TITLE
Set the GUI version to 3.50-beta-2

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-1"
+#define WINHTTRACK_VERSION "3.50-beta-2"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.1"
+#define WINHTTRACK_VERSIONID "3.49.99.2"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 1
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 2
 
 #endif


### PR DESCRIPTION
Bumps the GUI to 3.50-beta-2. Since beta-1 the app has picked up the rebranded icon and splash (6cae663) and the installer has picked up wizard artwork of its own (#89). The engine tree has moved too, even though its version string has not.

That last part is worth stating plainly: the engine is still 3.49-15, because 3.49.15 landed about an hour before beta-1 was built. What is new is the 29 commits master has taken since, two of which change what a mirror actually does. The cache no longer aborts a crawl on URLs it accepts (httrack#939), and a chunked response carrying trailers is no longer thrown away as "Invalid chunk" (httrack#913). The documentation the installer ships also gets the vector wordmark and ring background.
