### PR TITLE
New projects start throttled at 25 KB/s

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -3097,7 +3097,7 @@ void Read_profile(CString path,int load_path) {
                                   MyGetProfileString(path,strSection, "OtherHeaders");
   maintab->m_option6.m_default_referer =
                                   MyGetProfileString(path,strSection, "DefaultReferer");
-  maintab->m_option5.m_maxrate =  MyGetProfileString(path,strSection, "MaxRate", "25000");
+  maintab->m_option5.m_maxrate =  MyGetProfileString(path,strSection, "MaxRate");
   maintab->m_option5.m_maxconn =  MyGetProfileString(path,strSection, "MaxConn");
   maintab->m_option5.m_maxlinks = MyGetProfileString(path,strSection, "MaxLinks");
   

--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -1501,8 +1501,8 @@ BEGIN
 0x3633, 0x3030, "\000" 
     IDC_maxtime, 0x403, 5, 0
 0x3237, 0x3030, "\000" 
-    IDC_maxrate, 0x403, 2, 0
-0x0020, 
+    IDC_maxrate, 0x403, 1, 0
+"\000" 
     IDC_maxrate, 0x403, 3, 0
 0x3031, "\000" 
     IDC_maxrate, 0x403, 3, 0

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -262,10 +262,9 @@ def options(main, pid, ids, shots, connections=8, rate=2_000_000):
         shots.take(sheet, f"{4 + i:02d}_options_{page}")
     # Eight parallel transfers, so the animation shows a mirror working rather than one
     # file trickling in. Eight is the engine's ceiling; it clamps anything higher. The
-    # The rate cap goes up with it, since WinHTTrack starts a project at 25 KB/s
-    # (Shell.cpp, the MaxRate profile default) and eight throttled transfers would still
-    # crawl. Each on its own page, since a control on a page that is not on top is not
-    # visible to find().
+    # rate cap goes up with it: eight transfers sharing the engine's 100 KB/s default
+    # would still crawl. Each on its own page, since a control on a page that is not on
+    # top is not visible to find().
     for page, control, value in (("limits", "IDC_maxrate", rate),
                                  ("flow_control", "IDC_connexion", connections)):
         if page not in at:

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -67,10 +67,9 @@ in `run()`, anchored on a control ID from that pane's dialog.
   improper argument" inside MFC and leaves a message box over the wizard, so the
   connection count and rate cap are set on the way out of the first visit, after every
   tab has been shot with its defaults.
-- The connection count is not the only knob: WinHTTrack starts every project at a
-  25 KB/s transfer rate (`Shell.cpp`, the `MaxRate` profile default, where the engine's
-  own default is 100 KB/s), so the walk lifts that too and the transfers run at a speed
-  worth filming.
+- The connection count is not the only knob: eight transfers sharing the engine's
+  100 KB/s default rate would still crawl, so the walk lifts the rate as well and the
+  transfers run at a speed worth filming.
 - Frames are written through a single palette, which is lossless while the colour
   union fits 256 entries and halves the file. Quantising each frame against a shared
   palette image is **not** lossless even then; converting the frames together as one


### PR DESCRIPTION
New projects started capped at 25 KB/s: the profile reader had a hardcoded "25000" fallback for MaxRate, and it was the only key in the block with one. That is a quarter of the engine's own default. The rest fall back to empty, which means the option is never passed and the engine picks.

Saved projects keep whatever their profile says. A profile old enough to predate the key now gets the engine default instead of the cap.

Two things the review turned up and this PR carries. The Limits rate combo's first item is a single space where `maxtime` and `maxconn` both have an empty string, so with the field now empty by default, one trip through the options sheet would write `MaxRate= ` and leave it there; the engine ignores the space, but the field is meant to read as unset. And the screenshot walk's two comments named the 25 KB/s default as the reason it lifts the rate, which is no longer the reason.

Closes #103