### PR TITLE
Lay a re-shown options sheet out from its own window

### DIFF
--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -151,6 +151,7 @@ ON_WM_TIMER()
 ON_WM_HELPINFO()
 ON_WM_SIZE()
 ON_WM_GETMINMAXINFO()
+ON_WM_DESTROY()
 //}}AFX_MSG_MAP
 ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
 ON_COMMAND(ID_HELP,OnHelpInfo2)
@@ -221,6 +222,16 @@ void CMainTab::OnSize(UINT nType, int cx, int cy)
 {
   CPropertySheet::OnSize(nType, cx, cy);
   m_sheetLayout.Apply(cx, cy);
+}
+
+/* OptPannel re-shows the one CMainTab, so everything measured for this window has to go
+   with it: kept, it clamps the next window's creation size and is applied to it before
+   OnInitDialog can measure anything. */
+void CMainTab::OnDestroy()
+{
+  m_sheetLayout.Build(NULL);
+  m_minSize.cx = m_minSize.cy = 0;
+  CPropertySheet::OnDestroy();
 }
 
 void CMainTab::OnGetMinMaxInfo(MINMAXINFO* lpMMI)

--- a/WinHTTrack/MainTab.cpp
+++ b/WinHTTrack/MainTab.cpp
@@ -224,9 +224,8 @@ void CMainTab::OnSize(UINT nType, int cx, int cy)
   m_sheetLayout.Apply(cx, cy);
 }
 
-/* OptPannel re-shows the one CMainTab, so everything measured for this window has to go
-   with it: kept, it clamps the next window's creation size and is applied to it before
-   OnInitDialog can measure anything. */
+/* OptPannel re-shows this sheet, so what was measured for one window must not reach the
+   next: it clamps that window's size and is applied before Build can measure it. */
 void CMainTab::OnDestroy()
 {
   m_sheetLayout.Build(NULL);

--- a/WinHTTrack/MainTab.h
+++ b/WinHTTrack/MainTab.h
@@ -107,6 +107,7 @@ protected:
 	afx_msg BOOL OnHelpInfo(HELPINFO* dummy);
   afx_msg void OnSize(UINT nType, int cx, int cy);
   afx_msg void OnGetMinMaxInfo(MINMAXINFO* lpMMI);
+  afx_msg void OnDestroy();
   //}}AFX_MSG
   virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
 	afx_msg void OnHelpInfo2();

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -177,6 +177,9 @@ void CSheetLayout::Build(CPropertySheet* sheet)
   m_sheet = NULL;
   m_pageBase.SetRectEmpty();
   m_baseClient.cx = m_baseClient.cy = 0;
+  /* A re-shown sheet is a new window in the same object, so the furniture measured for
+     the old one must go: an OnSize before the next Build has to find nothing to apply. */
+  m_layout.Reset(NULL);
   if (sheet == NULL || sheet->m_hWnd == NULL)
     return;
   m_sheet = sheet;
@@ -226,7 +229,8 @@ void CSheetLayout::Build(CPropertySheet* sheet)
 
 void CSheetLayout::LayoutActivePage()
 {
-  if (m_sheet == NULL || m_pageBase.IsRectEmpty() || m_baseClient.cx == 0)
+  if (m_sheet == NULL || !::IsWindow(m_sheet->m_hWnd)
+      || m_pageBase.IsRectEmpty() || m_baseClient.cx == 0)
     return;
   /* Not GetActivePage(): FinalInProgress empties the page array between RemovePage and
      AddPage, and it then indexes -1 and hands back a wild pointer. */
@@ -234,7 +238,7 @@ void CSheetLayout::LayoutActivePage()
   if (active < 0 || active >= m_sheet->GetPageCount())
     return;
   CPropertyPage* const page = m_sheet->GetPage(active);
-  if (page == NULL || page->m_hWnd == NULL)
+  if (page == NULL || !::IsWindow(page->m_hWnd))
     return;
   CRect client;
   m_sheet->GetClientRect(client);

--- a/WinHTTrack/WndLayout.cpp
+++ b/WinHTTrack/WndLayout.cpp
@@ -177,8 +177,8 @@ void CSheetLayout::Build(CPropertySheet* sheet)
   m_sheet = NULL;
   m_pageBase.SetRectEmpty();
   m_baseClient.cx = m_baseClient.cy = 0;
-  /* A re-shown sheet is a new window in the same object, so the furniture measured for
-     the old one must go: an OnSize before the next Build has to find nothing to apply. */
+  /* A re-shown sheet is a new window in the same object; drop what was measured for the
+     old one, so an OnSize before the next Build finds nothing to apply. */
   m_layout.Reset(NULL);
   if (sheet == NULL || sheet->m_hWnd == NULL)
     return;

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -249,12 +249,16 @@ def close_options(sheet, pid, button):
 def reopen_options(main, pid, ids):
     """#112: the sheet outlives its window, so a second open used to be laid out from the
     previous one's geometry before anything was measured again."""
-    sheet, _, _ = open_options(main, pid, ids)
-    strays = [h for h in top_level_windows(pid)
-              if h not in (sheet, main) and win32gui.IsWindowVisible(h)]
-    if strays:
-        titles = ", ".join(repr(win32gui.GetWindowText(h)) for h in strays)
-        raise RuntimeError(f"the second Set options put {len(strays)} window(s) up: {titles}")
+    before = set(top_level_windows(pid))
+    click(find(main, control_id=ids["ID_setopt"], class_name="Button"))
+    sheet = wait(lambda: next((h for h in top_level_windows(pid) if h not in before), None),
+                 "the options sheet to open again", 30)
+    # An MFC error box is what comes up instead, so say what it said rather than timing
+    # out later on a tab control the box does not have.
+    if find(sheet, class_name="SysTabControl32") is None:
+        said = " / ".join(text for _, _, cls, text in controls(sheet)
+                          if cls == "Static" and text)
+        raise RuntimeError(f"the second Set options put up a box instead of the sheet: {said}")
     box = win32gui.GetWindowRect(sheet)
     screen = win32gui.GetWindowRect(win32gui.GetDesktopWindow())
     if box[2] - box[0] > screen[2] or box[3] - box[1] > screen[3]:

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -250,25 +250,34 @@ def reopen_options(main, pid, ids):
     """#112: reopening Options must not inherit the previous window's geometry."""
     before = set(top_level_windows(pid))
     click(find(main, control_id=ids["ID_setopt"], class_name="Button"))
-    sheet = wait(lambda: next((h for h in top_level_windows(pid) if h not in before), None),
-                 "the options sheet to open again", 30)
-    # Report the box's own text; it has no tab control to wait for.
-    if find(sheet, class_name="SysTabControl32") is None:
-        said = " / ".join(text for _, _, cls, text in controls(sheet)
+    wait(lambda: [h for h in top_level_windows(pid) if h not in before],
+         "the options sheet to open again", 30)
+    time.sleep(1.0)   # a box can trail the sheet rather than replace it
+    opened = [h for h in top_level_windows(pid) if h not in before]
+    sheets = [h for h in opened if find(h, class_name="SysTabControl32")]
+    strays = [h for h in opened if h not in sheets]
+    if strays:
+        said = " / ".join(text for h in strays for _, _, cls, text in controls(h)
                           if cls == "Static" and text)
-        raise RuntimeError(f"the second Set options put up a box instead of the sheet: {said}")
+        raise RuntimeError(f"the second Set options put up a box: {said}")
+    if len(sheets) != 1:
+        raise RuntimeError(f"the second Set options opened {len(sheets)} sheets")
+    sheet = sheets[0]
+    # Containment, not size: a sheet that merely fits can still hang off the bottom.
     box = win32gui.GetWindowRect(sheet)
-    screen = win32gui.GetWindowRect(win32gui.GetDesktopWindow())
-    if box[2] - box[0] > screen[2] or box[3] - box[1] > screen[3]:
-        raise RuntimeError(f"the second Set options sized the sheet {box[2]-box[0]}x"
-                           f"{box[3]-box[1]}, past the {screen[2]}x{screen[3]} screen")
+    desk = win32gui.GetWindowRect(win32gui.GetDesktopWindow())
+    if box[0] < desk[0] or box[1] < desk[1] or box[2] > desk[2] or box[3] > desk[3]:
+        raise RuntimeError(f"the second Set options put the sheet at {box}, "
+                           f"outside the desktop {desk}")
     # The buttons sit on the bottom edge, where a grown page can cover them.
     for button in (IDOK, IDCANCEL):
         hwnd = find(sheet, control_id=button, class_name="Button")
+        if hwnd is None:
+            raise RuntimeError(f"the second Set options has no button {button}")
         left, top, right, bottom = win32gui.GetWindowRect(hwnd)
         if win32gui.WindowFromPoint(((left + right) // 2, (top + bottom) // 2)) != hwnd:
             raise RuntimeError(f"button {button} is covered on the second Set options")
-    close_options(sheet, pid, IDCANCEL)
+    close_options(sheet, pid, IDOK)
     print("  second Set options: clean")
 
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -247,14 +247,12 @@ def close_options(sheet, pid, button):
 
 
 def reopen_options(main, pid, ids):
-    """#112: the sheet outlives its window, so a second open used to be laid out from the
-    previous one's geometry before anything was measured again."""
+    """#112: reopening Options must not inherit the previous window's geometry."""
     before = set(top_level_windows(pid))
     click(find(main, control_id=ids["ID_setopt"], class_name="Button"))
     sheet = wait(lambda: next((h for h in top_level_windows(pid) if h not in before), None),
                  "the options sheet to open again", 30)
-    # An MFC error box is what comes up instead, so say what it said rather than timing
-    # out later on a tab control the box does not have.
+    # Report the box's own text; it has no tab control to wait for.
     if find(sheet, class_name="SysTabControl32") is None:
         said = " / ".join(text for _, _, cls, text in controls(sheet)
                           if cls == "Static" and text)
@@ -264,7 +262,7 @@ def reopen_options(main, pid, ids):
     if box[2] - box[0] > screen[2] or box[3] - box[1] > screen[3]:
         raise RuntimeError(f"the second Set options sized the sheet {box[2]-box[0]}x"
                            f"{box[3]-box[1]}, past the {screen[2]}x{screen[3]} screen")
-    # The buttons ride the bottom edge; the grown page used to cover them mid-window.
+    # The buttons sit on the bottom edge, where a grown page can cover them.
     for button in (IDOK, IDCANCEL):
         hwnd = find(sheet, control_id=button, class_name="Button")
         left, top, right, bottom = win32gui.GetWindowRect(hwnd)

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -246,13 +246,33 @@ def close_options(sheet, pid, button):
     wait(lambda: sheet not in top_level_windows(pid), "the options sheet to close", 15)
 
 
+def reopen_options(main, pid, ids):
+    """#112: the sheet outlives its window, so a second open used to be laid out from the
+    previous one's geometry before anything was measured again."""
+    sheet, _, _ = open_options(main, pid, ids)
+    strays = [h for h in top_level_windows(pid)
+              if h not in (sheet, main) and win32gui.IsWindowVisible(h)]
+    if strays:
+        titles = ", ".join(repr(win32gui.GetWindowText(h)) for h in strays)
+        raise RuntimeError(f"the second Set options put {len(strays)} window(s) up: {titles}")
+    box = win32gui.GetWindowRect(sheet)
+    screen = win32gui.GetWindowRect(win32gui.GetDesktopWindow())
+    if box[2] - box[0] > screen[2] or box[3] - box[1] > screen[3]:
+        raise RuntimeError(f"the second Set options sized the sheet {box[2]-box[0]}x"
+                           f"{box[3]-box[1]}, past the {screen[2]}x{screen[3]} screen")
+    # The buttons ride the bottom edge; the grown page used to cover them mid-window.
+    for button in (IDOK, IDCANCEL):
+        hwnd = find(sheet, control_id=button, class_name="Button")
+        left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+        if win32gui.WindowFromPoint(((left + right) // 2, (top + bottom) // 2)) != hwnd:
+            raise RuntimeError(f"button {button} is covered on the second Set options")
+    close_options(sheet, pid, IDCANCEL)
+    print("  second Set options: clean")
+
+
 def options(main, pid, ids, shots, connections=8, rate=2_000_000):
     """The eleven option tabs, switched through the sheet rather than by clicking the tab
-    control, so a two-row tab layout cannot put a tab under the mouse of another.
-
-    The connection count is set on the way out, after every tab has been shot with its
-    defaults, because the sheet only opens once: a second "Set options..." throws
-    "Encountered an improper argument" inside MFC and leaves a message box on screen."""
+    control, so a two-row tab layout cannot put a tab under the mouse of another."""
     sheet, tabs, captions = open_options(main, pid, ids)
     count = win32gui.SendMessage(tabs, TCM_GETITEMCOUNT, 0, 0)
     print(f"  options sheet {sheet:#x}: {count} tabs")
@@ -277,6 +297,7 @@ def options(main, pid, ids, shots, connections=8, rate=2_000_000):
         set_text(find(sheet, control_id=ids[control]), str(value))
     close_options(sheet, pid, IDOK)
     print(f"  {connections} connections, {rate} B/s")
+    reopen_options(main, pid, ids)
 
 
 def run(pid, ids, shots, url, base_path):


### PR DESCRIPTION
The one CMainTab is re-shown by OptPannel, so geometry measured for one window survived into the next: it clamped the new window through OnGetMinMaxInfo and was applied from OnInitDialog's own SetWindowPos, before Build had measured anything. The layout now resets with the window.

The screenshot walk had this bug written into a comment as a thing to route around ("the sheet only opens once"), which is why nothing caught it. It now opens the sheet a second time and fails on a stray message box, a sheet bigger than the screen, or a covered button.

Closes #112