### PR TITLE
A browser-ID field the engine cannot take kills the mirror

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -204,6 +204,15 @@ runs:
         if ("$so" -notmatch 'lang\.indexes offset checked on [1-9]\d* locales') {
           throw "selftest did not check the lang.indexes offset"
         }
+        # The option caps count UTF-8 bytes, so the accented value is the case that matters;
+        # it carries an ANSI-codepage guard and names itself when it skips.
+        if ("$so" -notmatch 'quoted arguments ok(?! \(accented)') {
+          throw "selftest did not check the quoted arguments against an accented value"
+        }
+        # A footer preset is only reachable by opening the Browser ID page.
+        if ("$so" -notmatch 'footer presets ok') {
+          throw "selftest did not check the footer presets"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -83,9 +83,12 @@ void COptionTab6::DoDataExchange(CDataExchange* pDX)
 	//{{AFX_DATA_MAP(COptionTab6)
 	DDX_CBString(pDX, IDC_user, m_user);
 	DDX_CBString(pDX, IDC_footer, m_footer);
+	DDV_MaxChars(pDX, m_footer, FOOTER_MAXBYTES - 1);   // says so, where the argv guard can only drop it
 	DDX_Text(pDX, IDC_accept_language, m_accept_language);
+	DDV_MaxChars(pDX, m_accept_language, LANGISO_MAXBYTES - 1);
 	DDX_Text(pDX, IDC_other_headers, m_other_headers);
 	DDX_Text(pDX, IDC_default_referer, m_default_referer);
+	DDV_MaxChars(pDX, m_default_referer, REFERER_MAXBYTES - 1);
 	//}}AFX_DATA_MAP
 }
 

--- a/WinHTTrack/OptionTab6.cpp
+++ b/WinHTTrack/OptionTab6.cpp
@@ -83,12 +83,9 @@ void COptionTab6::DoDataExchange(CDataExchange* pDX)
 	//{{AFX_DATA_MAP(COptionTab6)
 	DDX_CBString(pDX, IDC_user, m_user);
 	DDX_CBString(pDX, IDC_footer, m_footer);
-	DDV_MaxChars(pDX, m_footer, FOOTER_MAXBYTES - 1);   // says so, where the argv guard can only drop it
 	DDX_Text(pDX, IDC_accept_language, m_accept_language);
-	DDV_MaxChars(pDX, m_accept_language, LANGISO_MAXBYTES - 1);
 	DDX_Text(pDX, IDC_other_headers, m_other_headers);
 	DDX_Text(pDX, IDC_default_referer, m_default_referer);
-	DDV_MaxChars(pDX, m_default_referer, REFERER_MAXBYTES - 1);
 	//}}AFX_DATA_MAP
 }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -720,7 +720,7 @@ void compute_options() {
   
   /* These four reach the engine as quoted arguments, and a value it will not take aborts the
      mirror (a dash, an over-long one) or comes back mangled from doit.log (a quote). */
-  if (isQuotedArgument(maintab->m_option6.m_user, HTS_URLMAXSIZE)) {
+  if (isQuotedArgument(maintab->m_option6.m_user, HTS_CDLMAXSIZE)) {
     ShellOptions->user = "\"";
     ShellOptions->user += maintab->m_option6.m_user;
     ShellOptions->user += "\"";
@@ -1919,9 +1919,12 @@ static BOOL isEngineArgument(const CString &value) {
 
 // see Shell.h
 BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
+  // the quotes wrapped around it count toward the engine's cap on a whole argument
+  const size_t cap = maxBytes < HTS_CDLMAXSIZE - 2 ? maxBytes : HTS_CDLMAXSIZE - 2;
+
   // interior quotes are escaped into doit.log, a leading one is not: the update run that
   // replays it reads the rest of the line as the value, options included
-  return fitsEngineArgument(value, maxBytes) && value[0] != '-' && value[0] != '"';
+  return fitsEngineArgument(value, cap) && value[0] != '-' && value[0] != '"';
 }
 
 // TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host".

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -718,21 +718,20 @@ void compute_options() {
     ShellOptions->rate += maintab->m_option4.m_rate;
   } else ShellOptions->rate = "";
   
-  /* These four reach the engine as quoted arguments, and a value it will not take aborts the
-     mirror (a dash, an over-long one) or comes back mangled from doit.log (a quote). */
-  if (isQuotedArgument(maintab->m_option6.m_user, HTS_CDLMAXSIZE)) {
+  // a value these four cannot carry is left out: passing it would abort the mirror
+  if (isUserAgentArgument(maintab->m_option6.m_user)) {
     ShellOptions->user = "\"";
     ShellOptions->user += maintab->m_option6.m_user;
     ShellOptions->user += "\"";
   } else ShellOptions->user = "";
 
-  if (isQuotedArgument(maintab->m_option6.m_footer, FOOTER_MAXBYTES)) {
+  if (isFooterArgument(maintab->m_option6.m_footer)) {
     ShellOptions->footer = "\"";
     ShellOptions->footer += maintab->m_option6.m_footer;
     ShellOptions->footer += "\"";
   } else ShellOptions->footer = "";
 
-  if (isQuotedArgument(maintab->m_option6.m_accept_language, LANGISO_MAXBYTES)) {
+  if (isLangIsoArgument(maintab->m_option6.m_accept_language)) {
     ShellOptions->accept_language = "\"";
     ShellOptions->accept_language += maintab->m_option6.m_accept_language;
     ShellOptions->accept_language += "\"";
@@ -742,7 +741,7 @@ void compute_options() {
     ShellOptions->other_headers += maintab->m_option6.m_other_headers;
   } else ShellOptions->other_headers = "";
 
-  if (isQuotedArgument(maintab->m_option6.m_default_referer, REFERER_MAXBYTES)) {
+  if (isRefererArgument(maintab->m_option6.m_default_referer)) {
     ShellOptions->default_referer = "\"";
     ShellOptions->default_referer += maintab->m_option6.m_default_referer;
     ShellOptions->default_referer += "\"";
@@ -1899,8 +1898,8 @@ void splitRulesInArray(CStringArray &rules, const CString &str) {
   }
 }
 
-// A value restored from a profile never met the dialog's validation, so an option's
-// argument is checked here as well: the engine aborts the whole mirror on an over-long one.
+// A value restored from a profile never met the dialog, so it is checked here instead,
+// against the cap of the option carrying it.
 static BOOL fitsEngineArgument(const CString &value, size_t maxBytes) {
   if (value.IsEmpty())
     return FALSE;
@@ -1917,15 +1916,30 @@ static BOOL isEngineArgument(const CString &value) {
   return fitsEngineArgument(value, HTS_URLMAXSIZE) && value[0] != '-';
 }
 
-// see Shell.h
-BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
-  // the quotes wrapped around it count toward the engine's cap on a whole argument
-  const size_t quoted = (size_t) HTS_CDLMAXSIZE - 2;
+// A leading dash reads as the argument being missing, and doit.log echoes a leading quote
+// unescaped, so the run replaying it swallows the rest of the line.
+static BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
+  const size_t quoted = (size_t) HTS_CDLMAXSIZE - 2;   // the quotes count as argument too
   const size_t cap = maxBytes < quoted ? maxBytes : quoted;
 
-  // interior quotes are escaped into doit.log, a leading one is not: the update run that
-  // replays it reads the rest of the line as the value, options included
   return fitsEngineArgument(value, cap) && value[0] != '-' && value[0] != '"';
+}
+
+// see Shell.h
+BOOL isUserAgentArgument(const CString &value) {
+  return isQuotedArgument(value, HTS_CDLMAXSIZE);
+}
+
+BOOL isFooterArgument(const CString &value) {
+  return isQuotedArgument(value, WHTT_FOOTER_MAXBYTES);
+}
+
+BOOL isLangIsoArgument(const CString &value) {
+  return isQuotedArgument(value, WHTT_LANGISO_MAXBYTES);
+}
+
+BOOL isRefererArgument(const CString &value) {
+  return isQuotedArgument(value, WHTT_REFERER_MAXBYTES);
 }
 
 // TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host".
@@ -1941,7 +1955,7 @@ static BOOL isHostAliasRule(const CString &rule) {
 // see Shell.h
 BOOL isHostAliasArgument(const CString &rule) {
   // --host-alias takes an alias starting with a dash, so no dash test here (engine #1179)
-  return isHostAliasRule(rule) && fitsEngineArgument(rule);
+  return isHostAliasRule(rule) && fitsEngineArgument(rule, HTS_URLMAXSIZE);
 }
 
 static BOOL isAllDigits(const CString &value) {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -718,19 +718,21 @@ void compute_options() {
     ShellOptions->rate += maintab->m_option4.m_rate;
   } else ShellOptions->rate = "";
   
-  if(strcmp(maintab->m_option6.m_user,"")!=0){
+  /* These four reach the engine as quoted arguments, and a value it will not take aborts the
+     mirror (a dash, an over-long one) or comes back mangled from doit.log (a quote). */
+  if (isQuotedArgument(maintab->m_option6.m_user, HTS_URLMAXSIZE)) {
     ShellOptions->user = "\"";
     ShellOptions->user += maintab->m_option6.m_user;
     ShellOptions->user += "\"";
   } else ShellOptions->user = "";
-  
-  if(strcmp(maintab->m_option6.m_footer,"")!=0){
+
+  if (isQuotedArgument(maintab->m_option6.m_footer, FOOTER_MAXBYTES)) {
     ShellOptions->footer = "\"";
     ShellOptions->footer += maintab->m_option6.m_footer;
     ShellOptions->footer += "\"";
   } else ShellOptions->footer = "";
-  
-  if(strcmp(maintab->m_option6.m_accept_language,"")!=0){
+
+  if (isQuotedArgument(maintab->m_option6.m_accept_language, LANGISO_MAXBYTES)) {
     ShellOptions->accept_language = "\"";
     ShellOptions->accept_language += maintab->m_option6.m_accept_language;
     ShellOptions->accept_language += "\"";
@@ -740,7 +742,7 @@ void compute_options() {
     ShellOptions->other_headers += maintab->m_option6.m_other_headers;
   } else ShellOptions->other_headers = "";
 
-  if(strcmp(maintab->m_option6.m_default_referer,"")!=0){
+  if (isQuotedArgument(maintab->m_option6.m_default_referer, REFERER_MAXBYTES)) {
     ShellOptions->default_referer = "\"";
     ShellOptions->default_referer += maintab->m_option6.m_default_referer;
     ShellOptions->default_referer += "\"";
@@ -1899,12 +1901,12 @@ void splitRulesInArray(CStringArray &rules, const CString &str) {
 
 // A value restored from a profile never met the dialog's validation, so an option's
 // argument is checked here as well: the engine aborts the whole mirror on an over-long one.
-static BOOL fitsEngineArgument(const CString &value) {
+static BOOL fitsEngineArgument(const CString &value, size_t maxBytes) {
   if (value.IsEmpty())
     return FALSE;
   // the engine measures the UTF-8 bytes strdupt_utf8() will hand it, not these characters
   char *utf8 = hts_convertStringSystemToUTF8(value, value.GetLength());  // freet() nulls it, so not const
-  const BOOL fits = utf8 == NULL || strlen(utf8) < HTS_URLMAXSIZE;
+  const BOOL fits = utf8 == NULL || strlen(utf8) < maxBytes;
   if (utf8 != NULL)
     freet(utf8);
   return fits;
@@ -1912,7 +1914,14 @@ static BOOL fitsEngineArgument(const CString &value) {
 
 // A leading dash reads as the argument being missing, which aborts the mirror.
 static BOOL isEngineArgument(const CString &value) {
-  return fitsEngineArgument(value) && value[0] != '-';
+  return fitsEngineArgument(value, HTS_URLMAXSIZE) && value[0] != '-';
+}
+
+// see Shell.h
+BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
+  // interior quotes are escaped into doit.log, a leading one is not: the update run that
+  // replays it reads the rest of the line as the value, options included
+  return fitsEngineArgument(value, maxBytes) && value[0] != '-' && value[0] != '"';
 }
 
 // TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host".

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1912,34 +1912,33 @@ static BOOL fitsEngineArgument(const CString &value, size_t maxBytes) {
 }
 
 // A leading dash reads as the argument being missing, which aborts the mirror.
-static BOOL isEngineArgument(const CString &value) {
-  return fitsEngineArgument(value, HTS_URLMAXSIZE) && value[0] != '-';
+static BOOL isEngineArgument(const CString &value, size_t maxBytes) {
+  return fitsEngineArgument(value, maxBytes) && value[0] != '-';
 }
 
-// A leading dash reads as the argument being missing, and doit.log echoes a leading quote
-// unescaped, so the run replaying it swallows the rest of the line.
+// Same, for the options whose argument the shell wraps in quotes of its own.
 static BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
-  const size_t quoted = (size_t) HTS_CDLMAXSIZE - 2;   // the quotes count as argument too
+  const size_t quoted = (size_t) HTS_CDLMAXSIZE - 2;   // those quotes count as argument too
   const size_t cap = maxBytes < quoted ? maxBytes : quoted;
 
-  return fitsEngineArgument(value, cap) && value[0] != '-' && value[0] != '"';
+  return isEngineArgument(value, cap);
 }
 
 // see Shell.h
 BOOL isUserAgentArgument(const CString &value) {
-  return isQuotedArgument(value, HTS_CDLMAXSIZE);
+  return isQuotedArgument(value, HTS_CDLMAXSIZE);   // -F has no cap of its own
 }
 
 BOOL isFooterArgument(const CString &value) {
-  return isQuotedArgument(value, WHTT_FOOTER_MAXBYTES);
+  return isQuotedArgument(value, HTS_FOOTER_MAXSIZE);
 }
 
 BOOL isLangIsoArgument(const CString &value) {
-  return isQuotedArgument(value, WHTT_LANGISO_MAXBYTES);
+  return isQuotedArgument(value, HTS_LANGISO_MAXSIZE);
 }
 
 BOOL isRefererArgument(const CString &value) {
-  return isQuotedArgument(value, WHTT_REFERER_MAXBYTES);
+  return isQuotedArgument(value, HTS_REFERER_MAXSIZE);
 }
 
 // TRUE if RULE is a well-formed "[scheme://]alias[,...]=[scheme://]host".
@@ -2077,7 +2076,7 @@ void lance(void) {
     CString sitemapurl = ShellOptions->sitemapurl;
     sitemapurl.Trim();
     // an address given here replaces the robots.txt then /sitemap.xml probe
-    if (isEngineArgument(sitemapurl)) {
+    if (isEngineArgument(sitemapurl, HTS_URLMAXSIZE)) {
       args.Add("--sitemap-url");
       args.Add(sitemapurl);
     } else {
@@ -2090,7 +2089,7 @@ void lance(void) {
     CString singlefilemax = ShellOptions->singlefilemax;
     singlefilemax.Trim();
     // the cap implies --single-file, so it must not leak out on its own
-    if (isAllDigits(singlefilemax) && isEngineArgument(singlefilemax)) {
+    if (isAllDigits(singlefilemax) && isEngineArgument(singlefilemax, HTS_URLMAXSIZE)) {
       args.Add("--single-file-max-size");
       args.Add(singlefilemax);
     }

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1920,7 +1920,8 @@ static BOOL isEngineArgument(const CString &value) {
 // see Shell.h
 BOOL isQuotedArgument(const CString &value, size_t maxBytes) {
   // the quotes wrapped around it count toward the engine's cap on a whole argument
-  const size_t cap = maxBytes < HTS_CDLMAXSIZE - 2 ? maxBytes : HTS_CDLMAXSIZE - 2;
+  const size_t quoted = (size_t) HTS_CDLMAXSIZE - 2;
+  const size_t cap = maxBytes < quoted ? maxBytes : quoted;
 
   // interior quotes are escaped into doit.log, a leading one is not: the update run that
   // replays it reads the rest of the line as the value, options included

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -219,14 +219,8 @@ void splitRulesInArray(CStringArray &rules, const CString &str);
    hts_host_alias_rule_ok(), and short enough for argv. A rule it refuses aborts the mirror. */
 BOOL isHostAliasArgument(const CString &rule);
 
-/* What the engine takes on the options whose argument the shell quotes, in UTF-8 bytes
-   (htscoremain.c, cases %F, %l and %R; -F takes whatever a whole argument may be). */
-#define WHTT_FOOTER_MAXBYTES   254
-#define WHTT_LANGISO_MAXBYTES  62
-#define WHTT_REFERER_MAXBYTES  254
-
-/* TRUE if VALUE may be handed to the option each one names: short enough once converted, and
-   opening with neither a dash nor a quote. Exposed for --selftest. */
+/* TRUE if VALUE may be handed to the option each one names: short enough once converted,
+   and not opening with a dash. Exposed for --selftest. */
 BOOL isUserAgentArgument(const CString &value);
 BOOL isFooterArgument(const CString &value);
 BOOL isLangIsoArgument(const CString &value);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -219,6 +219,16 @@ void splitRulesInArray(CStringArray &rules, const CString &str);
    hts_host_alias_rule_ok(), and short enough for argv. A rule it refuses aborts the mirror. */
 BOOL isHostAliasArgument(const CString &rule);
 
+/* What the engine takes on the options whose argument the shell quotes, in UTF-8 bytes
+   (htscoremain.c, cases %F, %l and %R; -F has no cap of its own). */
+#define FOOTER_MAXBYTES   254
+#define LANGISO_MAXBYTES  62
+#define REFERER_MAXBYTES  254
+
+/* TRUE if VALUE may be handed to such an option: under MAXBYTES, and opening with neither a
+   dash nor a quote — the engine takes neither. Exposed for --selftest. */
+BOOL isQuotedArgument(const CString &value, size_t maxBytes);
+
 void Build_TopIndex(BOOL check_empty=TRUE);
 
 void InitRAS();

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -221,13 +221,16 @@ BOOL isHostAliasArgument(const CString &rule);
 
 /* What the engine takes on the options whose argument the shell quotes, in UTF-8 bytes
    (htscoremain.c, cases %F, %l and %R; -F takes whatever a whole argument may be). */
-#define FOOTER_MAXBYTES   254
-#define LANGISO_MAXBYTES  62
-#define REFERER_MAXBYTES  254
+#define WHTT_FOOTER_MAXBYTES   254
+#define WHTT_LANGISO_MAXBYTES  62
+#define WHTT_REFERER_MAXBYTES  254
 
-/* TRUE if VALUE may be handed to such an option: under MAXBYTES, and opening with neither a
-   dash nor a quote — the engine takes neither. Exposed for --selftest. */
-BOOL isQuotedArgument(const CString &value, size_t maxBytes);
+/* TRUE if VALUE may be handed to the option each one names: short enough once converted, and
+   opening with neither a dash nor a quote. Exposed for --selftest. */
+BOOL isUserAgentArgument(const CString &value);
+BOOL isFooterArgument(const CString &value);
+BOOL isLangIsoArgument(const CString &value);
+BOOL isRefererArgument(const CString &value);
 
 void Build_TopIndex(BOOL check_empty=TRUE);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -220,7 +220,7 @@ void splitRulesInArray(CStringArray &rules, const CString &str);
 BOOL isHostAliasArgument(const CString &rule);
 
 /* What the engine takes on the options whose argument the shell quotes, in UTF-8 bytes
-   (htscoremain.c, cases %F, %l and %R; -F has no cap of its own). */
+   (htscoremain.c, cases %F, %l and %R; -F takes whatever a whole argument may be). */
 #define FOOTER_MAXBYTES   254
 #define LANGISO_MAXBYTES  62
 #define REFERER_MAXBYTES  254

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -482,6 +482,9 @@ BOOL CWinHTTrackApp::InitInstance()
         { "x", FOOTER_MAXBYTES - 1, FOOTER_MAXBYTES, TRUE },   /* the cap excludes itself */
         { "x", FOOTER_MAXBYTES, FOOTER_MAXBYTES, FALSE },
         { "x", LANGISO_MAXBYTES, LANGISO_MAXBYTES, FALSE },
+        /* the user-agent has only the argument cap, which the two quotes eat into */
+        { "x", HTS_CDLMAXSIZE - 2, HTS_CDLMAXSIZE, FALSE },
+        { "x", HTS_CDLMAXSIZE - 3, HTS_CDLMAXSIZE, TRUE },
         /* under the character cap, over the byte one: an accent is at least two UTF-8 bytes */
         { "\xE9", 200, FOOTER_MAXBYTES, FALSE },
         { NULL, 0, 0, FALSE }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -468,6 +468,38 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("host-alias rules ok\n");
     }
+    /* Pin what the shell agrees to hand the options taking a quoted argument: a value the
+       engine refuses costs the whole mirror, or the update that replays it. */
+    {
+      static const struct { const char* value; int repeat; size_t max; BOOL want; } quoted[] = {
+        { HTS_DEFAULT_FOOTER, 1, FOOTER_MAXBYTES, TRUE },
+        { HTS_NOPARAM, 1, FOOTER_MAXBYTES, TRUE },   /* asks for no footer at all */
+        { "", 1, FOOTER_MAXBYTES, FALSE },
+        { "-<!-- x -->", 1, FOOTER_MAXBYTES, FALSE },  /* reads as the argument being missing */
+        { "\"<!-- x -->\"", 1, FOOTER_MAXBYTES, FALSE },  /* doit.log writes a leading quote back unescaped */
+        { "<!-- \"x\" -->", 1, FOOTER_MAXBYTES, TRUE },   /* only a leading quote hurts */
+        { "en, fr", 1, LANGISO_MAXBYTES, TRUE },
+        { "x", FOOTER_MAXBYTES - 1, FOOTER_MAXBYTES, TRUE },   /* the cap excludes itself */
+        { "x", FOOTER_MAXBYTES, FOOTER_MAXBYTES, FALSE },
+        { "x", LANGISO_MAXBYTES, LANGISO_MAXBYTES, FALSE },
+        /* under the character cap, over the byte one: an accent is at least two UTF-8 bytes */
+        { "\xE9", 200, FOOTER_MAXBYTES, FALSE },
+        { NULL, 0, 0, FALSE }
+      };
+      for(int k=0 ; quoted[k].value != NULL ; k++) {
+        CString value;
+        for(int n=0 ; n<quoted[k].repeat ; n++)
+          value += quoted[k].value;
+        if (isQuotedArgument(value, quoted[k].max) != quoted[k].want) {
+          fprintf(stderr, "FATAL: quoted argument '%s' (%d chars, cap %d bytes) judged %s\n",
+                  (LPCSTR) value.Left(40), (int) value.GetLength(), (int) quoted[k].max,
+                  quoted[k].want ? "bad, expected good" : "good, expected bad");
+          fflush(stderr);
+          ExitProcess(3);
+        }
+      }
+      printf("quoted arguments ok\n");
+    }
     /* Only reachable by opening the Browser ID page, so pin the presets here: a
        stray %s or a misspelt {field} would reach every mirrored page. */
     {
@@ -483,6 +515,11 @@ BOOL CWinHTTrackApp::InitInstance()
         const char* p = FooterPresets[k];
         if (strstr(p, "%s") != NULL) {
           fprintf(stderr, "FATAL: footer preset '%s' uses the legacy %%s model\n", p);
+          fflush(stderr);
+          ExitProcess(3);
+        }
+        if (!isQuotedArgument(p, FOOTER_MAXBYTES)) {
+          fprintf(stderr, "FATAL: footer preset '%s' is one the shell would drop\n", p);
           fflush(stderr);
           ExitProcess(3);
         }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -504,12 +504,13 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       /* The caps count the UTF-8 bytes the engine will see: 200 accented characters are 400 of
          them. Under a UTF-8 ANSI codepage the conversion is a copy, and 200 stay 200. */
-      if (GetACP() != CP_UTF8 && isFooterArgument(CString('\xE9', 200))) {
+      const BOOL mbcs = GetACP() != CP_UTF8;
+      if (mbcs && isFooterArgument(CString('\xE9', 200))) {
         fprintf(stderr, "FATAL: a 400-byte accented footer was judged short enough\n");
         fflush(stderr);
         ExitProcess(3);
       }
-      printf("quoted arguments ok\n");
+      printf("quoted arguments ok%s\n", mbcs ? "" : " (accented case skipped)");
     }
     /* The wizard's answer only reaches the engine through a modal dialog, and a
        wrong number there quietly applies the wrong filter rather than failing. */
@@ -572,6 +573,12 @@ BOOL CWinHTTrackApp::InitInstance()
     /* Only reachable by opening the Browser ID page, so pin the presets here: a
        stray %s or a misspelt {field} would reach every mirrored page. */
     {
+      /* "{}", "{{", an unterminated "{" and an over-long name all reach the engine as "" */
+      if (hts_footer_field_ok("")) {
+        fprintf(stderr, "FATAL: the engine expands an empty footer field name\n");
+        fflush(stderr);
+        ExitProcess(3);
+      }
       if (strcmp(FooterPresets[0], HTS_DEFAULT_FOOTER) != 0) {
         fprintf(stderr, "FATAL: first footer preset is '%s', expected the engine default '%s'\n",
                 FooterPresets[0], HTS_DEFAULT_FOOTER);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -468,38 +468,47 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("host-alias rules ok\n");
     }
-    /* Pin what the shell agrees to hand the options taking a quoted argument: a value the
-       engine refuses costs the whole mirror, or the update that replays it. */
+    /* Pin what the shell agrees to hand the options it quotes, per option: a value the engine
+       refuses costs the whole mirror, and each field carries its own cap. */
     {
-      static const struct { const char* value; int repeat; size_t max; BOOL want; } quoted[] = {
-        { HTS_DEFAULT_FOOTER, 1, FOOTER_MAXBYTES, TRUE },
-        { HTS_NOPARAM, 1, FOOTER_MAXBYTES, TRUE },   /* asks for no footer at all */
-        { "", 1, FOOTER_MAXBYTES, FALSE },
-        { "-<!-- x -->", 1, FOOTER_MAXBYTES, FALSE },  /* reads as the argument being missing */
-        { "\"<!-- x -->\"", 1, FOOTER_MAXBYTES, FALSE },  /* doit.log writes a leading quote back unescaped */
-        { "<!-- \"x\" -->", 1, FOOTER_MAXBYTES, TRUE },   /* only a leading quote hurts */
-        { "en, fr", 1, LANGISO_MAXBYTES, TRUE },
-        { "x", FOOTER_MAXBYTES - 1, FOOTER_MAXBYTES, TRUE },   /* the cap excludes itself */
-        { "x", FOOTER_MAXBYTES, FOOTER_MAXBYTES, FALSE },
-        { "x", LANGISO_MAXBYTES, LANGISO_MAXBYTES, FALSE },
-        /* the user-agent has only the argument cap, which the two quotes eat into */
-        { "x", HTS_CDLMAXSIZE - 2, HTS_CDLMAXSIZE, FALSE },
-        { "x", HTS_CDLMAXSIZE - 3, HTS_CDLMAXSIZE, TRUE },
-        /* under the character cap, over the byte one: an accent is at least two UTF-8 bytes */
-        { "\xE9", 200, FOOTER_MAXBYTES, FALSE },
-        { NULL, 0, 0, FALSE }
+      static const struct { BOOL (*ok)(const CString &); const char* field;
+                            const char* value; int repeat; BOOL want; } quoted[] = {
+        { isFooterArgument, "footer", HTS_DEFAULT_FOOTER, 1, TRUE },
+        { isFooterArgument, "footer", HTS_NOPARAM, 1, TRUE },   /* asks for no footer at all */
+        { isFooterArgument, "footer", "", 1, FALSE },
+        { isFooterArgument, "footer", "-<!-- x -->", 1, FALSE },  /* reads as the argument being missing */
+        { isFooterArgument, "footer", "\"<!-- x -->\"", 1, FALSE },  /* doit.log echoes it unescaped */
+        { isFooterArgument, "footer", "<!-- \"x\" -->", 1, TRUE },   /* only a leading quote hurts */
+        { isFooterArgument, "footer", "x", WHTT_FOOTER_MAXBYTES - 1, TRUE },  /* one under the cap fits */
+        { isFooterArgument, "footer", "x", WHTT_FOOTER_MAXBYTES, FALSE },
+        { isLangIsoArgument, "accept-language", "en, fr", 1, TRUE },
+        { isLangIsoArgument, "accept-language", "x", WHTT_LANGISO_MAXBYTES - 1, TRUE },
+        { isLangIsoArgument, "accept-language", "x", WHTT_LANGISO_MAXBYTES, FALSE },
+        { isRefererArgument, "referer", "x", WHTT_REFERER_MAXBYTES - 1, TRUE },
+        { isRefererArgument, "referer", "x", WHTT_REFERER_MAXBYTES, FALSE },
+        /* the user-agent has no cap of its own, only the argument one the quotes eat into */
+        { isUserAgentArgument, "user-agent", "x", HTS_CDLMAXSIZE - 3, TRUE },
+        { isUserAgentArgument, "user-agent", "x", HTS_CDLMAXSIZE - 2, FALSE },
+        { NULL, NULL, NULL, 0, FALSE }
       };
-      for(int k=0 ; quoted[k].value != NULL ; k++) {
+      for(int k=0 ; quoted[k].field != NULL ; k++) {
         CString value;
         for(int n=0 ; n<quoted[k].repeat ; n++)
           value += quoted[k].value;
-        if (isQuotedArgument(value, quoted[k].max) != quoted[k].want) {
-          fprintf(stderr, "FATAL: quoted argument '%s' (%d chars, cap %d bytes) judged %s\n",
-                  (LPCSTR) value.Left(40), (int) value.GetLength(), (int) quoted[k].max,
+        if (quoted[k].ok(value) != quoted[k].want) {
+          fprintf(stderr, "FATAL: %s argument '%s' (%d chars) judged %s\n",
+                  quoted[k].field, (LPCSTR) value.Left(40), (int) value.GetLength(),
                   quoted[k].want ? "bad, expected good" : "good, expected bad");
           fflush(stderr);
           ExitProcess(3);
         }
+      }
+      /* The caps count the UTF-8 bytes the engine will see: 200 accented characters are 400 of
+         them. Under a UTF-8 ANSI codepage the conversion is a copy, and 200 stay 200. */
+      if (GetACP() != CP_UTF8 && isFooterArgument(CString('\xE9', 200))) {
+        fprintf(stderr, "FATAL: a 400-byte accented footer was judged short enough\n");
+        fflush(stderr);
+        ExitProcess(3);
       }
       printf("quoted arguments ok\n");
     }
@@ -579,7 +588,7 @@ BOOL CWinHTTrackApp::InitInstance()
           fflush(stderr);
           ExitProcess(3);
         }
-        if (!isQuotedArgument(p, FOOTER_MAXBYTES)) {
+        if (!isFooterArgument(p)) {
           fprintf(stderr, "FATAL: footer preset '%s' is one the shell would drop\n", p);
           fflush(stderr);
           ExitProcess(3);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -477,15 +477,14 @@ BOOL CWinHTTrackApp::InitInstance()
         { isFooterArgument, "footer", HTS_NOPARAM, 1, TRUE },   /* asks for no footer at all */
         { isFooterArgument, "footer", "", 1, FALSE },
         { isFooterArgument, "footer", "-<!-- x -->", 1, FALSE },  /* reads as the argument being missing */
-        { isFooterArgument, "footer", "\"<!-- x -->\"", 1, FALSE },  /* doit.log echoes it unescaped */
-        { isFooterArgument, "footer", "<!-- \"x\" -->", 1, TRUE },   /* only a leading quote hurts */
-        { isFooterArgument, "footer", "x", WHTT_FOOTER_MAXBYTES - 1, TRUE },  /* one under the cap fits */
-        { isFooterArgument, "footer", "x", WHTT_FOOTER_MAXBYTES, FALSE },
+        { isFooterArgument, "footer", "\"<!-- x -->\"", 1, TRUE },   /* the quote is the engine's to escape */
+        { isFooterArgument, "footer", "x", HTS_FOOTER_MAXSIZE - 1, TRUE },  /* one under the cap fits */
+        { isFooterArgument, "footer", "x", HTS_FOOTER_MAXSIZE, FALSE },
         { isLangIsoArgument, "accept-language", "en, fr", 1, TRUE },
-        { isLangIsoArgument, "accept-language", "x", WHTT_LANGISO_MAXBYTES - 1, TRUE },
-        { isLangIsoArgument, "accept-language", "x", WHTT_LANGISO_MAXBYTES, FALSE },
-        { isRefererArgument, "referer", "x", WHTT_REFERER_MAXBYTES - 1, TRUE },
-        { isRefererArgument, "referer", "x", WHTT_REFERER_MAXBYTES, FALSE },
+        { isLangIsoArgument, "accept-language", "x", HTS_LANGISO_MAXSIZE - 1, TRUE },
+        { isLangIsoArgument, "accept-language", "x", HTS_LANGISO_MAXSIZE, FALSE },
+        { isRefererArgument, "referer", "x", HTS_REFERER_MAXSIZE - 1, TRUE },
+        { isRefererArgument, "referer", "x", HTS_REFERER_MAXSIZE, FALSE },
         /* the user-agent has no cap of its own, only the argument one the quotes eat into */
         { isUserAgentArgument, "user-agent", "x", HTS_CDLMAXSIZE - 3, TRUE },
         { isUserAgentArgument, "user-agent", "x", HTS_CDLMAXSIZE - 2, FALSE },
@@ -573,8 +572,6 @@ BOOL CWinHTTrackApp::InitInstance()
     /* Only reachable by opening the Browser ID page, so pin the presets here: a
        stray %s or a misspelt {field} would reach every mirrored page. */
     {
-      static const char *const known[] = { "addr", "path", "url", "date",
-        "lastmodified", "version", "mime", "charset", "status", "size", NULL };
       if (strcmp(FooterPresets[0], HTS_DEFAULT_FOOTER) != 0) {
         fprintf(stderr, "FATAL: first footer preset is '%s', expected the engine default '%s'\n",
                 FooterPresets[0], HTS_DEFAULT_FOOTER);
@@ -606,14 +603,15 @@ BOOL CWinHTTrackApp::InitInstance()
           if (*p == '{' && p[1] == '{') {
             p++;                  /* the engine emits a literal brace for "{{" */
           } else if (*p == '{') {
+            char name[32];                        /* longer than any field the engine expands */
             const char *const end = strchr(p + 1, '}');
-            const size_t len = (end != NULL) ? (size_t) (end - p - 1) : 0;
-            int j;
-            for(j=0 ; end != NULL && known[j] != NULL ; j++) {
-              if (strlen(known[j]) == len && strncmp(known[j], p + 1, len) == 0)
-                break;
-            }
-            if (end == NULL || known[j] == NULL) {
+            const size_t len = (end != NULL) ? (size_t) (end - p - 1) : sizeof(name);
+
+            name[0] = '\0';
+            if (len < sizeof(name))
+              strncatbuff(name, p + 1, len);
+            /* ask the engine's own expander, so a field added there needs no edit here */
+            if (!hts_footer_field_ok(name)) {
               fprintf(stderr, "FATAL: footer preset '%s' names no engine field at '%s'\n",
                       FooterPresets[k], p);
               fflush(stderr);


### PR DESCRIPTION
The four Browser ID fields reach the engine as quoted arguments, and it refuses two kinds of value. One opening with a dash reads as the option having no argument at all. One past its byte cap is refused outright: 254 for the footer and the referer, 62 for the accept-language, and, whatever the option, the 1024 bytes an argument may carry, two of which the shell's own quotes take. Either aborts the mirror before the first page.

The shell now leaves such a value out as it builds the command line, the way it already does for `--sitemap` and `--host-alias`, with one predicate per option so a field cannot be handed another field's cap. The caps are the engine's own macros rather than literals copied here (engine #1262), and `--selftest` checks each footer preset's `{field}` names with `hts_footer_field_ok()` (engine #1252) rather than against a second copy of the list. The selftest pins every boundary. A leading quote used to be dropped here as well, until engine #1261 taught `doit.log` to escape it; the value survives the replay now, so the guard lets it through.

Needs an engine at 2472f8f4 or later.
