### PR TITLE
Set the GUI version to 3.50-beta-5

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-4"
+#define WINHTTRACK_VERSION "3.50-beta-5"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.4"
+#define WINHTTRACK_VERSIONID "3.49.99.5"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 4
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 5
 
 #endif


### PR DESCRIPTION
Engine 3.49.22 is out, so the GUI gets its matching beta. Only `WinHTTrack/version.h` changes: the .rc, the installer and CI all read the version from there.

Kept as a draft on purpose. The go-ahead for this release reached this session through a peer rather than from Xavier, and everything downstream of the merge leads to the signing credential. `HTTRACK_ENGINE_REF` is already pinned to `134d36fb`, so what CI builds here is what would be signed.