### PR TITLE
A release engine pin is never cleared, and silently freezes later builds

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -237,6 +237,10 @@ jobs:
           if ($env:GH_REF -like 'refs/tags/*' -and $env:ENGINE_REF -notmatch '^[0-9a-f]{40}$') {
             throw "Tagged build needs HTTRACK_ENGINE_REF pinned to a 40-hex SHA (got '$env:ENGINE_REF')"
           }
+          # That pin outlives the release that needed it, freezing every later build.
+          if ($env:GH_REF -notlike 'refs/tags/*' -and $env:ENGINE_REF) {
+            Write-Host "::warning::engine is pinned to $env:ENGINE_REF; clear the HTTRACK_ENGINE_REF variable unless this build is meant to be frozen"
+          }
 
       # Located with vswhere rather than microsoft/setup-msbuild. A repo that
       # restricts Actions to GitHub-owned ones kills a third-party action as a

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -237,7 +237,7 @@ jobs:
           if ($env:GH_REF -like 'refs/tags/*' -and $env:ENGINE_REF -notmatch '^[0-9a-f]{40}$') {
             throw "Tagged build needs HTTRACK_ENGINE_REF pinned to a 40-hex SHA (got '$env:ENGINE_REF')"
           }
-          # That pin outlives the release that needed it, freezing every later build.
+          # A release tag sets that pin, and nothing clears it afterwards.
           if ($env:GH_REF -notlike 'refs/tags/*' -and $env:ENGINE_REF) {
             Write-Host "::warning::engine is pinned to $env:ENGINE_REF; clear the HTTRACK_ENGINE_REF variable unless this build is meant to be frozen"
           }


### PR DESCRIPTION
A tagged build refuses to run on a floating engine, so cutting a release means pinning `HTTRACK_ENGINE_REF`. It is a repo variable, though, so the pin goes on applying to ordinary master pushes afterwards and quietly freezes them on that engine. 3.49.14 left it set; 3.50-beta-2 set it again.

Non-tag builds now warn. It stays a warning deliberately: pinning on purpose while chasing an engine regression is a real thing to want, and letting CI clear the variable itself would mean handing the signing workflow write access to repo settings.
