### PR TITLE
Documentation screenshots advertise a loopback address

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -62,15 +62,25 @@ jobs:
           gh run download $id --name WinHTTrack-x64-Release --dir app
           if (-not (Test-Path app\WinHTTrack.exe)) { throw 'artifact has no WinHTTrack.exe' }
 
+      # The address is on screen in the wizard panes and names the mirror folder, so the
+      # crawl answers to a name rather than to loopback and a port. example.com is the
+      # domain reserved for documentation (RFC 2606).
+      - name: Let the crawl address a named site on port 80
+        shell: pwsh
+        run: Add-Content "$env:SystemRoot\System32\drivers\etc\hosts" "`n127.0.0.1 www.example.com"
+
       - name: Capture
         shell: pwsh
         env:
           MODE: ${{ inputs.mode }}
         run: |
           python -m pip install --quiet pywin32 pillow pywinauto
-          $script = if ($env:MODE -eq 'probe') { 'screenshot-probe.py' } else { 'screenshot-walk.py' }
+          $script = 'screenshot-walk.py'
+          $site = @('--site-host', 'www.example.com', '--site-port', '80')
+          # The probe only answers whether the machine renders at all, and takes neither.
+          if ($env:MODE -eq 'probe') { $script = 'screenshot-probe.py'; $site = @() }
           Write-Host "running $script"
-          python "tools\$script" --exe app\WinHTTrack.exe --out shots
+          python "tools\$script" --exe app\WinHTTrack.exe --out shots @site
 
       - name: Upload the screens
         if: always()

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -62,21 +62,12 @@ jobs:
           gh run download $id --name WinHTTrack-x64-Release --dir app
           if (-not (Test-Path app\WinHTTrack.exe)) { throw 'artifact has no WinHTTrack.exe' }
 
-      # The address is on screen in the wizard panes and names the mirror folder, so the
-      # crawl answers to a name rather than to loopback and a port. example.com is the
-      # domain reserved for documentation (RFC 2606).
-      - name: Let the crawl address a named site on port 80
+      # The address shows in the wizard panes and in the mirror folder name, so the crawl
+      # uses a real host. example.com is reserved for documentation (RFC 2606). The port
+      # stays: http.sys holds 80 for WinRM, and the runner excludes it from binding.
+      - name: Let the crawl address a named site
         shell: pwsh
-        run: |
-          Add-Content "$env:SystemRoot\System32\drivers\etc\hosts" "`n127.0.0.1 www.example.com"
-          # TEMP: why does binding 80 give WinError 10013 here?
-          netstat -ano | Select-String ':80\s'
-          netsh http show servicestate view=requestq | Select-Object -First 30
-          netsh interface ipv4 show excludedportrange protocol=tcp
-          try {
-            $l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 80)
-            $l.Start(); Write-Host 'bind 80 OK'; $l.Stop()
-          } catch { Write-Host "bind 80 failed: $_" }
+        run: Add-Content "$env:SystemRoot\System32\drivers\etc\hosts" "`n127.0.0.1 www.example.com"
 
       - name: Capture
         shell: pwsh
@@ -85,8 +76,8 @@ jobs:
         run: |
           python -m pip install --quiet pywin32 pillow pywinauto
           $script = 'screenshot-walk.py'
-          $site = @('--site-host', 'www.example.com', '--site-port', '8099')
-          # The probe only answers whether the machine renders at all, and takes neither.
+          $site = @('--site-host', 'www.example.com')
+          # The probe only answers whether the machine renders at all, and takes no site.
           if ($env:MODE -eq 'probe') { $script = 'screenshot-probe.py'; $site = @() }
           Write-Host "running $script"
           python "tools\$script" --exe app\WinHTTrack.exe --out shots @site

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -67,7 +67,16 @@ jobs:
       # domain reserved for documentation (RFC 2606).
       - name: Let the crawl address a named site on port 80
         shell: pwsh
-        run: Add-Content "$env:SystemRoot\System32\drivers\etc\hosts" "`n127.0.0.1 www.example.com"
+        run: |
+          Add-Content "$env:SystemRoot\System32\drivers\etc\hosts" "`n127.0.0.1 www.example.com"
+          # TEMP: why does binding 80 give WinError 10013 here?
+          netstat -ano | Select-String ':80\s'
+          netsh http show servicestate view=requestq | Select-Object -First 30
+          netsh interface ipv4 show excludedportrange protocol=tcp
+          try {
+            $l = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 80)
+            $l.Start(); Write-Host 'bind 80 OK'; $l.Stop()
+          } catch { Write-Host "bind 80 failed: $_" }
 
       - name: Capture
         shell: pwsh
@@ -76,7 +85,7 @@ jobs:
         run: |
           python -m pip install --quiet pywin32 pillow pywinauto
           $script = 'screenshot-walk.py'
-          $site = @('--site-host', 'www.example.com', '--site-port', '80')
+          $site = @('--site-host', 'www.example.com', '--site-port', '8099')
           # The probe only answers whether the machine renders at all, and takes neither.
           if ($env:MODE -eq 'probe') { $script = 'screenshot-probe.py'; $site = @() }
           Write-Host "running $script"

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -100,7 +100,8 @@ def serve(host, port):
     a developer's machine. `host` has to resolve to 127.0.0.1 for the crawl to reach it."""
     server = ThreadingHTTPServer(("127.0.0.1", port), Site)
     threading.Thread(target=server.serve_forever, daemon=True).start()
-    return server, "http://%s/" % (host if port == 80 else f"{host}:{port}")
+    bound = server.socket.getsockname()[1]
+    return server, "http://%s/" % (host if bound == 80 else f"{host}:{bound}")
 
 
 def resource_ids(path):

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -354,7 +354,8 @@ def main():
     ap.add_argument("--resource-h", default=os.path.join("WinHTTrack", "resource.h"))
     ap.add_argument("--site-host", default="127.0.0.1",
                     help="name the crawled site answers to; must resolve to 127.0.0.1")
-    ap.add_argument("--site-port", type=int, default=8099)
+    ap.add_argument("--site-port", type=int, default=8099,
+                    help="port to serve it on (0 picks a free one)")
     ap.add_argument("--base-path", default=r"C:\shots-mirror")
     args = ap.parse_args()
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -95,10 +95,12 @@ class Site(BaseHTTPRequestHandler):
         pass
 
 
-def serve(port):
+def serve(host, port):
+    """Serve on loopback, addressed as `host` so the shots read like a site rather than
+    a developer's machine. `host` has to resolve to 127.0.0.1 for the crawl to reach it."""
     server = ThreadingHTTPServer(("127.0.0.1", port), Site)
     threading.Thread(target=server.serve_forever, daemon=True).start()
-    return server
+    return server, "http://%s/" % (host if port == 80 else f"{host}:{port}")
 
 
 def resource_ids(path):
@@ -349,7 +351,9 @@ def main():
     ap.add_argument("--exe", required=True)
     ap.add_argument("--out", default="shots")
     ap.add_argument("--resource-h", default=os.path.join("WinHTTrack", "resource.h"))
-    ap.add_argument("--port", type=int, default=8099)
+    ap.add_argument("--site-host", default="127.0.0.1",
+                    help="name the crawled site answers to; must resolve to 127.0.0.1")
+    ap.add_argument("--site-port", type=int, default=8099)
     ap.add_argument("--base-path", default=r"C:\shots-mirror")
     args = ap.parse_args()
 
@@ -358,13 +362,13 @@ def main():
     # An existing mirror finishes from cache in no time, which turns the progress shot
     # into a second copy of the finished screen.
     shutil.rmtree(args.base_path, ignore_errors=True)
-    serve(args.port)
+    _, site_url = serve(args.site_host, args.site_port)
 
     shots = Shots(args.out)
     exe = os.path.abspath(args.exe)
     proc = subprocess.Popen([exe], cwd=os.path.dirname(exe))
     try:
-        run(proc.pid, ids, shots, f"http://127.0.0.1:{args.port}/", args.base_path)
+        run(proc.pid, ids, shots, site_url, args.base_path)
     except Exception as e:
         print(f"FAILED: {e}")
         diagnose(proc.pid, args.out)

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -35,10 +35,11 @@ pip install pywin32 pillow pywinauto
 python tools\screenshot-walk.py --exe path\to\WinHTTrack.exe --out shots
 ```
 
-That serves the crawl on `127.0.0.1:8099`, and that address is on screen in the wizard
-panes and names the mirror folder. Shots meant for publication want `--site-host` and
-`--site-port` as the workflow passes them: `www.example.com`, mapped to loopback in
-`%SystemRoot%\System32\drivers\etc\hosts` and answering on 80 so no port shows either.
+That serves the crawl on `127.0.0.1:8099`, and that address shows in the wizard panes
+and in the mirror folder name. For publication, pass `--site-host` as the workflow does:
+`www.example.com`, mapped to loopback in `%SystemRoot%\System32\drivers\etc\hosts`. The
+port stays visible, since `http.sys` holds 80 on the runner and 80 is excluded from
+binding there.
 
 ## Adding an option page
 

--- a/tools/screenshots.md
+++ b/tools/screenshots.md
@@ -35,6 +35,11 @@ pip install pywin32 pillow pywinauto
 python tools\screenshot-walk.py --exe path\to\WinHTTrack.exe --out shots
 ```
 
+That serves the crawl on `127.0.0.1:8099`, and that address is on screen in the wizard
+panes and names the mirror folder. Shots meant for publication want `--site-host` and
+`--site-port` as the workflow passes them: `www.example.com`, mapped to loopback in
+`%SystemRoot%\System32\drivers\etc\hosts` and answering on 80 so no port shows either.
+
 ## Adding an option page
 
 Nothing to edit: the tabs are enumerated from the sheet and named after their caption,


### PR DESCRIPTION
The walk addressed its own demo site as `http://127.0.0.1:8099/`. That string shows in the wizard panes, in the mirror folder name, and once per active slot on the progress pane. `--site-host` now names the server: the workflow maps `www.example.com` (RFC 2606, reserved for documentation) to loopback in the hosts file, so the shots read `www.example.com:8099`.

The port could not go too. The engine's equivalent, xroche/httrack#1133, serves on 80 after lowering the Linux unprivileged-port limit; on a `windows-2022` runner `http.sys` already listens on `0.0.0.0:80` for WinRM and the image excludes 80 from binding, which a diagnostic run on this branch confirmed. The script half of that PR ports directly, the workflow half does not.

The walk ran green on this branch with the new address. The screens are not regenerated here, the next reshoot picks it up.

Closes #104