### PR TITLE
Ask the engine whether a host-alias rule is well-formed

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1910,7 +1910,7 @@ static BOOL fitsEngineArgument(const CString &value) {
   return fits;
 }
 
-// A leading dash reads as the argument being missing: the engine takes the next option for it.
+// A leading dash reads as the argument being missing, which aborts the mirror.
 static BOOL isEngineArgument(const CString &value) {
   return fitsEngineArgument(value) && value[0] != '-';
 }

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1911,58 +1911,14 @@ static BOOL isEngineArgument(const CString &value) {
   return fits;
 }
 
-// One side of a rule: a bare host, optionally behind its scheme. Mirrors the engine's
-// hts_host_alias_token_ok(), which is not exported from libhttrack.
-static BOOL isHostAliasToken(CString token, BOOL glob) {
-  static const char *const schemes[] = { "http:", "ftp:", "https:", "file:",
-                                         "socks5h:", "socks5:", "connect:", NULL };
-  CString host;
-  int n, scheme;
-
-  token.Trim(_T(" \t"));
-  for(n = token.GetLength() ; n > 0 && token[n - 1] == '/' ; n--);
-  token = token.Left(n);            // the matcher strips the whole trailing run
-  // the scheme may itself be a glob on the alias side, so cut on "://"
-  scheme = token.Find(_T("://"));
-  if (scheme >= 0) {
-    host = token.Mid(scheme + 3);
-  } else {
-    host = token;
-    for(int i = 0 ; schemes[i] != NULL ; i++) {
-      const int len = (int) strlen(schemes[i]);
-      if (host.Left(len).CompareNoCase(schemes[i]) == 0) {
-        host = host.Mid(len);
-        break;
-      }
-    }
-    if (host.Left(2) == _T("//"))
-      host = host.Mid(2);
-  }
-  // a scheme with no host behind it, and the engine's own pseudo-host, name nothing
-  if (host.IsEmpty() || host == _T("primary"))
-    return FALSE;
-  if (host.Find('/') >= 0)          // a path belongs to no part of an address
-    return FALSE;
-  return host.FindOneOf(glob ? _T("=# \t") : _T("=,*?();\\#@ \t")) < 0;
-}
-
 // see Shell.h
 BOOL isHostAliasRule(const CString &rule) {
-  const int eq = rule.Find('=');
+  // ask the engine about the very bytes argv will carry, not the ANSI ones MFC holds
+  char *utf8 = strdupt_utf8(rule);   // freet() nulls it, so not const
+  const BOOL ok = hts_host_alias_rule_ok(utf8) ? TRUE : FALSE;
 
-  if (eq <= 0 || eq == rule.GetLength() - 1)
-    return FALSE;
-  if (!isHostAliasToken(rule.Mid(eq + 1), FALSE))
-    return FALSE;
-  for(int pat = 0 ; pat < eq ; ) {
-    const int sep = rule.Find(',', pat);
-    const int end = (sep >= 0 && sep < eq) ? sep : eq;
-
-    if (!isHostAliasToken(rule.Mid(pat, end - pat), TRUE))
-      return FALSE;
-    pat = end + 1;
-  }
-  return TRUE;
+  freet(utf8);
+  return ok;
 }
 
 static BOOL isAllDigits(const CString &value) {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1898,10 +1898,9 @@ void splitRulesInArray(CStringArray &rules, const CString &str) {
 }
 
 // A value restored from a profile never met the dialog's validation, so an option's
-// argument is checked here as well: the engine aborts the whole mirror on one that is
-// over-long, or that starts with a dash, which it reads as the argument being missing.
-static BOOL isEngineArgument(const CString &value) {
-  if (value.IsEmpty() || value[0] == '-')
+// argument is checked here as well: the engine aborts the whole mirror on an over-long one.
+static BOOL fitsEngineArgument(const CString &value) {
+  if (value.IsEmpty())
     return FALSE;
   // the engine measures the UTF-8 bytes strdupt_utf8() will hand it, not these characters
   char *utf8 = hts_convertStringSystemToUTF8(value, value.GetLength());  // freet() nulls it, so not const
@@ -1911,14 +1910,25 @@ static BOOL isEngineArgument(const CString &value) {
   return fits;
 }
 
-// see Shell.h
-BOOL isHostAliasRule(const CString &rule) {
+// A leading dash reads as the argument being missing: the engine takes the next option for it.
+static BOOL isEngineArgument(const CString &value) {
+  return fitsEngineArgument(value) && value[0] != '-';
+}
+
+// TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host".
+static BOOL isHostAliasRule(const CString &rule) {
   // ask the engine about the very bytes argv will carry, not the ANSI ones MFC holds
   char *utf8 = strdupt_utf8(rule);   // freet() nulls it, so not const
   const BOOL ok = hts_host_alias_rule_ok(utf8) ? TRUE : FALSE;
 
   freet(utf8);
   return ok;
+}
+
+// see Shell.h
+BOOL isHostAliasArgument(const CString &rule) {
+  // --host-alias takes an alias starting with a dash, so no dash test here (engine #1179)
+  return isHostAliasRule(rule) && fitsEngineArgument(rule);
 }
 
 static BOOL isAllDigits(const CString &value) {
@@ -2121,7 +2131,7 @@ void lance(void) {
     CStringArray rules;
     splitRulesInArray(rules, ShellOptions->hostalias);
     for(INT_PTR i = 0 ; i < rules.GetSize() ; i++) {
-      if (isHostAliasRule(rules[i]) && isEngineArgument(rules[i])) {
+      if (isHostAliasArgument(rules[i])) {
         args.Add("--host-alias");
         args.Add(rules[i]);
       }

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -215,8 +215,8 @@ int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value);
    Exposed for --selftest; see the definition for the separator rule. */
 void splitRulesInArray(CStringArray &rules, const CString &str);
 
-/* TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host". Mirrors the
-   engine's unexported hts_host_alias_rule_ok(); a rule it refuses aborts the mirror. */
+/* TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host", as the engine's
+   hts_host_alias_rule_ok() judges it; a rule it refuses aborts the mirror. */
 BOOL isHostAliasRule(const CString &rule);
 
 void Build_TopIndex(BOOL check_empty=TRUE);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -215,9 +215,9 @@ int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value);
    Exposed for --selftest; see the definition for the separator rule. */
 void splitRulesInArray(CStringArray &rules, const CString &str);
 
-/* TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host", as the engine's
-   hts_host_alias_rule_ok() judges it; a rule it refuses aborts the mirror. */
-BOOL isHostAliasRule(const CString &rule);
+/* TRUE if RULE may be handed to --host-alias: well-formed per the engine's
+   hts_host_alias_rule_ok(), and short enough for argv. One it refuses aborts the mirror. */
+BOOL isHostAliasArgument(const CString &rule);
 
 void Build_TopIndex(BOOL check_empty=TRUE);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -216,7 +216,7 @@ int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value);
 void splitRulesInArray(CStringArray &rules, const CString &str);
 
 /* TRUE if RULE may be handed to --host-alias: well-formed per the engine's
-   hts_host_alias_rule_ok(), and short enough for argv. One it refuses aborts the mirror. */
+   hts_host_alias_rule_ok(), and short enough for argv. A rule it refuses aborts the mirror. */
 BOOL isHostAliasArgument(const CString &rule);
 
 void Build_TopIndex(BOOL check_empty=TRUE);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -405,8 +405,8 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("rule splitting ok\n");
     }
-    /* Copied from the engine's own htsselftest.c: the GUI must refuse exactly what
-       hts_host_alias_rule_ok() refuses, or a rule it lets through aborts the mirror. */
+    /* Pins the engine's grammar through the DLL: a rule the field lets through and
+       the engine then refuses aborts the mirror. */
     {
       static const struct { const char* rule; BOOL want; } aliases[] = {
         { "b.com = a.com", TRUE },       { "*://b.com=a.com", TRUE },
@@ -424,6 +424,9 @@ BOOL CWinHTTrackApp::InitInstance()
         { "https://www.foo.com/=ftp://ftp.foo.com/pub/", FALSE },
         { "https://www.foo.com/a=ftp://ftp.foo.com", FALSE },
         { "a.com,b.com/deep=c.com", FALSE },
+        /* an unknown scheme is not one, and a control byte names no host */
+        { "b.com=x://a.com", FALSE },    { "b.com=a\vcom", FALSE },
+        { "b.com=a\fcom", FALSE },       { "b.com=a.com\x7f", FALSE },
         { NULL, FALSE }
       };
       for(int k=0 ; aliases[k].rule != NULL ; k++) {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -405,8 +405,8 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("rule splitting ok\n");
     }
-    /* Pins the engine's grammar through the DLL: a rule the field lets through and
-       the engine then refuses aborts the mirror. */
+    /* Pins the engine's grammar through the DLL: a rule that passes here but not
+       there aborts the mirror. */
     {
       static const struct { const char* rule; BOOL want; } aliases[] = {
         { "b.com = a.com", TRUE },       { "*://b.com=a.com", TRUE },
@@ -424,13 +424,19 @@ BOOL CWinHTTrackApp::InitInstance()
         { "https://www.foo.com/=ftp://ftp.foo.com/pub/", FALSE },
         { "https://www.foo.com/a=ftp://ftp.foo.com", FALSE },
         { "a.com,b.com/deep=c.com", FALSE },
-        /* an unknown scheme is not one, and a control byte names no host */
-        { "b.com=x://a.com", FALSE },    { "b.com=a\vcom", FALSE },
-        { "b.com=a\fcom", FALSE },       { "b.com=a.com\x7f", FALSE },
+        /* an unknown scheme and a control byte both name no host */
+        { "b.com=x://a.com", FALSE },    { "b.com=a.com://c.com", FALSE },
+        { "b.com=a\vcom", FALSE },       { "b.com=a\fcom", FALSE },
+        { "b.com=a.com\x7f", FALSE },    { "b\v.com=a.com", FALSE },
+        { "b.com=a.com\nc.com", FALSE }, { "b.com=ftp://a.com", TRUE },
+        /* an accented or IDN host is high bytes, which the engine passes through */
+        { "b.com=caf\xC3\xA9.example", TRUE },
+        /* the engine takes an alias starting with a dash (#1179) */
+        { "-legacy.example.com=example.com", TRUE },
         { NULL, FALSE }
       };
       for(int k=0 ; aliases[k].rule != NULL ; k++) {
-        if (isHostAliasRule(aliases[k].rule) != aliases[k].want) {
+        if (isHostAliasArgument(aliases[k].rule) != aliases[k].want) {
           fprintf(stderr, "FATAL: host-alias rule '%s' judged %s\n",
                   aliases[k].rule, aliases[k].want ? "bad, expected good"
                                                    : "good, expected bad");

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -405,8 +405,8 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("rule splitting ok\n");
     }
-    /* Pins the engine's grammar through the DLL: a rule that passes here but not
-       there aborts the mirror. */
+    /* Pins the engine's grammar through the DLL, so a change to it lands here and
+       not in a mirror. */
     {
       static const struct { const char* rule; BOOL want; } aliases[] = {
         { "b.com = a.com", TRUE },       { "*://b.com=a.com", TRUE },
@@ -429,8 +429,8 @@ BOOL CWinHTTrackApp::InitInstance()
         { "b.com=a\vcom", FALSE },       { "b.com=a\fcom", FALSE },
         { "b.com=a.com\x7f", FALSE },    { "b\v.com=a.com", FALSE },
         { "b.com=a.com\nc.com", FALSE }, { "b.com=ftp://a.com", TRUE },
-        /* an accented or IDN host is high bytes, which the engine passes through */
-        { "b.com=caf\xC3\xA9.example", TRUE },
+        /* an accented host reaches the engine as UTF-8 high bytes, which it passes through */
+        { "b.com=caf\xE9.example", TRUE },
         /* the engine takes an alias starting with a dash (#1179) */
         { "-legacy.example.com=example.com", TRUE },
         { NULL, FALSE }


### PR DESCRIPTION
The Host aliases field on the Spider page kept its own copy of the engine's rule grammar, because `hts_host_alias_rule_ok()` was not exported. Engine 14e91080 exports it, so the field now asks the engine. The copy had already drifted looser than the original: it accepted `\v`, `\f` and an unknown scheme such as `b.com=x://a.com`, all of which the engine refuses. A rule that passes here and fails there aborts the mirror rather than being skipped.

Reviewing that turned up a second bug, fixed in the follow-up commit. The argv guard refused any value starting with a dash, because the engine reads one as the option's argument being missing. `--host-alias` is the documented exception (engine #1179): it takes the next argument whatever it looks like, so `-legacy.example.com=example.com` was legal and silently dropped. `lance()` asks one predicate now, `isHostAliasArgument()`.

The `--selftest` table exercises that predicate through the DLL, with rows for the cases above plus a newline, a pattern-side control byte, a double scheme, and a high-byte host.

Needs the engine at 14e91080 or later. CI floats master, so there is nothing to pin.
