### PR TITLE
Keep the welcome banner inside the wizard pane

### DIFF
--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -111,11 +111,12 @@ BOOL CFirstInfo::OnInitDialog()
 	CPropertyPage::OnInitDialog();
 	EnableToolTips(true);     // TOOL TIPS
 
-  /* The banner is far wider than the icon box the template sizes it from, so pin it to
-     the margin: kept where the template puts it, the right-edge anchor pushes it off. */
+  /* The banner overflows the icon box the template sizes it from, so the right-edge
+     anchor would carry it off the page. Lay it against the margin instead. */
   CRect client, welcome;
+  CWnd* text=GetDlgItem(IDC_STATIC_welcome);
   GetClientRect(&client);
-  GetDlgItem(IDC_STATIC_welcome)->GetWindowRect(&welcome);
+  text->GetWindowRect(&welcome);
   ScreenToClient(&welcome);
 
   WINDOWPLACEMENT wp;
@@ -124,6 +125,10 @@ BOOL CFirstInfo::OnInitDialog()
   wp.rcNormalPosition.left=wp.rcNormalPosition.right-(300+1);
   wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1;
   m_splash.SetWindowPlacement(&wp);
+
+  /* Text and banner both take the growth, so the text must end before the banner. */
+  welcome.right=wp.rcNormalPosition.left-welcome.left;
+  text->MoveWindow(&welcome);
 
   /* After the splash resize: anchors come from the rects now, not the template's box. */
   BuildLayout();

--- a/WinHTTrack/FirstInfo.cpp
+++ b/WinHTTrack/FirstInfo.cpp
@@ -111,9 +111,17 @@ BOOL CFirstInfo::OnInitDialog()
 	CPropertyPage::OnInitDialog();
 	EnableToolTips(true);     // TOOL TIPS
 
+  /* The banner is far wider than the icon box the template sizes it from, so pin it to
+     the margin: kept where the template puts it, the right-edge anchor pushes it off. */
+  CRect client, welcome;
+  GetClientRect(&client);
+  GetDlgItem(IDC_STATIC_welcome)->GetWindowRect(&welcome);
+  ScreenToClient(&welcome);
+
   WINDOWPLACEMENT wp;
   m_splash.GetWindowPlacement(&wp);
-  wp.rcNormalPosition.right=wp.rcNormalPosition.left+300+1;
+  wp.rcNormalPosition.right=client.right-welcome.left;
+  wp.rcNormalPosition.left=wp.rcNormalPosition.right-(300+1);
   wp.rcNormalPosition.bottom=wp.rcNormalPosition.top+69+1;
   m_splash.SetWindowPlacement(&wp);
 


### PR DESCRIPTION
The welcome pane's banner has been clipped since #98. Its template rect is a 20x20 icon box that `OnInitDialog` grows into the 300x69 bitmap, so it already overhangs the dialog's right margin. The new right-edge anchor then carried that overhang out of the page: the screenshot walk on master (run 31396932625) shows the banner flush against the pane border with the right of "COPIER" cut off. Placing it against the same margin the welcome text uses on the left makes the anchor keep it there at every width, and the text now ends where the banner starts so the two no longer share a column.
