### PR TITLE
A wizard question longer than 999 bytes aborts WinHTTrack

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -132,9 +132,9 @@ extern CSplitterFrame* this_CSplitterFrame;
 /* Main WizTab frame */
 #include "WizTab.h"
 extern CWizTab* this_CWizTab;
-/* Argh - pas de domodal dans des autres threads ?!?! */
-char WIZ_question[1000];
-char WIZ_reponse[1000];
+/* Argh - no DoModal() outside the main thread ?!?! */
+char WIZ_question[WIZ_QUESTION_SIZE];
+char WIZ_reponse[WIZ_QUESTION_SIZE];
 
 httrackp *global_opt = NULL;
 
@@ -1625,10 +1625,16 @@ int inprogress_refresh() {
   return 1;
 }
 
-/* Plantages si DoModal() dans un thread != du principal.. passons.. */
+/* The question comes off the wire, so clip it rather than let strcpybuff abort. */
+static void wiz_setquestion(const char* question) {
+  WIZ_question[0] = '\0';
+  strlncatbuff(WIZ_question, question, sizeof(WIZ_question), sizeof(WIZ_question) - 1);
+  WIZ_reponse[0] = '\0';
+}
+
+/* DoModal() from a non-main thread crashes, so never mind.. */
 const char* __cdecl httrackengine_query(t_hts_callbackarg *carg, httrackp *opt, const char* question) {
-  strcpybuff(WIZ_question,question);
-  strcpybuff(WIZ_reponse, "");
+  wiz_setquestion(question);
   // AfxGetMainWnd()
   CWnd* wnd = GetMainWindow();
   if (wnd) {
@@ -1638,8 +1644,7 @@ const char* __cdecl httrackengine_query(t_hts_callbackarg *carg, httrackp *opt, 
 }
 
 const char* __cdecl httrackengine_query2(t_hts_callbackarg *carg, httrackp *opt, const char* question) {
-  strcpybuff(WIZ_question,question);
-  strcpybuff(WIZ_reponse, "");
+  wiz_setquestion(question);
   // AfxGetMainWnd()
   CWnd* wnd = GetMainWindow();
   if (wnd) {
@@ -1649,8 +1654,7 @@ const char* __cdecl httrackengine_query2(t_hts_callbackarg *carg, httrackp *opt,
 }
 
 const char* __cdecl httrackengine_query3(t_hts_callbackarg *carg, httrackp *opt, const char* question) {
-  strcpybuff(WIZ_question,question);
-  strcpybuff(WIZ_reponse, "");
+  wiz_setquestion(question);
   CWnd* wnd = GetMainWindow();
   if (wnd) {
     wnd->SendMessage(WM_COMMAND,wm_WizRequest3,0);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -70,6 +70,11 @@ Please visit our Website: http://www.httrack.com
 #define wm_WizRequest2 (WM_USER + 102)
 #define wm_WizRequest3 (WM_USER + 103)
 
+// Wizard question/answer: the question can be a whole URL, which the engine bounds at HTS_URLMAXSIZE*2.
+#define WIZ_QUESTION_SIZE (HTS_URLMAXSIZE * 2)
+extern char WIZ_question[WIZ_QUESTION_SIZE];
+extern char WIZ_reponse[WIZ_QUESTION_SIZE];
+
 // char[] dynamiques
 #define dynstrcpy(dest,src) { \
   if (dest) free(dest);\

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -78,12 +78,10 @@ static char THIS_FILE[] = __FILE__;
 #include "DialogContainer.h"
 #include "InfoUrl.h"
 
-// PAS de domodal a l'exterieur!!!!!
+// No DoModal() outside the main thread!
 #include "wizard.h"
 #include "wizard2.h"
 #include "WizLinks.h"
-extern char WIZ_question[1000];
-extern char WIZ_reponse[1000];
 
 
 extern Wid1* dialog1;
@@ -745,7 +743,9 @@ void CWinHTTrackApp::OnWizRequest1() {
   wizard diawiz;
   diawiz.m_question=WIZ_question;
   diawiz.DoModal();
-  strcpybuff(WIZ_reponse,diawiz.m_reponse);
+  // User-typed, so clip rather than abort on a long one.
+  WIZ_reponse[0] = '\0';
+  strlncatbuff(WIZ_reponse, (LPCTSTR) diawiz.m_reponse, sizeof(WIZ_reponse), sizeof(WIZ_reponse) - 1);
 }
 
 void CWinHTTrackApp::OnWizRequest2() {


### PR DESCRIPTION
`WIZ_question` is the buffer the engine threads hand the wizard dialogs their question through, and it was 1000 bytes. `query3` passes a whole URL, which `htswizard.c` builds in a `char[HTS_URLMAXSIZE * 2]`, so anything past 999 bytes overflows it. `strcpybuff` aborts instead of truncating, so WinHTTrack dies on a link the crawl found rather than asking about it. Any site can trigger it in "Download web site(s) + questions" mode, since the URL comes off the wire.

The buffer is now sized to the engine's own bound and declared once in `Shell.h`, rather than twice with a literal in two files that had to agree. The copy clips, so a later change on the engine side cannot bring the abort back. The answer typed into the wizard's edit box goes the same way, because a long enough paste aborted there too.

I found this while looking at xroche/httrack#277, which asks for the whole link to be visible in that dialog. #33 already fixed that; this is the buffer underneath it. I checked the clip by compiling the macro against the engine headers on Linux and running it: 1200 bytes used to SIGABRT and now round-trips intact, the full 2047 survives, and anything longer clips. The dialog itself still needs a Windows box to confirm. CI compiles and links the GUI, but it never displays it.
