### PR TITLE
Let the tab pages follow the window size

### DIFF
--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -117,8 +117,7 @@ BOOL CFirstInfo::OnInitDialog()
   wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1;
   m_splash.SetWindowPlacement(&wp);
 
-  /* Only now that the splash has its real size: the anchors are recorded from the rects
-     the controls have at this point, and the template gives it a 20x20 icon box. */
+  /* After the splash resize: anchors come from the rects now, not the template's box. */
   BuildLayout();
 
   // Patcher l'interface pour les Français ;-)

--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -109,14 +109,17 @@ BOOL CFirstInfo::OnInitDialog()
 {
 
 	CPropertyPage::OnInitDialog();
-  BuildLayout();
 	EnableToolTips(true);     // TOOL TIPS
 
   WINDOWPLACEMENT wp;
   m_splash.GetWindowPlacement(&wp);
   wp.rcNormalPosition.right=wp.rcNormalPosition.left+300+1;
-  wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1; 
+  wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1;
   m_splash.SetWindowPlacement(&wp);
+
+  /* Only now that the splash has its real size: the anchors are recorded from the rects
+     the controls have at this point, and the template gives it a 20x20 icon box. */
+  BuildLayout();
 
   // Patcher l'interface pour les Français ;-)
   if (LANG_T(-1)) {    // Patcher en français

--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -80,6 +80,7 @@ BEGIN_MESSAGE_MAP(CFirstInfo, CPropertyPage)
 	//{{AFX_MSG_MAP(CFirstInfo)
 	ON_WM_MOUSEMOVE()
 	ON_WM_LBUTTONDOWN()
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -108,6 +109,7 @@ BOOL CFirstInfo::OnInitDialog()
 {
 
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
 	EnableToolTips(true);     // TOOL TIPS
 
   WINDOWPLACEMENT wp;
@@ -188,3 +190,16 @@ void CFirstInfo::OnLButtonDown(UINT nFlags, CPoint point)
 }
 // !! FIN COPIE DE ABOUT.CPP !!
 
+
+void CFirstInfo::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_welcome, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_SPLASH, 100, 0);
+}
+
+void CFirstInfo::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/FirstInfo.h
+++ b/WinHTTrack/FirstInfo.h
@@ -37,6 +37,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // CFirstInfo dialog
 
+#include "WndLayout.h"
+
 class CFirstInfo : public CPropertyPage
 {
 	DECLARE_DYNCREATE(CFirstInfo)
@@ -63,10 +65,13 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(CFirstInfo)
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
 	BOOL OnInitDialog();
   BOOL OnSetActive();

--- a/WinHTTrack/Infoend.cpp
+++ b/WinHTTrack/Infoend.cpp
@@ -106,6 +106,7 @@ BEGIN_MESSAGE_MAP(Cinfoend, CPropertyPage)
 	ON_WM_HELPINFO()
 	ON_WM_TIMER()
 	ON_WM_DESTROY()
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
   ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
@@ -118,6 +119,7 @@ END_MESSAGE_MAP()
 
 BOOL Cinfoend::OnInitDialog() 
 {
+  BuildLayout();
   UpdateData(false);      // force to call DoDataExchange
 
 	//CPropertyPage::OnInitDialog();
@@ -322,4 +324,18 @@ void Cinfoend::OnDestroy()
     tm=-1; 
   }
 	CPropertyPage::OnDestroy();
+}
+
+void Cinfoend::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_infoend, 0, 100, 0, 100);
+  m_layout.AddId(this, IDlog, 0, 0, 100, 0);
+  m_layout.AddId(this, IDbrowse, 0, 0, 100, 0);
+}
+
+void Cinfoend::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
 }

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -76,6 +76,7 @@ CMainTab::~CMainTab()
 {
 }
 
+/* NULL for every sheet here: MFC installs a callback only on the modeless Create path. */
 static PFNPROPSHEETCALLBACK sheet_callback = NULL;
 
 /* A sizing border only works if it is in the dialog template comctl32 builds: adding
@@ -95,7 +96,7 @@ static int CALLBACK SheetPreCreate(HWND hWnd, UINT message, LPARAM lParam)
     else
       ((DLGTEMPLATE*) lParam)->style |= WS_THICKFRAME|WS_MAXIMIZEBOX;
   }
-  // MFC hooks PSCB_INITIALIZED with its own callback; SheetPreCreate must call it too.
+  // Chain whatever was there, so a sheet brought up modeless keeps MFC's own callback.
   return (sheet_callback != NULL) ? sheet_callback(hWnd, message, lParam) : 0;
 }
 

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -76,9 +76,40 @@ CMainTab::~CMainTab()
 {
 }
 
+/* comctl32 builds the sheet's dialog template itself, and a sizing border only works if
+   it is in that template: adding WS_THICKFRAME to the created window draws the border
+   but leaves the window fixed. PSCB_PRECREATE is the one chance to reach the template. */
+static PFNPROPSHEETCALLBACK sheet_callback = NULL;
+
+static int CALLBACK SheetPreCreate(HWND hWnd, UINT message, LPARAM lParam)
+{
+  if (message == PSCB_PRECREATE && lParam != 0) {
+    /* Either template shape can turn up. The extended one carries a 0xFFFF signature
+       where the plain one has the top half of its style. */
+    struct DLGTEMPLATEEX_HEAD {
+      WORD dlgVer, signature;
+      DWORD helpID, exStyle, style;
+    };
+    DLGTEMPLATEEX_HEAD* const ex = (DLGTEMPLATEEX_HEAD*) lParam;
+    if (ex->signature == 0xFFFF)
+      ex->style |= WS_THICKFRAME|WS_MAXIMIZEBOX;
+    else
+      ((DLGTEMPLATE*) lParam)->style |= WS_THICKFRAME|WS_MAXIMIZEBOX;
+  }
+  // MFC's own callback hooks the sheet at PSCB_INITIALIZED, so it has to keep running.
+  return (sheet_callback != NULL) ? sheet_callback(hWnd, message, lParam) : 0;
+}
+
 void CMainTab::AddControlPages()
 {
   m_minSize.cx = m_minSize.cy = 0;    // OnInitDialog measures it
+  // Guarded: UnDefineDefaultProxy calls this again, and chaining onto ourselves would
+  // recurse forever.
+  if (m_psh.pfnCallback != SheetPreCreate) {
+    sheet_callback = m_psh.pfnCallback;
+    m_psh.pfnCallback = SheetPreCreate;
+    m_psh.dwFlags |= PSH_USECALLBACK;
+  }
   m_hIcon = httrack_icon;
   m_psh.dwFlags |= PSP_USEHICON;  // utiliser icône
   m_psh.dwFlags &= ~PSH_HASHELP;  // pas de bouton help
@@ -167,10 +198,10 @@ BOOL CMainTab::OnInitDialog()
   //SetActivePage(GetPageCount()-1);
   SetActivePage(0);
 
-  /* The template is a fixed dialog; give it a sizing border so the pages holding long
-     text (scan rules, HTTP headers) can be enlarged. A sizing border is thicker than
-     the one the sheet was created with, so grow the window by what it takes from the
-     client area: the controls were placed for the old one. */
+  /* Second half of the sizing border, for the case where the template above was not
+     ours to change: this draws the frame, and the growth below gives back the client
+     area a thicker frame takes from controls placed for the old one. Both are no-ops
+     once SheetPreCreate has done its work. */
   CRect before, after, frame;
   GetClientRect(before);
   ModifyStyle(0, WS_THICKFRAME|WS_MAXIMIZEBOX);
@@ -201,6 +232,10 @@ void CMainTab::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
   if (m_minSize.cx > 0) {
     lpMMI->ptMinTrackSize.x = m_minSize.cx;
     lpMMI->ptMinTrackSize.y = m_minSize.cy;
+    /* Last word on the maximum as well: a sheet proc that means to stay fixed pins this
+       to the size it computed, and the drag then has nowhere to go. */
+    lpMMI->ptMaxTrackSize.x = max(lpMMI->ptMaxTrackSize.x, ::GetSystemMetrics(SM_CXMAXTRACK));
+    lpMMI->ptMaxTrackSize.y = max(lpMMI->ptMaxTrackSize.y, ::GetSystemMetrics(SM_CYMAXTRACK));
   }
 }
 

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -77,7 +77,7 @@ CMainTab::~CMainTab()
 }
 
 /* NULL for every sheet here: MFC installs a callback only on the modeless Create path. */
-static PFNPROPSHEETCALLBACK sheet_callback = NULL;
+static PFNPROPSHEETCALLBACK sheetCallback = NULL;
 
 /* A sizing border only works if it is in the dialog template comctl32 builds: adding
    WS_THICKFRAME to the created window draws it but leaves the size fixed. */
@@ -97,7 +97,7 @@ static int CALLBACK SheetPreCreate(HWND hWnd, UINT message, LPARAM lParam)
       ((DLGTEMPLATE*) lParam)->style |= WS_THICKFRAME|WS_MAXIMIZEBOX;
   }
   // Chain whatever was there, so a sheet brought up modeless keeps MFC's own callback.
-  return (sheet_callback != NULL) ? sheet_callback(hWnd, message, lParam) : 0;
+  return (sheetCallback != NULL) ? sheetCallback(hWnd, message, lParam) : 0;
 }
 
 void CMainTab::AddControlPages()
@@ -105,7 +105,7 @@ void CMainTab::AddControlPages()
   m_minSize.cx = m_minSize.cy = 0;    // OnInitDialog measures it
   // UnDefineDefaultProxy calls this again; chaining onto ourselves would recurse forever.
   if (m_psh.pfnCallback != SheetPreCreate) {
-    sheet_callback = m_psh.pfnCallback;
+    sheetCallback = m_psh.pfnCallback;
     m_psh.pfnCallback = SheetPreCreate;
     m_psh.dwFlags |= PSH_USECALLBACK;
   }
@@ -239,8 +239,7 @@ void CMainTab::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
 LRESULT CMainTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
   const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
-  if (CSheetLayout::IsPageChange(message, wParam, lParam))
-    m_sheetLayout.LayoutActivePage();
+  m_sheetLayout.HandleMessage(message, wParam, lParam);
   return r;
 }
 

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -168,11 +168,19 @@ BOOL CMainTab::OnInitDialog()
   SetActivePage(0);
 
   /* The template is a fixed dialog; give it a sizing border so the pages holding long
-     text (scan rules, HTTP headers) can be enlarged. Measure afterwards: the new frame
-     is thicker than the one the sheet was created with. */
+     text (scan rules, HTTP headers) can be enlarged. A sizing border is thicker than
+     the one the sheet was created with, so grow the window by what it takes from the
+     client area: the controls were placed for the old one. */
+  CRect before, after, frame;
+  GetClientRect(before);
   ModifyStyle(0, WS_THICKFRAME|WS_MAXIMIZEBOX);
   SetWindowPos(NULL, 0,0,0,0, SWP_NOMOVE|SWP_NOSIZE|SWP_NOZORDER|SWP_FRAMECHANGED);
-  CRect frame;
+  GetClientRect(after);
+  GetWindowRect(frame);
+  SetWindowPos(NULL, 0, 0,
+               frame.Width()  + before.Width()  - after.Width(),
+               frame.Height() + before.Height() - after.Height(),
+               SWP_NOMOVE|SWP_NOZORDER);
   GetWindowRect(frame);
   m_minSize = frame.Size();
   m_sheetLayout.Build(this);
@@ -199,8 +207,7 @@ void CMainTab::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
 LRESULT CMainTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
   const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
-  // A page comctl32 has just shown comes back at its creation rect.
-  if (message == PSM_SETCURSEL || message == PSM_SETCURSELID)
+  if (CSheetLayout::IsPageChange(message, wParam, lParam))
     m_sheetLayout.LayoutActivePage();
   return r;
 }

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -78,6 +78,7 @@ CMainTab::~CMainTab()
 
 void CMainTab::AddControlPages()
 {
+  m_minSize.cx = m_minSize.cy = 0;    // OnInitDialog measures it
   m_hIcon = httrack_icon;
   m_psh.dwFlags |= PSP_USEHICON;  // utiliser icône
   m_psh.dwFlags &= ~PSH_HASHELP;  // pas de bouton help
@@ -118,6 +119,8 @@ ON_WM_QUERYDRAGICON()
 ON_WM_SYSCOMMAND()
 ON_WM_TIMER()
 ON_WM_HELPINFO()
+ON_WM_SIZE()
+ON_WM_GETMINMAXINFO()
 //}}AFX_MSG_MAP
 ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
 ON_COMMAND(ID_HELP,OnHelpInfo2)
@@ -164,9 +167,44 @@ BOOL CMainTab::OnInitDialog()
   //SetActivePage(GetPageCount()-1);
   SetActivePage(0);
 
+  /* The template is a fixed dialog; give it a sizing border so the pages holding long
+     text (scan rules, HTTP headers) can be enlarged. Measure afterwards: the new frame
+     is thicker than the one the sheet was created with. */
+  ModifyStyle(0, WS_THICKFRAME|WS_MAXIMIZEBOX);
+  SetWindowPos(NULL, 0,0,0,0, SWP_NOMOVE|SWP_NOSIZE|SWP_NOZORDER|SWP_FRAMECHANGED);
+  CRect frame;
+  GetWindowRect(frame);
+  m_minSize = frame.Size();
+  m_sheetLayout.Build(this);
+
   // mode modif à la volée
   return r;
 }
+
+void CMainTab::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertySheet::OnSize(nType, cx, cy);
+  m_sheetLayout.Apply(cx, cy);
+}
+
+void CMainTab::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
+{
+  CPropertySheet::OnGetMinMaxInfo(lpMMI);
+  if (m_minSize.cx > 0) {
+    lpMMI->ptMinTrackSize.x = m_minSize.cx;
+    lpMMI->ptMinTrackSize.y = m_minSize.cy;
+  }
+}
+
+LRESULT CMainTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
+{
+  const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
+  // A page comctl32 has just shown comes back at its creation rect.
+  if (message == PSM_SETCURSEL || message == PSM_SETCURSELID)
+    m_sheetLayout.LayoutActivePage();
+  return r;
+}
+
 HCURSOR CMainTab::OnQueryDragIcon()
 {
   return (HCURSOR) m_hIcon;

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -76,11 +76,10 @@ CMainTab::~CMainTab()
 {
 }
 
-/* comctl32 builds the sheet's dialog template itself, and a sizing border only works if
-   it is in that template: adding WS_THICKFRAME to the created window draws the border
-   but leaves the window fixed. PSCB_PRECREATE is the one chance to reach the template. */
 static PFNPROPSHEETCALLBACK sheet_callback = NULL;
 
+/* A sizing border only works if it is in the dialog template comctl32 builds: adding
+   WS_THICKFRAME to the created window draws it but leaves the size fixed. */
 static int CALLBACK SheetPreCreate(HWND hWnd, UINT message, LPARAM lParam)
 {
   if (message == PSCB_PRECREATE && lParam != 0) {
@@ -96,15 +95,14 @@ static int CALLBACK SheetPreCreate(HWND hWnd, UINT message, LPARAM lParam)
     else
       ((DLGTEMPLATE*) lParam)->style |= WS_THICKFRAME|WS_MAXIMIZEBOX;
   }
-  // MFC's own callback hooks the sheet at PSCB_INITIALIZED, so it has to keep running.
+  // MFC hooks PSCB_INITIALIZED with its own callback; SheetPreCreate must call it too.
   return (sheet_callback != NULL) ? sheet_callback(hWnd, message, lParam) : 0;
 }
 
 void CMainTab::AddControlPages()
 {
   m_minSize.cx = m_minSize.cy = 0;    // OnInitDialog measures it
-  // Guarded: UnDefineDefaultProxy calls this again, and chaining onto ourselves would
-  // recurse forever.
+  // UnDefineDefaultProxy calls this again; chaining onto ourselves would recurse forever.
   if (m_psh.pfnCallback != SheetPreCreate) {
     sheet_callback = m_psh.pfnCallback;
     m_psh.pfnCallback = SheetPreCreate;
@@ -198,10 +196,8 @@ BOOL CMainTab::OnInitDialog()
   //SetActivePage(GetPageCount()-1);
   SetActivePage(0);
 
-  /* Second half of the sizing border, for the case where the template above was not
-     ours to change: this draws the frame, and the growth below gives back the client
-     area a thicker frame takes from controls placed for the old one. Both are no-ops
-     once SheetPreCreate has done its work. */
+  /* Fallback for a sheet SheetPreCreate could not reach, and a no-op once it did: the
+     thicker border comes out of the client area, so give that back. */
   CRect before, after, frame;
   GetClientRect(before);
   ModifyStyle(0, WS_THICKFRAME|WS_MAXIMIZEBOX);

--- a/WinHTTrack/MainTab.h
+++ b/WinHTTrack/MainTab.h
@@ -30,6 +30,7 @@ Please visit our Website: http://www.httrack.com
 // Tab Control Principal
 
 // En-tête pour l'affichage des tabs
+#include "WndLayout.h"
 #include "OptionTab1.h"
 #include "OptionTab2.h"
 #include "OptionTab3.h"
@@ -94,15 +95,20 @@ public:
   void DefineDefaultProxy();
   void UnDefineDefaultProxy();
   
-  // Generated message map functions
 protected:
-  
+
   const char* GetTip(int id);
+  CSheetLayout m_sheetLayout;
+  CSize m_minSize;       /* the template size; the sheet may grow but not shrink */
+  // Generated message map functions
   //{{AFX_MSG(CMainTab)
   afx_msg HCURSOR OnQueryDragIcon();
   afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
+  afx_msg void OnSize(UINT nType, int cx, int cy);
+  afx_msg void OnGetMinMaxInfo(MINMAXINFO* lpMMI);
   //}}AFX_MSG
+  virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	afx_msg void OnHelpInfo2();
   //afx_msg void OnOK( );
   //afx_msg void OnCancel( );

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -122,6 +122,7 @@ BEGIN_MESSAGE_MAP(CNewProj, CPropertyPage)
 	ON_CBN_EDITCHANGE(IDC_projname, OnChangeprojname)
 	ON_WM_CREATE()
 	ON_CBN_SELCHANGE(IDC_projname, OnSelchangeprojname)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
   ON_COMMAND(ID_HELP,OnHelpInfo2)
@@ -257,6 +258,7 @@ void CNewProj::Onbr()
 BOOL CNewProj::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
   SetIcon(httrack_icon,false);
   SetIcon(httrack_icon,true);
   EnableToolTips(true);     // TOOL TIPS
@@ -655,3 +657,24 @@ BOOL CNewProj::OnKillActive( ) {
 }
 
 
+
+void CNewProj::BuildLayout()
+{
+  /* The Info box takes the height; the base-path row rides the bottom. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_projname, 0, 100);
+  m_layout.AddId(this, IDC_projcateg, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_projinfo, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_comments, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_basepath, 0, 0, 100, 0);
+  m_layout.AddId(this, IDC_projpath, 0, 100, 100, 0);
+  m_layout.AddId(this, IDC_br, 100, 0, 100, 0);
+  m_layout.AddId(this, IDC_STATIC_mupdate, 0, 0, 100, 0);
+  m_layout.AddId(this, IDC_mupdate, 100, 0, 100, 0);
+}
+
+void CNewProj::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/NewProj.h
+++ b/WinHTTrack/NewProj.h
@@ -40,6 +40,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // CNewProj dialog
 
+#include "WndLayout.h"
+
 class CNewProj : public CPropertyPage
 {
 	DECLARE_DYNCREATE(CNewProj)
@@ -77,6 +79,8 @@ protected:
   const char* GetTip(int id);
   void OnHelpInfo2();
   void Changeprojname(CString stl);
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(CNewProj)
 	afx_msg void Onbr();
@@ -85,6 +89,7 @@ protected:
 	afx_msg void OnChangeprojname();
 	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
 	afx_msg void OnSelchangeprojname();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   virtual BOOL OnKillActive( );
   virtual BOOL OnQueryCancel( );

--- a/WinHTTrack/OptionTab11.cpp
+++ b/WinHTTrack/OptionTab11.cpp
@@ -101,6 +101,7 @@ void COptionTab11::DoDataExchange(CDataExchange* pDX)
 
 BEGIN_MESSAGE_MAP(COptionTab11, CPropertyPage)
 	//{{AFX_MSG_MAP(COptionTab11)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -111,6 +112,7 @@ END_MESSAGE_MAP()
 BOOL COptionTab11::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
 	
   EnableToolTips(true);     // TOOL TIPS
 
@@ -236,3 +238,23 @@ const char* COptionTab11::GetTip(int ID)
 // ------------------------------------------------------------
 
 
+
+void COptionTab11::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_asso, 0, 100);
+  m_layout.AddId(this, IDC_mime1, 0, 100);
+  m_layout.AddId(this, IDC_mime2, 0, 100);
+  m_layout.AddId(this, IDC_mime3, 0, 100);
+  m_layout.AddId(this, IDC_mime4, 0, 100);
+  m_layout.AddId(this, IDC_mime5, 0, 100);
+  m_layout.AddId(this, IDC_mime6, 0, 100);
+  m_layout.AddId(this, IDC_mime7, 0, 100);
+  m_layout.AddId(this, IDC_mime8, 0, 100);
+}
+
+void COptionTab11::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/OptionTab11.h
+++ b/WinHTTrack/OptionTab11.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab11 dialog
 
+#include "WndLayout.h"
+
 class COptionTab11 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab11)
@@ -78,9 +80,12 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab11)
 	virtual BOOL OnInitDialog();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
 	DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/OptionTab2.cpp
+++ b/WinHTTrack/OptionTab2.cpp
@@ -90,6 +90,7 @@ BEGIN_MESSAGE_MAP(COptionTab2, CPropertyPage)
 	//{{AFX_MSG_MAP(COptionTab2)
 	ON_BN_CLICKED(IDC_buildopt, Onbuildopt)
 	ON_CBN_SELCHANGE(IDC_build, OnSelchangebuild)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -110,6 +111,7 @@ void COptionTab2::Onbuildopt()
 BOOL COptionTab2::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
   EnableToolTips(true);     // TOOL TIPS
 	
   // Patcher l'interface pour les Français ;-)
@@ -224,3 +226,17 @@ void COptionTab2::OnSelchangebuild()
   }
 }
 
+
+void COptionTab2::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_buildopt, 0, 100);
+  m_layout.AddId(this, IDC_build, 0, 100);
+  m_layout.AddId(this, IDC_buildopt, 100, 0);
+}
+
+void COptionTab2::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/OptionTab2.h
+++ b/WinHTTrack/OptionTab2.h
@@ -39,6 +39,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab2 dialog
 
+#include "WndLayout.h"
+
 class COptionTab2 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab2)
@@ -77,11 +79,14 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab2)
 	afx_msg void Onbuildopt();
 	virtual BOOL OnInitDialog();
 	afx_msg void OnSelchangebuild();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
 	DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/OptionTab3.cpp
+++ b/WinHTTrack/OptionTab3.cpp
@@ -88,6 +88,7 @@ void COptionTab3::DoDataExchange(CDataExchange* pDX)
 
 BEGIN_MESSAGE_MAP(COptionTab3, CPropertyPage)
 	//{{AFX_MSG_MAP(COptionTab3)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -98,6 +99,7 @@ END_MESSAGE_MAP()
 BOOL COptionTab3::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
   EnableToolTips(true);     // TOOL TIPS
 	
   // mode modif à la volée
@@ -199,3 +201,23 @@ const char* COptionTab3::GetTip(int ID)
 // TOOL TIPS
 // ------------------------------------------------------------
 
+
+void COptionTab3::BuildLayout()
+{
+  /* Two columns, each taking half the extra width. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_warning, 0, 100);
+  m_layout.AddId(this, IDC_filter, 0, 50);
+  m_layout.AddId(this, IDC_travel, 0, 50);
+  m_layout.AddId(this, IDC_travel3, 0, 50);
+  m_layout.AddId(this, IDC_STATIC_travel2, 50, 50);
+  m_layout.AddId(this, IDC_travel2, 50, 50);
+  m_layout.AddId(this, IDC_STATIC_stripquery, 50, 50);
+  m_layout.AddId(this, IDC_stripquery, 50, 50);
+}
+
+void COptionTab3::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/OptionTab3.h
+++ b/WinHTTrack/OptionTab3.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab3 dialog
 
+#include "WndLayout.h"
+
 class COptionTab3 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab3)
@@ -74,9 +76,12 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab3)
 	virtual BOOL OnInitDialog();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
 	DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -80,6 +80,7 @@ void COptionTab6::DoDataExchange(CDataExchange* pDX)
 
 BEGIN_MESSAGE_MAP(COptionTab6, CPropertyPage)
 	//{{AFX_MSG_MAP(COptionTab6)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -90,6 +91,7 @@ END_MESSAGE_MAP()
 BOOL COptionTab6::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
   EnableToolTips(true);     // TOOL TIPS
 	
   // Patcher l'interface pour les Français ;-)
@@ -155,3 +157,21 @@ const char* COptionTab6::GetTip(int ID)
 // TOOL TIPS
 // ------------------------------------------------------------
 
+
+void COptionTab6::BuildLayout()
+{
+  /* The headers box takes the height; the referer row stays under it. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_user, 0, 100);
+  m_layout.AddId(this, IDC_footer, 0, 100);
+  m_layout.AddId(this, IDC_accept_language, 0, 100);
+  m_layout.AddId(this, IDC_other_headers, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_default_referer, 0, 0, 100, 0);
+  m_layout.AddId(this, IDC_default_referer, 0, 100, 100, 0);
+}
+
+void COptionTab6::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/OptionTab6.h
+++ b/WinHTTrack/OptionTab6.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab6 dialog
 
+#include "WndLayout.h"
+
 class COptionTab6 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab6)
@@ -66,9 +68,12 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab6)
 	virtual BOOL OnInitDialog();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
 	DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/OptionTab7.cpp
+++ b/WinHTTrack/OptionTab7.cpp
@@ -85,6 +85,7 @@ BEGIN_MESSAGE_MAP(COptionTab7, CPropertyPage)
 	ON_BN_CLICKED(IDC_CHECK1, OnCheck1)
 	ON_BN_CLICKED(IDC_CHECK2, OnCheck2)
 	ON_BN_CLICKED(IDC_CHECK3, OnCheck3)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -246,6 +247,7 @@ void COptionTab7::OnAdd2()
 BOOL COptionTab7::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
   EnableToolTips(true);     // TOOL TIPS
 
   // mode modif à la volée
@@ -367,4 +369,19 @@ void COptionTab7::OnCheck2()
 void COptionTab7::OnCheck3() 
 {
   EnsureIncluded(this->IsDlgButtonChecked(IDC_CHECK3),"+*.mov +*.mpg +*.mpeg +*.avi +*.asf +*.mp3 +*.mp2 +*.rm +*.wav +*.vob +*.qt +*.vid +*.ac3 +*.wma +*.wmv");
+}
+
+void COptionTab7::BuildLayout()
+{
+  /* The rules box takes the room; the tip stays under it. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_finfo, 0, 100);
+  m_layout.AddId(this, IDC_URL2, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_tip, 0, 100, 100, 0);
+}
+
+void COptionTab7::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
 }

--- a/WinHTTrack/OptionTab7.h
+++ b/WinHTTrack/OptionTab7.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab7 dialog
 
+#include "WndLayout.h"
+
 class COptionTab7 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab7)
@@ -63,6 +65,8 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab7)
 	afx_msg void OnAdd1();
@@ -71,6 +75,7 @@ protected:
 	afx_msg void OnCheck1();
 	afx_msg void OnCheck2();
 	afx_msg void OnCheck3();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
 	DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -94,6 +94,7 @@ void COptionTab8::DoDataExchange(CDataExchange* pDX)
 BEGIN_MESSAGE_MAP(COptionTab8, CPropertyPage)
 	//{{AFX_MSG_MAP(COptionTab8)
 	ON_BN_CLICKED(IDC_cookiesfilebrowse, OnCookiesFileBrowse)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
 END_MESSAGE_MAP()
@@ -113,6 +114,7 @@ void COptionTab8::OnCookiesFileBrowse()
 BOOL COptionTab8::OnInitDialog() 
 {
 	CDialog::OnInitDialog();
+  BuildLayout();
   EnableToolTips(true);     // TOOL TIPS
 
   // mode modif à la volée
@@ -224,3 +226,19 @@ const char* COptionTab8::GetTip(int ID)
 // ------------------------------------------------------------
 
 
+
+void COptionTab8::BuildLayout()
+{
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_checktype, 0, 100);
+  m_layout.AddId(this, IDC_robots, 0, 100);
+  m_layout.AddId(this, IDC_cookiesfile, 0, 100);
+  m_layout.AddId(this, IDC_cookiesfilebrowse, 100, 0);
+  m_layout.AddId(this, IDC_sitemapurl, 0, 100);
+}
+
+void COptionTab8::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
+}

--- a/WinHTTrack/OptionTab8.h
+++ b/WinHTTrack/OptionTab8.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // COptionTab8 dialog
 
+#include "WndLayout.h"
+
 class COptionTab8 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(COptionTab8)
@@ -73,10 +75,13 @@ public:
 
 // Implementation
 protected:
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(COptionTab8)
 	virtual BOOL OnInitDialog();
 	afx_msg void OnCookiesFileBrowse();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
   DECLARE_MESSAGE_MAP()

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -145,6 +145,7 @@ BEGIN_MESSAGE_MAP(Wid1, CPropertyPage)
 	ON_WM_DRAWITEM()
 	ON_WM_SHOWWINDOW()
 	ON_EN_CHANGE(IDC_filelist, OnChangefilelist)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
 	ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
 	ON_COMMAND(ID_HELP,OnHelpInfo2)
@@ -168,6 +169,7 @@ END_MESSAGE_MAP()
 
 BOOL Wid1::OnInitDialog( ) {
   CPropertyPage::OnInitDialog();
+  BuildLayout();
   // The URL list has no CEdit member; bound it by handle.
   GetDlgItem(IDC_URL)->SendMessage(EM_SETLIMITTEXT, 32000, 0);
   GetDlgItem(IDC_filelist)->SendMessage(EM_SETLIMITTEXT, 2000, 0);
@@ -896,4 +898,25 @@ void Wid1::OnChangefilelist()
     }
     GetDlgItem(IDC_STATIC_filelist)->RedrawWindow();
   }
+}
+
+void Wid1::BuildLayout()
+{
+  /* The URL box takes the room; the rows under it ride along at the bottom. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_INFOMAIN, 0, 100);
+  m_layout.AddId(this, IDC_todo, 0, 100);
+  m_layout.AddId(this, IDC_login2, 100, 0);
+  m_layout.AddId(this, IDC_URL, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_filelist, 0, 0, 100, 0);
+  m_layout.AddId(this, IDC_filelist, 0, 100, 100, 0);
+  m_layout.AddId(this, IDC_br, 100, 0, 100, 0);
+  m_layout.AddId(this, IDC_STATIC_filters2, 0, 0, 100, 0);
+  m_layout.AddId(this, ID_setopt, 100, 0, 100, 0);
+}
+
+void Wid1::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
 }

--- a/WinHTTrack/Wid1.h
+++ b/WinHTTrack/Wid1.h
@@ -40,6 +40,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // Wid1 dialog
 
+#include "WndLayout.h"
+
 class Wid1 : public CPropertyPage
 {
 	DECLARE_DYNCREATE(Wid1)
@@ -91,6 +93,8 @@ protected:
   int load_after_changes;
   const char* GetTip(int id);
   void AddText(CString add_st);
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(Wid1)
 	afx_msg void OnChangeUrl();
@@ -102,6 +106,7 @@ protected:
 	afx_msg void Onlogin2();
 	afx_msg void Onbr();
 	afx_msg void OnChangefilelist();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   virtual BOOL OnKillActive( );
   virtual BOOL OnQueryCancel( );

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -184,7 +184,7 @@ IDD_Debut DIALOGEX 0, 0, 256, 205
 STYLE DS_SETFONT | WS_CHILD
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    GROUPBOX        "",IDC_STATIC,7,6,242,158
+    GROUPBOX        "",IDC_STATIC_connect,7,6,242,158
     CONTROL         "Please adjust connection parameters if necessary,\nthen press FINISH to launch the mirroring operation.",IDC_select_start,
                     "Button",BS_AUTORADIOBUTTON | BS_MULTILINE,12,16,233,23
     GROUPBOX        "Remote connect",IDC_STATIC_ras,20,42,225,70
@@ -197,7 +197,7 @@ BEGIN
     EDITTEXT        IDC_hh,25,143,16,12,ES_AUTOHSCROLL | ES_NUMBER
     EDITTEXT        IDC_mm,42,143,16,12,ES_AUTOHSCROLL | ES_NUMBER
     EDITTEXT        IDC_ss,60,143,16,12,ES_AUTOHSCROLL | ES_NUMBER
-    GROUPBOX        "",IDC_STATIC,7,167,242,31
+    GROUPBOX        "",IDC_STATIC_save,7,167,242,31
     CONTROL         "Save settings only, do not launch download now.",IDC_select_save,
                     "Button",BS_AUTORADIOBUTTON | BS_MULTILINE,12,174,233,20
 END
@@ -436,7 +436,7 @@ BEGIN
     COMBOBOX        IDC_projname,130,7,185,113,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Project category:",IDC_STATIC_projcateg,7,30,118,13
     COMBOBOX        IDC_projcateg,130,30,102,113,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    GROUPBOX        "Info",IDC_STATIC,7,45,308,85
+    GROUPBOX        "Info",IDC_STATIC_projinfo,7,45,308,85
     LTEXT           "",IDC_STATIC_comments,16,60,234,41
     LTEXT           "Base path:",IDC_STATIC_basepath,7,140,118,13,WS_DISABLED
     EDITTEXT        IDC_projpath,125,140,173,12,ES_AUTOHSCROLL

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -280,8 +280,7 @@ void CWizTab::OnSize(UINT nType, int cx, int cy)
 LRESULT CWizTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
   const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
-  if (CSheetLayout::IsPageChange(message, wParam, lParam))
-    m_sheetLayout.LayoutActivePage();
+  m_sheetLayout.HandleMessage(message, wParam, lParam);
   return r;
 }
 

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -280,9 +280,8 @@ void CWizTab::OnSize(UINT nType, int cx, int cy)
 LRESULT CWizTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
   const LRESULT r = CPropertySheet::WindowProc(message, wParam, lParam);
-  // A page comctl32 has just shown comes back at its creation rect.
-  if (message == PSM_SETCURSEL || message == PSM_SETCURSELID)
-    LayoutActivePage();
+  if (CSheetLayout::IsPageChange(message, wParam, lParam))
+    m_sheetLayout.LayoutActivePage();
   return r;
 }
 

--- a/WinHTTrack/WizTab.cpp
+++ b/WinHTTrack/WizTab.cpp
@@ -94,8 +94,6 @@ CWizTab::~CWizTab()
 }
 
 void CWizTab::DoInits() {
-  m_pageBase.SetRectEmpty();     // BuildLayout fills these once the sheet exists
-  m_pageBaseClient.cx=m_pageBaseClient.cy=0;
   m_tab0=NULL;
   m_tab1=NULL;
   m_tab2=NULL;
@@ -263,82 +261,20 @@ BOOL CWizTab::OnInitDialog()
   return r;
 }
 
-static BOOL IsSheetPage(CPropertySheet* sheet, HWND hwnd)
-{
-  for(int i=0 ; i<sheet->GetPageCount() ; i++) {
-    const CPropertyPage* const page = sheet->GetPage(i);
-    if (page != NULL && page->m_hWnd == hwnd)
-      return TRUE;
-  }
-  return FALSE;
-}
-
 void CWizTab::BuildLayout()
 {
-  m_layout.Reset(this);
-  m_pageBase.SetRectEmpty();
-
-  CRect client;
-  GetClientRect(client);
-  m_pageBaseClient = client.Size();
-
-  // Wizard mode hides the tab control but still gives it the page area, so it serves
-  // as the reference before any page has a window.
-  const int active = GetActiveIndex();
-  CWnd* ref = (active >= 0 && active < GetPageCount()) ? (CWnd*) GetPage(active) : NULL;
-  if (ref == NULL || ref->m_hWnd == NULL)
-    ref = GetTabControl();
-  if (ref != NULL && ref->m_hWnd != NULL) {
-    ref->GetWindowRect(m_pageBase);
-    ScreenToClient(m_pageBase);
-  }
-
-  for(CWnd* child = GetWindow(GW_CHILD) ; child != NULL ; child = child->GetWindow(GW_HWNDNEXT)) {
-    if (IsSheetPage(this, child->m_hWnd))
-      continue;                      // LayoutActivePage owns these
-    switch(child->GetDlgCtrlID()) {
-      case ID_WIZBACK: case ID_WIZNEXT: case ID_WIZFINISH:
-      case IDOK: case IDCANCEL: case IDHELP:
-        m_layout.Add(child, 100, 0, 100, 0);   // keep the strip in the bottom right
-        break;
-      default: {
-        TCHAR cls[16];
-        // The rule above the buttons is the only other static the sheet owns.
-        if (::GetClassName(child->m_hWnd, cls, (int)_countof(cls)) > 0
-            && _tcsicmp(cls, _T("Static")) == 0)
-          m_layout.Add(child, 0, 100, 100, 0);
-        break;
-      }
-    }
-  }
+  m_sheetLayout.Build(this);
 }
 
 void CWizTab::LayoutActivePage()
 {
-  if (m_pageBase.IsRectEmpty() || m_pageBaseClient.cx == 0)
-    return;
-  /* Not GetActivePage(): FinalInProgress empties the page array between RemovePage and
-     AddPage, and it then indexes -1 and hands back a wild pointer. */
-  const int active = GetActiveIndex();
-  if (active < 0 || active >= GetPageCount())
-    return;
-  CPropertyPage* const page = GetPage(active);
-  if (page == NULL || page->m_hWnd == NULL)
-    return;
-  CRect client;
-  GetClientRect(client);
-  const int dx = max(client.Width() - m_pageBaseClient.cx, 0);
-  const int dy = max(client.Height() - m_pageBaseClient.cy, 0);
-  page->SetWindowPos(NULL, m_pageBase.left, m_pageBase.top,
-                     m_pageBase.Width() + dx, m_pageBase.Height() + dy,
-                     SWP_NOZORDER|SWP_NOACTIVATE);
+  m_sheetLayout.LayoutActivePage();
 }
 
 void CWizTab::OnSize(UINT nType, int cx, int cy)
 {
   CPropertySheet::OnSize(nType, cx, cy);
-  m_layout.Apply(cx, cy);
-  LayoutActivePage();
+  m_sheetLayout.Apply(cx, cy);
 }
 
 LRESULT CWizTab::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)

--- a/WinHTTrack/WizTab.h
+++ b/WinHTTrack/WizTab.h
@@ -78,12 +78,9 @@ public:
 public:
   virtual ~CWizTab();
   virtual BOOL OnInitDialog();
-  /* Give the page comctl32 has just shown the sheet's current size. comctl32 restores
-     the rect the page had at creation, so this has to run after every page change. */
+  /* CSheetLayout, for the container: BuildLayout once the sheet is built, then
+     LayoutActivePage after every page change. */
   void LayoutActivePage();
-  /* Records template geometry. Run it once the sheet is built and its active page has a
-     window, so the page's own rect is measured instead of the hidden tab control
-     standing in for it. */
   void BuildLayout();
   void ApplyAndSave();
   void Apply();
@@ -98,9 +95,7 @@ protected:
   void ClearInits();
   
   const char* GetTip(int id);
-  CWndLayout m_layout;   /* buttons and the separator; the page is sized separately */
-  CRect m_pageBase;      /* page rect, and the client size it was measured against */
-  CSize m_pageBaseClient;
+  CSheetLayout m_sheetLayout;
   //{{AFX_MSG(CWizTab)
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
 	afx_msg void OnSize(UINT nType, int cx, int cy);

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -133,3 +133,98 @@ void CWndLayout::Apply(int cx, int cy) const
   if (::IsWindow(m_parent))
     ::InvalidateRect(m_parent, NULL, TRUE);
 }
+
+CSheetLayout::CSheetLayout()
+{
+  m_sheet = NULL;
+  m_baseClient.cx = m_baseClient.cy = 0;
+}
+
+static BOOL IsSheetPage(CPropertySheet* sheet, HWND hwnd)
+{
+  for(int i=0 ; i<sheet->GetPageCount() ; i++) {
+    const CPropertyPage* const page = sheet->GetPage(i);
+    if (page != NULL && page->m_hWnd == hwnd)
+      return TRUE;
+  }
+  return FALSE;
+}
+
+void CSheetLayout::Build(CPropertySheet* sheet)
+{
+  m_sheet = NULL;
+  m_pageBase.SetRectEmpty();
+  m_baseClient.cx = m_baseClient.cy = 0;
+  if (sheet == NULL || sheet->m_hWnd == NULL)
+    return;
+  m_sheet = sheet;
+  m_layout.Reset(sheet);
+
+  CRect client;
+  sheet->GetClientRect(client);
+  m_baseClient = client.Size();
+
+  CTabCtrl* const tabs = sheet->GetTabControl();
+  const HWND tabsHwnd = (tabs != NULL) ? tabs->m_hWnd : NULL;
+
+  // Wizard mode hides the tab control but still gives it the page area, so it serves
+  // as the reference before any page has a window.
+  const int active = sheet->GetActiveIndex();
+  CWnd* ref = (active >= 0 && active < sheet->GetPageCount()) ? (CWnd*) sheet->GetPage(active) : NULL;
+  if (ref == NULL || ref->m_hWnd == NULL)
+    ref = tabs;
+  if (ref != NULL && ref->m_hWnd != NULL) {
+    ref->GetWindowRect(m_pageBase);
+    sheet->ScreenToClient(m_pageBase);
+  }
+
+  for(CWnd* child = sheet->GetWindow(GW_CHILD) ; child != NULL ; child = child->GetWindow(GW_HWNDNEXT)) {
+    if (IsSheetPage(sheet, child->m_hWnd))
+      continue;                      // LayoutActivePage owns these
+    if (child->m_hWnd == tabsHwnd) {
+      m_layout.Add(child, 0, 100, 0, 100);   // frames the pages, so it grows with them
+      continue;
+    }
+    switch(child->GetDlgCtrlID()) {
+      case ID_WIZBACK: case ID_WIZNEXT: case ID_WIZFINISH:
+      case IDOK: case IDCANCEL: case IDHELP: case ID_APPLY_NOW:
+        m_layout.Add(child, 100, 0, 100, 0);   // keep the strip in the bottom right
+        break;
+      default: {
+        TCHAR cls[16];
+        // The rule above the buttons is the only other static a sheet owns.
+        if (::GetClassName(child->m_hWnd, cls, (int)_countof(cls)) > 0
+            && _tcsicmp(cls, _T("Static")) == 0)
+          m_layout.Add(child, 0, 100, 100, 0);
+        break;
+      }
+    }
+  }
+}
+
+void CSheetLayout::LayoutActivePage()
+{
+  if (m_sheet == NULL || m_pageBase.IsRectEmpty() || m_baseClient.cx == 0)
+    return;
+  /* Not GetActivePage(): FinalInProgress empties the page array between RemovePage and
+     AddPage, and it then indexes -1 and hands back a wild pointer. */
+  const int active = m_sheet->GetActiveIndex();
+  if (active < 0 || active >= m_sheet->GetPageCount())
+    return;
+  CPropertyPage* const page = m_sheet->GetPage(active);
+  if (page == NULL || page->m_hWnd == NULL)
+    return;
+  CRect client;
+  m_sheet->GetClientRect(client);
+  const int dx = max(client.Width() - m_baseClient.cx, 0);
+  const int dy = max(client.Height() - m_baseClient.cy, 0);
+  page->SetWindowPos(NULL, m_pageBase.left, m_pageBase.top,
+                     m_pageBase.Width() + dx, m_pageBase.Height() + dy,
+                     SWP_NOZORDER|SWP_NOACTIVATE);
+}
+
+void CSheetLayout::Apply(int cx, int cy)
+{
+  m_layout.Apply(cx, cy);
+  LayoutActivePage();
+}

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -245,6 +245,12 @@ void CSheetLayout::LayoutActivePage()
                      SWP_NOZORDER|SWP_NOACTIVATE);
 }
 
+void CSheetLayout::HandleMessage(UINT message, WPARAM wParam, LPARAM lParam)
+{
+  if (IsPageChange(message, wParam, lParam))
+    LayoutActivePage();
+}
+
 void CSheetLayout::Apply(int cx, int cy)
 {
   m_layout.Apply(cx, cy);

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -137,7 +137,29 @@ void CWndLayout::Apply(int cx, int cy) const
 CSheetLayout::CSheetLayout()
 {
   m_sheet = NULL;
+  m_pageBase.SetRectEmpty();
   m_baseClient.cx = m_baseClient.cy = 0;
+}
+
+BOOL CSheetLayout::IsPageChange(UINT message, WPARAM wParam, LPARAM lParam)
+{
+  switch(message) {
+    case PSM_SETCURSEL: case PSM_SETCURSELID:
+      return TRUE;
+    /* comctl32 turns a tab click or a wizard button into its own page switch without
+       ever sending itself PSM_SETCURSEL, so those two have to be watched as well. */
+    case WM_NOTIFY: {
+      const NMHDR* const hdr = (const NMHDR*) lParam;
+      return hdr != NULL && hdr->code == TCN_SELCHANGE;
+    }
+    case WM_COMMAND:
+      switch(LOWORD(wParam)) {
+        case ID_WIZBACK: case ID_WIZNEXT: case ID_WIZFINISH:
+          return TRUE;
+      }
+      break;
+  }
+  return FALSE;
 }
 
 static BOOL IsSheetPage(CPropertySheet* sheet, HWND hwnd)

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -104,12 +104,15 @@ public:
      the page had at creation, so this has to run after every page change. */
   void LayoutActivePage();
 
-  /* True once a message the sheet has just handled may have swapped the visible page.
-     Call LayoutActivePage when it is: a page comctl32 creates on demand comes up at the
-     template rect it cached before the sheet grew. */
-  static BOOL IsPageChange(UINT message, WPARAM wParam, LPARAM lParam);
+  /* Re-lay the active page out if this message may have swapped it. Call from the
+     sheet's WindowProc, once the base class has run. */
+  void HandleMessage(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
+  /* A page comctl32 creates on demand comes up at the rect it cached before the sheet
+     grew, so every way of reaching a new page has to be caught. */
+  static BOOL IsPageChange(UINT message, WPARAM wParam, LPARAM lParam);
+
   CPropertySheet* m_sheet;
   CWndLayout m_layout;
   CRect m_pageBase;              /* page rect, and the client size it was measured at */

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -35,6 +35,7 @@ Please visit our Website: http://www.httrack.com
 #define WINHTTRACK_WNDLAYOUT_H
 
 #include <afxtempl.h>   /* CArray; StdAfx.h brings in the rest of MFC */
+#include <afxdlgs.h>    /* CPropertySheet */
 
 /* Lets a dialog laid out from a fixed template follow its parent's size.
    Each control keeps the rect the template gave it and then takes a percentage of
@@ -80,6 +81,34 @@ private:
   CArray<ITEM,ITEM&> m_items;
   HWND m_parent;
   CSize m_base;                  /* client size the rects above were recorded at */
+};
+
+/* The sheet-level half of the same idea: the furniture a property sheet owns (its
+   buttons, the wizard rule, the tab control) follows the sheet, and the active page is
+   stretched to match. Each page still anchors its own controls; this only gives them
+   the room. */
+class CSheetLayout
+{
+public:
+  CSheetLayout();
+
+  /* Record template geometry. Run once the sheet is built and its active page has a
+     window, so the page's own rect is measured instead of the tab control standing in
+     for it. */
+  void Build(CPropertySheet* sheet);
+
+  /* Furniture and active page, for a client area of cx by cy. */
+  void Apply(int cx, int cy);
+
+  /* Give the page comctl32 has just shown the sheet's current size: it restores the rect
+     the page had at creation, so this has to run after every page change. */
+  void LayoutActivePage();
+
+private:
+  CPropertySheet* m_sheet;
+  CWndLayout m_layout;
+  CRect m_pageBase;              /* page rect, and the client size it was measured at */
+  CSize m_baseClient;
 };
 
 #endif

--- a/WinHTTrack/WndLayout.h
+++ b/WinHTTrack/WndLayout.h
@@ -104,6 +104,11 @@ public:
      the page had at creation, so this has to run after every page change. */
   void LayoutActivePage();
 
+  /* True once a message the sheet has just handled may have swapped the visible page.
+     Call LayoutActivePage when it is: a page comctl32 creates on demand comes up at the
+     template rect it cached before the sheet grew. */
+  static BOOL IsPageChange(UINT message, WPARAM wParam, LPARAM lParam);
+
 private:
   CPropertySheet* m_sheet;
   CWndLayout m_layout;

--- a/WinHTTrack/infoend.h
+++ b/WinHTTrack/infoend.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // Cinfoend dialog
 
+#include "WndLayout.h"
+
 class Cinfoend : public CPropertyPage
 {
 public:
@@ -67,6 +69,8 @@ protected:
   void OnBye();
   UINT_PTR tm;
 
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(Cinfoend)
 	virtual BOOL OnInitDialog();
@@ -75,6 +79,7 @@ protected:
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnDestroy();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
   virtual BOOL OnSetActive( );

--- a/WinHTTrack/resource.h
+++ b/WinHTTrack/resource.h
@@ -540,6 +540,9 @@ Please visit our Website: http://www.httrack.com
 #define IDC_changes                     1328
 #define IDC_warccdx                     1329
 #define IDC_wacz                        1330
+#define IDC_STATIC_projinfo             1331
+#define IDC_STATIC_connect              1332
+#define IDC_STATIC_save                 1333
 #define ID_MENUITEM32771                32771
 #define ID_MENUITEM32772                32772
 #define ID_EXIT                         32772
@@ -611,7 +614,7 @@ Please visit our Website: http://www.httrack.com
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        247
 #define _APS_NEXT_COMMAND_VALUE         32837
-#define _APS_NEXT_CONTROL_VALUE         1331
+#define _APS_NEXT_CONTROL_VALUE         1334
 #define _APS_NEXT_SYMED_VALUE           108
 #endif
 #endif

--- a/WinHTTrack/trans.cpp
+++ b/WinHTTrack/trans.cpp
@@ -148,6 +148,7 @@ BEGIN_MESSAGE_MAP(Ctrans, CPropertyPage)
 	ON_CBN_DROPDOWN(IDC_rasid, OnDropdownrasid)
 	ON_WM_SHOWWINDOW()
 	ON_BN_CLICKED(IDC_rasdisc, Onrasdisc)
+	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
 	ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
   ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
@@ -191,6 +192,7 @@ void Ctrans::OnChangehh()
 BOOL Ctrans::OnInitDialog() 
 {
 	CPropertyPage::OnInitDialog();
+  BuildLayout();
 
   ((CButton*)GetDlgItem(IDC_select_start))->SetCheck(1);
   strcpybuff(RasString,"");
@@ -486,4 +488,27 @@ BOOL Ctrans::OnKillActive( ) {
 void Ctrans::Onrasdisc() 
 {
   InitRAS();
+}
+
+void Ctrans::BuildLayout()
+{
+  /* The connection box takes the height; the save-only box rides the bottom. */
+  m_layout.Reset(this);
+  m_layout.AddId(this, IDC_STATIC_connect, 0, 100, 0, 100);
+  m_layout.AddId(this, IDC_select_start, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_ras, 0, 100);
+  m_layout.AddId(this, IDC_cnx, 0, 100);
+  m_layout.AddId(this, IDC_rasid, 0, 100);
+  m_layout.AddId(this, IDC_rasdisc, 0, 100);
+  m_layout.AddId(this, IDC_rasshut, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_delay, 0, 100);
+  m_layout.AddId(this, IDC_wait, 0, 100);
+  m_layout.AddId(this, IDC_STATIC_save, 0, 100, 100, 0);
+  m_layout.AddId(this, IDC_select_save, 0, 100, 100, 0);
+}
+
+void Ctrans::OnSize(UINT nType, int cx, int cy)
+{
+  CPropertyPage::OnSize(nType, cx, cy);
+  m_layout.Apply(cx, cy);
 }

--- a/WinHTTrack/trans.h
+++ b/WinHTTrack/trans.h
@@ -39,6 +39,8 @@ Please visit our Website: http://www.httrack.com
 /////////////////////////////////////////////////////////////////////////////
 // Ctrans dialog
 
+#include "WndLayout.h"
+
 class Ctrans : public CPropertyPage
 {
 	DECLARE_DYNCREATE(Ctrans)
@@ -85,6 +87,8 @@ protected:
   void FillProviderList(int fill);
   BOOL isfilled;
 
+	CWndLayout m_layout;
+	void BuildLayout();
 	// Generated message map functions
 	//{{AFX_MSG(Ctrans)
 	afx_msg void OnChangehh();
@@ -93,6 +97,7 @@ protected:
 	afx_msg void OnSelchangerasid();
 	afx_msg void OnDropdownrasid();
 	afx_msg void Onrasdisc();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
 	//}}AFX_MSG
   virtual BOOL OnKillActive( );
   virtual BOOL OnQueryCancel( );


### PR DESCRIPTION
Every wizard page now follows the window the way the transfer panel already did: the URL box, the project Info block, the connection panel and the end-of-mirror log take the extra room instead of leaving it blank beside them. The options sheet gets a sizing border, so the scan-rules and HTTP-header boxes can be enlarged.

The sheet-level half of the layout code that shipped with the transfer panel moves into `CSheetLayout` so both sheets share it, and three unnamed group boxes get control ids so they can be anchored.

I checked the anchors against the resource templates: every anchored id exists in its own dialog, and nothing collides or leaves the page once the growth is applied. That is static though, and layout is a look-at-it change, so it still wants a VM pass.