### PR TITLE
Make the binaries warning visible, and its match line exact

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -56,12 +56,13 @@ jobs:
           if ($id) {
             $sha = gh run view $id --json headSha -q '.headSha'
             Write-Host "binaries from run $id (given), built from $sha"
-            if ($sha -ne $env:SHA) { Write-Warning "run $id was built from $sha, not this checkout's $($env:SHA)" }
+            if ($sha -ne $env:SHA) { Write-Host "::warning::run $id was built from $sha, not this checkout's $($env:SHA)" }
           } else {
             # A moved tag keeps the old build attached to the ref, so match the commit, not the ref name.
             foreach ($ref in @($env:BRANCH, 'master') | Select-Object -Unique) {
               $run = Get-Builds $ref | Where-Object { $_.headSha -eq $env:SHA } | Select-Object -First 1
-              if ($run) { $id = $run.databaseId; Write-Host "binaries from run $id ($ref), built from this commit $($env:SHA)"; break }
+              # "of", not "from": a pull_request build is of the merge commit for this head.
+              if ($run) { $id = $run.databaseId; Write-Host "binaries from run $id ($ref), the build of $($env:SHA)"; break }
             }
             if (-not $id) {
               $run = Get-Builds 'master' | Select-Object -First 1
@@ -69,7 +70,7 @@ jobs:
               $id = $run.databaseId
               # The walk reads control IDs out of the checked-out resource.h, so another tree's binaries can disagree with it.
               Write-Host "binaries from run $id (master), built from $($run.headSha)"
-              Write-Warning "no build of $($env:SHA): these are master's binaries from $($run.headSha), which may not match this checkout"
+              Write-Host "::warning::no build of $($env:SHA): these are master's binaries from $($run.headSha), which may not match this checkout"
             }
           }
           gh run download $id --name WinHTTrack-x64-Release --dir app


### PR DESCRIPTION
Two follow-ups from the #117 review. The mismatch warnings used Write-Warning, which is log text only and never reaches the run summary, so the one case worth noticing was the easiest to miss; they are ::warning:: annotations now. And the match line said "built from this commit", while a pull_request build is of the merge commit for that head, so it now says "the build of".

No behaviour change: the run selection is untouched.