### PR TITLE
A transient download failure should not fail the build

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -196,7 +196,8 @@ jobs:
     env:
       # vcpkg calls a codeload 503 (curl error 56) non-transient and gives up at once (#115), so
       # downloads retry through curl; still SHA512-checked, and a failed script falls back to vcpkg.
-      X_VCPKG_ASSET_SOURCES: 'x-script,curl.exe --location --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 3 --output {dst} {url}'
+      # --create-dirs: the first download of a run lands in a downloads/ vcpkg has not made yet.
+      X_VCPKG_ASSET_SOURCES: 'x-script,curl.exe --location --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 3 --create-dirs --output {dst} {url}'
     steps:
       - name: Checkout httrack-windows
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -193,6 +193,10 @@ jobs:
     concurrency:
       group: windows-build-${{ matrix.platform }}
       queue: max
+    env:
+      # vcpkg calls a codeload 503 (curl error 56) non-transient and gives up at once (#115), so
+      # downloads retry through curl; still SHA512-checked, and a failed script falls back to vcpkg.
+      X_VCPKG_ASSET_SOURCES: 'x-script,curl.exe --location --fail --silent --show-error --retry 5 --retry-all-errors --retry-delay 3 --output {dst} {url}'
     steps:
       - name: Checkout httrack-windows
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Every run builds brotli, openssl, zlib and zstd from source and fetches each tarball live, along with cmake, nasm, jom, Strawberry Perl and two msys2 packages. When codeload answers 503, vcpkg sees curl error 56, decides it is "not a transient network error" and gives up without retrying, which is what took out six legs across the 3.50-beta-4 release. Pointing `X_VCPKG_ASSET_SOURCES` at an `x-script` source hands every download to curl with `--retry-all-errors`, so a 503 now costs a few seconds. vcpkg still checks the pinned SHA512 of whatever the script produced, and a failing script falls back to its own downloader, so the worst case is what we have today.

No cache shared between runs, deliberately: nothing an untrusted run can write should reach a build that gets signed. GitHub scopes a pull request's cache to `refs/pull/N/merge` and a branch's cache to that branch, so master could not read either one, but this way there is no shared store to reason about at all.

Closes #115
