### PR TITLE
Set the GUI version to 3.50-beta-4

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-3"
+#define WINHTTRACK_VERSION "3.50-beta-4"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.3"
+#define WINHTTRACK_VERSIONID "3.49.99.4"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 3
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 4
 
 #endif


### PR DESCRIPTION
Sets the GUI version to 3.50-beta-4 for the next beta, which would be signed on engine 3.49.21.

Only version.h changes: it has been the single source for the GUI version since the beta-1 split, and the .rc, the installer and CI all read it from there.

Draft on purpose. The request to cut beta-4 reached this session through a relay whose origin cannot be identified, so it stays a draft until Xavier confirms he wants the beta.