### PR TITLE
Capture the mirror-in-progress panel as an animation

### DIFF
--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -21,8 +21,8 @@ import win32gui
 from pywinauto.controls.common_controls import TabControlWrapper
 from pywinauto.controls.win32_controls import ComboBoxWrapper
 
-from wincapture import (Timeout, capture, click, controls, find, set_text, slug,
-                        top_level_windows, wait, window_titled)
+from wincapture import (Timeout, capture, click, controls, find, grab, nonblack, set_text,
+                        slug, top_level_windows, wait, window_titled)
 
 # MFC's wizard buttons and the property-sheet page selector are standard.
 ID_WIZBACK, ID_WIZNEXT, ID_WIZFINISH = 0x3023, 0x3024, 0x3025
@@ -94,19 +94,50 @@ def resource_ids(path):
 
 
 class Shots:
+    # Ten frames, close enough together to fit inside the crawl the walk already runs.
+    # The panel refreshes every 100ms (HTS_SLEEP_WIN), so every frame is a distinct one.
+    FRAMES, INTERVAL = 10, 0.6
+
     def __init__(self, outdir):
         self.outdir = outdir
         self.taken = []
 
     def take(self, hwnd, name):
         path = os.path.join(self.outdir, f"{name}.png")
-        nonblack = capture(hwnd, path)
-        print(f"  {name}.png  {nonblack:.3f} non-black")
+        img = grab(hwnd)
+        img.save(path)
+        self.check(img, f"{name}.png")
+        self.taken.append(path)
+
+    def check(self, img, what):
+        share = nonblack(img)
+        print(f"  {what}  {share:.3f} non-black")
         # A window that is up but has not painted captures as a black rectangle, which
         # looks like a successful shot until someone opens the artifact.
-        if nonblack < 0.02:
-            raise RuntimeError(f"{name}.png came out blank")
-        self.taken.append(path)
+        if share < 0.02:
+            raise RuntimeError(f"{what} came out blank")
+
+    def animate(self, hwnd, name, over):
+        """A window on a cadence, as an APNG plus frame 1 as an ordinary PNG: only the
+        pixels that move cost bytes, and a decoder with no APNG support shows frame 1."""
+        frames = []
+        for i in range(self.FRAMES):
+            if i:
+                time.sleep(self.INTERVAL)
+            if over():
+                break
+            frames.append(grab(hwnd))
+        if len(frames) < self.FRAMES:
+            raise RuntimeError(f"{name}: {len(frames)} of {self.FRAMES} frames before the "
+                               "mirror ended -- serve more pages, or serve them slower")
+        self.check(frames[0], f"{name}.apng")
+        still = os.path.join(self.outdir, f"{name}.png")
+        apng = os.path.join(self.outdir, f"{name}.apng")
+        frames[0].save(still)
+        frames[0].save(apng, format="PNG", save_all=True, append_images=frames[1:],
+                       duration=int(self.INTERVAL * 1000), loop=0)
+        print(f"  {name}.apng  {len(frames)} frames, {os.path.getsize(apng) / 1024:.0f} KB")
+        self.taken += [still, apng]
 
 
 def pane(main, anchor, what, timeout=30):
@@ -170,12 +201,18 @@ def run(pid, ids, shots, url, base_path):
     pane(main, ids["IDC_select_start"], "the ready-to-start pane")
     shots.take(main, "15_ready_to_start")
 
+    started = time.monotonic()
     click(find(main, control_id=ID_WIZFINISH))
-    pane(main, ids["IDC_inforun"], "the progress pane", timeout=60)
+    inforun = pane(main, ids["IDC_inforun"], "the progress pane", timeout=60)
     time.sleep(6)  # let the counters fill, or the shot is a screen of zeros
     shots.take(main, "16_mirror_progress")
+    # The pane's own hwnd rather than a crop of the window: a crop box would go stale the
+    # next time the layout moves, and the panel is what the website shows.
+    shots.animate(win32gui.GetParent(inforun), "16_mirror_progress_panel",
+                  lambda: find(main, control_id=ids["IDC_infoend"]))
 
     pane(main, ids["IDC_infoend"], "the finished pane", timeout=300)
+    print(f"  the mirror ran {time.monotonic() - started:.0f}s; the sequence has to fit in it")
     time.sleep(1)
     shots.take(main, "17_mirror_finished")
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -21,9 +21,8 @@ import win32gui
 from pywinauto.controls.common_controls import TabControlWrapper
 from pywinauto.controls.win32_controls import ComboBoxWrapper
 
-from wincapture import (Timeout, capture, click, controls, find, grab, nonblack,
-                        relative_rect, set_text, slug, top_level_windows, wait,
-                        window_titled)
+from wincapture import (Timeout, capture, click, content_rect, controls, find, grab,
+                        nonblack, set_text, slug, top_level_windows, wait, window_titled)
 
 # MFC's wizard buttons and the property-sheet page selector are standard.
 ID_WIZBACK, ID_WIZNEXT, ID_WIZFINISH = 0x3023, 0x3024, 0x3025
@@ -41,7 +40,7 @@ class Site(BaseHTTPRequestHandler):
     it when the progress screen is captured, and for the ten frames that follow it."""
 
     pages = 120
-    delay = 0.35
+    delay = 0.8
     filler = "HTTrack copies a site by following its links, page by page. " * 90
 
     def body(self):
@@ -119,10 +118,10 @@ class Shots:
             raise RuntimeError(f"{what} came out blank")
 
     def animate(self, hwnd, inner, name, over):
-        """A window on a cadence, cropped to a descendant of it, as an APNG plus frame 1
-        as a PNG: only the pixels that move cost bytes, and a decoder with no APNG
-        support shows frame 1."""
-        box = relative_rect(inner, hwnd)
+        """A window on a cadence, cropped to what a descendant of it has on it, as an
+        APNG plus frame 1 as a PNG: only the pixels that move cost bytes, and a decoder
+        with no APNG support shows frame 1."""
+        box = content_rect(inner, hwnd)
         frames = []
         for i in range(self.FRAMES):
             if i:

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -21,8 +21,9 @@ import win32gui
 from pywinauto.controls.common_controls import TabControlWrapper
 from pywinauto.controls.win32_controls import ComboBoxWrapper
 
-from wincapture import (Timeout, capture, click, controls, find, grab, nonblack, set_text,
-                        slug, top_level_windows, wait, window_titled)
+from wincapture import (Timeout, capture, click, controls, find, grab, nonblack,
+                        relative_rect, set_text, slug, top_level_windows, wait,
+                        window_titled)
 
 # MFC's wizard buttons and the property-sheet page selector are standard.
 ID_WIZBACK, ID_WIZNEXT, ID_WIZFINISH = 0x3023, 0x3024, 0x3025
@@ -36,10 +37,10 @@ NEEDED = ("IDC_lang", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath", "IDC
 
 
 class Site(BaseHTTPRequestHandler):
-    """Interlinked pages served slowly, so the crawl is still running with real numbers
-    on it when the progress screen is captured."""
+    """Interlinked pages served slowly, so the crawl is still running with real numbers on
+    it when the progress screen is captured, and for the ten frames that follow it."""
 
-    pages = 24
+    pages = 120
     delay = 0.35
     filler = "HTTrack copies a site by following its links, page by page. " * 90
 
@@ -117,16 +118,18 @@ class Shots:
         if share < 0.02:
             raise RuntimeError(f"{what} came out blank")
 
-    def animate(self, hwnd, name, over):
-        """A window on a cadence, as an APNG plus frame 1 as an ordinary PNG: only the
-        pixels that move cost bytes, and a decoder with no APNG support shows frame 1."""
+    def animate(self, hwnd, inner, name, over):
+        """A window on a cadence, cropped to a descendant of it, as an APNG plus frame 1
+        as a PNG: only the pixels that move cost bytes, and a decoder with no APNG
+        support shows frame 1."""
+        box = relative_rect(inner, hwnd)
         frames = []
         for i in range(self.FRAMES):
             if i:
                 time.sleep(self.INTERVAL)
             if over():
                 break
-            frames.append(grab(hwnd))
+            frames.append(grab(hwnd).crop(box))
         if len(frames) < self.FRAMES:
             raise RuntimeError(f"{name}: {len(frames)} of {self.FRAMES} frames before the "
                                "mirror ended -- serve more pages, or serve them slower")
@@ -206,9 +209,9 @@ def run(pid, ids, shots, url, base_path):
     inforun = pane(main, ids["IDC_inforun"], "the progress pane", timeout=60)
     time.sleep(6)  # let the counters fill, or the shot is a screen of zeros
     shots.take(main, "16_mirror_progress")
-    # The pane's own hwnd rather than a crop of the window: a crop box would go stale the
-    # next time the layout moves, and the panel is what the website shows.
-    shots.animate(win32gui.GetParent(inforun), "16_mirror_progress_panel",
+    # Framed on the pane's own rectangle, read from the live layout: the panel is what the
+    # website shows, and a crop box written down here would go stale when the layout moves.
+    shots.animate(main, win32gui.GetParent(inforun), "16_mirror_progress_panel",
                   lambda: find(main, control_id=ids["IDC_infoend"]))
 
     pane(main, ids["IDC_infoend"], "the finished pane", timeout=300)

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -18,6 +18,7 @@ import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import win32gui
+from PIL import Image
 from pywinauto.controls.common_controls import TabControlWrapper
 from pywinauto.controls.win32_controls import ComboBoxWrapper
 
@@ -96,7 +97,10 @@ def resource_ids(path):
 class Shots:
     # Ten frames, close enough together to fit inside the crawl the walk already runs.
     # The panel refreshes every 100ms (HTS_SLEEP_WIN), so every frame is a distinct one.
-    FRAMES, INTERVAL = 10, 0.6
+    FRAMES, INTERVAL = 10, 0.45
+    # Motion shown alongside body text needs a way to stop it past five seconds (WCAG
+    # 2.2.2), and an APNG in an <img> offers none. One short play is outside that.
+    PLAYS, SECONDS = 1, 5.0
 
     def __init__(self, outdir):
         self.outdir = outdir
@@ -137,9 +141,23 @@ class Shots:
         apng = os.path.join(self.outdir, f"{name}.apng")
         frames[0].save(still)
         frames[0].save(apng, format="PNG", save_all=True, append_images=frames[1:],
-                       duration=int(self.INTERVAL * 1000), loop=0)
+                       duration=int(self.INTERVAL * 1000), loop=self.PLAYS)
+        self.plays_once(apng, name)
         print(f"  {name}.apng  {len(frames)} frames, {os.path.getsize(apng) / 1024:.0f} KB")
         self.taken += [still, apng]
+
+    def plays_once(self, path, name):
+        """Read back what was actually written. Four header bytes are all that separate a
+        short play from one that never stops, and `loop` does not mean the same thing for
+        every format Pillow writes."""
+        shown = Image.open(path)
+        plays, total = shown.info.get("loop"), 0
+        for i in range(shown.n_frames):
+            shown.seek(i)
+            total += shown.info.get("duration", 0)
+        if plays != self.PLAYS or total > self.SECONDS * 1000:
+            raise RuntimeError(f"{name}.apng plays {plays}x for {total / 1000:.1f}s, and has "
+                               f"to play {self.PLAYS}x within {self.SECONDS:.0f}s")
 
 
 def warmed_up(main, ids, files=20, seconds=25):

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -32,7 +32,7 @@ TCM_GETITEMCOUNT = 0x1304
 
 PROJECT = "Demo Project"
 NEEDED = ("IDC_lang", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath", "IDC_URL",
-          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend", "IDC_i3")
+          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend", "IDC_i6")
 
 
 class Site(BaseHTTPRequestHandler):
@@ -142,16 +142,20 @@ class Shots:
         self.taken += [still, apng]
 
 
-def warmed_up(main, ids, seconds=25):
-    """Six seconds in, the engine is still parsing the first page: one connection, and a
-    panel where only the byte counter moves. Wait for it to open more before filming, and
-    film anyway if it never does -- the wait is the warm-up either way."""
-    live = ids["IDC_i3"]
+def warmed_up(main, ids, files=20, seconds=25):
+    """Six seconds in, the engine is still parsing the first page and the counters are
+    barely off zero. Wait for them to climb before filming, and film anyway if they do
+    not -- the wait is the warm-up either way."""
+    written = ids["IDC_i6"]
+
+    def enough():
+        count = win32gui.GetWindowText(find(main, control_id=written))
+        return count.isdigit() and int(count) >= files
+
     try:
-        wait(lambda: win32gui.GetWindowText(find(main, control_id=live)) not in ("", "0", "1"),
-             "more than one connection", seconds)
+        wait(enough, f"{files} files written", seconds)
     except Timeout:
-        print("  one connection throughout: filming the sequence regardless")
+        print(f"  under {files} files after {seconds}s: filming the sequence regardless")
 
 
 def pane(main, anchor, what, timeout=30):

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -142,14 +142,17 @@ class Shots:
         frames[0].save(still)
         frames[0].save(apng, format="PNG", save_all=True, append_images=frames[1:],
                        duration=int(self.INTERVAL * 1000), loop=self.PLAYS)
-        self.plays_once(apng, name)
-        print(f"  {name}.apng  {len(frames)} frames, {os.path.getsize(apng) / 1024:.0f} KB")
+        # Report the file rather than the capture: two identical frames in a row are
+        # written as one with their delays added, so the counts differ legitimately.
+        stored, seconds = self.plays_once(apng, name)
+        print(f"  {name}.apng  {stored} frames of {len(frames)}, {seconds:.1f}s, "
+              f"{os.path.getsize(apng) / 1024:.0f} KB")
         self.taken += [still, apng]
 
     def plays_once(self, path, name):
-        """Read back what was actually written. Four header bytes are all that separate a
-        short play from one that never stops, and `loop` does not mean the same thing for
-        every format Pillow writes."""
+        """Read back what was actually written, and return its frames and seconds. Four
+        header bytes are all that separate a short play from one that never stops, and
+        `loop` does not mean the same thing for every format Pillow writes."""
         shown = Image.open(path)
         plays, total = shown.info.get("loop"), 0
         for i in range(shown.n_frames):
@@ -158,6 +161,7 @@ class Shots:
         if plays != self.PLAYS or total > self.SECONDS * 1000:
             raise RuntimeError(f"{name}.apng plays {plays}x for {total / 1000:.1f}s, and has "
                                f"to play {self.PLAYS}x within {self.SECONDS:.0f}s")
+        return shown.n_frames, total / 1000
 
 
 def warmed_up(main, ids, files=20, seconds=25):

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -32,7 +32,7 @@ TCM_GETITEMCOUNT = 0x1304
 
 PROJECT = "Demo Project"
 NEEDED = ("IDC_lang", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath", "IDC_URL",
-          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend")
+          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend", "IDC_i3")
 
 
 class Site(BaseHTTPRequestHandler):
@@ -142,6 +142,18 @@ class Shots:
         self.taken += [still, apng]
 
 
+def warmed_up(main, ids, seconds=25):
+    """Six seconds in, the engine is still parsing the first page: one connection, and a
+    panel where only the byte counter moves. Wait for it to open more before filming, and
+    film anyway if it never does -- the wait is the warm-up either way."""
+    live = ids["IDC_i3"]
+    try:
+        wait(lambda: win32gui.GetWindowText(find(main, control_id=live)) not in ("", "0", "1"),
+             "more than one connection", seconds)
+    except Timeout:
+        print("  one connection throughout: filming the sequence regardless")
+
+
 def pane(main, anchor, what, timeout=30):
     """Wait for a wizard pane: its own anchor control turns visible only once the page
     is on screen, since the sheet keeps every page's controls alive from the start."""
@@ -208,7 +220,8 @@ def run(pid, ids, shots, url, base_path):
     inforun = pane(main, ids["IDC_inforun"], "the progress pane", timeout=60)
     time.sleep(6)  # let the counters fill, or the shot is a screen of zeros
     shots.take(main, "16_mirror_progress")
-    # Framed on the pane's own rectangle, read from the live layout: the panel is what the
+    warmed_up(main, ids)
+    # Framed on the pane's own controls, read from the live layout: the panel is what the
     # website shows, and a crop box written down here would go stale when the layout moves.
     shots.animate(main, win32gui.GetParent(inforun), "16_mirror_progress_panel",
                   lambda: find(main, control_id=ids["IDC_infoend"]))

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -6,6 +6,12 @@ tabs, the ready-to-start pane, and a mirror in progress and finished. The crawl 
 real — the script serves a small site to itself, so the progress screen carries live
 counters rather than zeros.
 
+The progress pane comes out a second time as a ten-frame animation,
+`16_mirror_progress_panel.apng`, with its first frame beside it as a PNG. The website's
+front page uses it to show a mirror actually running rather than a frozen one. It is a
+shot of the pane's own window rather than a crop, so it follows the layout instead of
+going stale with it.
+
 ## Replay
 
 Run the **screenshots** workflow (Actions → Run workflow) and download the
@@ -41,3 +47,9 @@ in `run()`, anchored on a control ID from that pane's dialog.
 - Shots of the main window include the file tree, so on a runner they show that
   machine's `C:\`. A VM with a tidy drive gives nicer full-window shots; the option
   tabs are separate dialogs and carry none of it.
+- Comparing a new set against the previous one byte for byte is what makes the walk
+  worth running before a layout change. The animation cannot take part — its counters
+  differ on every run — so `16_mirror_progress.png` stays the guarded shot of that
+  screen, and the animation is eyeballed.
+- The sequence has to fit inside the crawl: the walk fails rather than write a short
+  animation, and prints how long the mirror ran so the cadence can be matched to it.

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -53,3 +53,6 @@ in `run()`, anchored on a control ID from that pane's dialog.
   screen, and the animation is eyeballed.
 - The sequence has to fit inside the crawl: the walk fails rather than write a short
   animation, and prints how long the mirror ran so the cadence can be matched to it.
+- `PrintWindow` through a child window's own device context dies on the runner with
+  `DeleteDC failed`, so the panel is cropped out of a shot of the whole window rather
+  than captured directly. The crop box still comes from the pane's live rectangle.

--- a/tools/wincapture.py
+++ b/tools/wincapture.py
@@ -87,9 +87,9 @@ def set_text(hwnd, text):
     win32gui.SendMessage(hwnd, WM_SETTEXT, 0, text)
 
 
-def capture(hwnd, path):
+def grab(hwnd):
     """PrintWindow into a memory DC, so the shot carries no taskbar and nothing that
-    happens to overlap. Returns the fraction of the image that is not black."""
+    happens to overlap. Takes a child window as readily as a top-level one."""
     left, top, right, bottom = win32gui.GetWindowRect(hwnd)
     w, h = right - left, bottom - top
     if w <= 0 or h <= 0:
@@ -106,8 +106,20 @@ def capture(hwnd, path):
     mem.DeleteDC()
     dc.DeleteDC()
     win32gui.ReleaseDC(hwnd, src)
-    img.save(path)
+    return img
+
+
+def nonblack(img):
+    """Fraction of the image that is not black."""
+    w, h = img.size
     return 1.0 - sum(img.convert("L").histogram()[:16]) / (w * h)
+
+
+def capture(hwnd, path):
+    """Shoot a window to a PNG. Returns the fraction of the image that is not black."""
+    img = grab(hwnd)
+    img.save(path)
+    return nonblack(img)
 
 
 def slug(text):

--- a/tools/wincapture.py
+++ b/tools/wincapture.py
@@ -89,7 +89,7 @@ def set_text(hwnd, text):
 
 def grab(hwnd):
     """PrintWindow into a memory DC, so the shot carries no taskbar and nothing that
-    happens to overlap. Takes a child window as readily as a top-level one."""
+    happens to overlap."""
     left, top, right, bottom = win32gui.GetWindowRect(hwnd)
     w, h = right - left, bottom - top
     if w <= 0 or h <= 0:
@@ -99,9 +99,12 @@ def grab(hwnd):
     mem = dc.CreateCompatibleDC()
     bmp = win32ui.CreateBitmap()
     bmp.CreateCompatibleBitmap(dc, w, h)
-    mem.SelectObject(bmp)
+    old = mem.SelectObject(bmp)
     user32.PrintWindow(hwnd, mem.GetSafeHdc(), PW_RENDERFULLCONTENT)
     img = Image.frombuffer("RGB", (w, h), bmp.GetBitmapBits(True), "raw", "BGRX", 0, 1)
+    # Select the original bitmap back before deleting ours: deleting a bitmap that is
+    # still selected fails, and so then does deleting the DC holding it.
+    mem.SelectObject(old)
     win32gui.DeleteObject(bmp.GetHandle())
     mem.DeleteDC()
     dc.DeleteDC()
@@ -120,6 +123,13 @@ def capture(hwnd, path):
     img = grab(hwnd)
     img.save(path)
     return nonblack(img)
+
+
+def relative_rect(hwnd, parent):
+    """A window's rectangle in the coordinates of a shot of one of its ancestors."""
+    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+    x, y = win32gui.GetWindowRect(parent)[:2]
+    return left - x, top - y, right - x, bottom - y
 
 
 def slug(text):

--- a/tools/wincapture.py
+++ b/tools/wincapture.py
@@ -125,11 +125,18 @@ def capture(hwnd, path):
     return nonblack(img)
 
 
-def relative_rect(hwnd, parent):
-    """A window's rectangle in the coordinates of a shot of one of its ancestors."""
-    left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+def content_rect(hwnd, parent, pad=8):
+    """What a window actually has on it, padded and clipped to the window itself, in the
+    coordinates of a shot of one of its ancestors. Its own rectangle is not the answer: a
+    dialog stretched to fill a pane leaves a wide band of nothing under its controls."""
+    boxes = [win32gui.GetWindowRect(c) for c, _, _, _ in controls(hwnd)
+             if win32gui.IsWindowVisible(c)]
+    own = win32gui.GetWindowRect(hwnd)
     x, y = win32gui.GetWindowRect(parent)[:2]
-    return left - x, top - y, right - x, bottom - y
+    return (max(min(b[0] for b in boxes) - pad, own[0]) - x,
+            max(min(b[1] for b in boxes) - pad, own[1]) - y,
+            min(max(b[2] for b in boxes) + pad, own[2]) - x,
+            min(max(b[3] for b in boxes) + pad, own[3]) - y)
 
 
 def slug(text):


### PR DESCRIPTION
The front page's progress screenshot is a 1040x744 window shrunk to 300px, where nothing on it can be read. The walk now also shoots the progress panel as a ten-frame sequence and writes it as an APNG, with frame 1 beside it as a plain PNG for the fallback. It comes out 781x423 and about 39 KB, and shows the counters climbing and the bar filling instead of a frozen screen.

It plays once, for 4.5 seconds, and the walk reads the number of plays and the summed delays back out of the file: an APNG inside an <img> has no pause control, so an endless loop beside body text would be motion nobody can stop, and four header bytes are all that separate the two.

The frame is computed at run time from the pane's own controls rather than written down here, so it follows the layout instead of needing a crop box maintained beside it. Filming waits until the crawl has 20 files behind it, which puts every run at the same point and gives the counters something to show, and the demo site now serves more pages more slowly so the sequence fits inside the mirror. That last part also changes the numbers on the two mirror stills, which is the one rebaseline in here.

The animation stays out of the walk's byte-for-byte comparison, since its counters differ on every run: 16_mirror_progress.png is still the guarded shot of that screen. Captured set: run 31495676263.
