### PR TITLE
Windows CI runs from other branches starve each other's runners

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,6 +31,11 @@ jobs:
   capture:
     runs-on: windows-2022
     timeout-minutes: 20
+    # Competes for the same Windows runners as the build; queue: max, as the default
+    # cancels a waiter rather than holding it.
+    concurrency:
+      group: screenshots-capture
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,8 +31,7 @@ jobs:
   capture:
     runs-on: windows-2022
     timeout-minutes: 20
-    # Competes for the same Windows runners as the build; queue: max, as the default
-    # cancels a waiter rather than holding it.
+    # Shares the Windows runners with the build; queue: max, as the default cancels a waiter.
     concurrency:
       group: screenshots-capture
       queue: max

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,10 +24,11 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded PR and branch-push runs. Never a tag or a dispatch: those can sign.
+# Cancel superseded runs on a branch or PR, never a tag's: that run signs. A dispatch can
+# sign too, and cancel-in-progress is the arriving run's flag, so it needs a group of its own.
 concurrency:
-  group: windows-build-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type != 'tag') }}
+  group: windows-build-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   # Cheap guard for the rules .gitattributes cannot enforce on its own.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,10 +24,10 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on the same branch or PR -- but never a tag's, which signs.
+# Cancel superseded PR and branch-push runs. Never a tag or a dispatch: those can sign.
 concurrency:
   group: windows-build-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type != 'tag') }}
 
 jobs:
   # Cheap guard for the rules .gitattributes cannot enforce on its own.
@@ -188,7 +188,7 @@ jobs:
         platform: [x64, Win32]
         configuration: [Release]
     # Windows runs from other branches starve this one's runner (xroche/httrack#1213),
-    # so cap them repo-wide at one per platform.
+    # so cap them at one per platform. queue: max, as the default cancels a waiter.
     concurrency:
       group: windows-build-${{ matrix.platform }}
       queue: max
@@ -774,8 +774,8 @@ jobs:
     needs: build
     runs-on: windows-2022
     environment: signing
-    # Two tags pushed at once would fight over the signing session. queue: max, as
-    # the shorthand's default cancels the waiting run instead of holding it.
+    # Two tags pushed at once would fight over the signing session; queue: max holds
+    # the waiter the shorthand would have cancelled.
     concurrency:
       group: certum-signing
       queue: max

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -24,6 +24,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same branch or PR -- but never a tag's, which signs.
+concurrency:
+  group: windows-build-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
 jobs:
   # Cheap guard for the rules .gitattributes cannot enforce on its own.
   encoding:
@@ -182,6 +187,11 @@ jobs:
       matrix:
         platform: [x64, Win32]
         configuration: [Release]
+    # Windows runs from other branches starve this one's runner (xroche/httrack#1213),
+    # so cap them repo-wide at one per platform.
+    concurrency:
+      group: windows-build-${{ matrix.platform }}
+      queue: max
     steps:
       - name: Checkout httrack-windows
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -764,8 +774,11 @@ jobs:
     needs: build
     runs-on: windows-2022
     environment: signing
-    # Two tags pushed at once would fight over the signing session.
-    concurrency: certum-signing
+    # Two tags pushed at once would fight over the signing session. queue: max, as
+    # the shorthand's default cancels the waiting run instead of holding it.
+    concurrency:
+      group: certum-signing
+      queue: max
     permissions:
       contents: read
       # download-artifact reads this run's artifacts through the Actions API.


### PR DESCRIPTION
Windows jobs from other branches starve this repo's runners, and a starved job dies leaving no log and no artifact behind (xroche/httrack#1213, capped there in #1214). This repo had no concurrency control at any level.

The build is now capped repo-wide at one run per platform, the screenshots capture likewise, and superseded PR and branch-push runs are cancelled. Runs that can sign are kept out of that: a tag has its own group already, and a `workflow_dispatch` gets one, since `cancel-in-progress` is the arriving run's flag and a run cannot exempt itself from it. Everything asks for `queue: max`, since the default holds a single waiter and cancels it when the next run arrives; that default is what the sign job's `concurrency: certum-signing` shorthand was quietly taking.