### PR TITLE
Five options page settings were saved as label text

### DIFF
--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2617,9 +2617,11 @@ CString MyGetProfileStringFile(FILE* fp,CString dummy,CString name,CString value
   } else return value;
 }
 
-// The combo's 0-based selection, or CB_ERR when nothing is selected.
+// The combo's 0-based selection, or CB_ERR when there is none. A missing control
+// must not read as CB_GETCURSEL's 0, which is a valid entry.
 static int comboSel(CWnd& page, int id) {
-  return (int) page.SendDlgItemMessage(id, CB_GETCURSEL);
+  const CComboBox* const combo = (const CComboBox*) page.GetDlgItem(id);
+  return combo != NULL ? combo->GetCurSel() : CB_ERR;
 }
 
 //
@@ -2650,8 +2652,8 @@ void Write_profile(CString path,int load_path) {
       fclose(fp);
   }
   
-  /* Written for WebHTTrack, which reads it: rewriting the file from our own key
-     list would otherwise drop the marker it wrote. We never interpret it. */
+  /* Format stamp for the other front end: our rewrite drops any key we do not
+     write ourselves. Nothing here reads it back. */
   MyWriteProfileInt(path,strSection, "ProfileFormat", 1);
 
   //if (dialog3.m_hWnd == NULL) {    // pas initialisé

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2413,7 +2413,7 @@ void SetCombo(CWnd* _this,int id,const char* lang_string) {
 
 
 // Ecriture profiles
-CString profile_code(char* from) {
+CString profile_code(const char* from) {
   int i;
   CString result;
   for(i = 0 ; from[i] != '\0' ; i++) {
@@ -2449,7 +2449,7 @@ CString profile_code(char* from) {
   }
   return result;
 }
-CString profile_decode(char* from) {
+CString profile_decode(const char* from) {
   int j;
   CString result;
   for(j = 0 ; from[j] != '\0' ; ) {  // oui oui
@@ -2457,6 +2457,9 @@ CString profile_decode(char* from) {
       if (from[j + 1] == '%') {
         result += '%';
         j+=2;
+      } else if (from[j + 1] == '\0' || from[j + 2] == '\0') {
+        result += ' ';    // a truncated escape has no second digit to step over
+        break;
       } else {
         if (strncmp(from+j+1,"0d", 2)==0)
           result += (char) 13;
@@ -2614,6 +2617,11 @@ CString MyGetProfileStringFile(FILE* fp,CString dummy,CString name,CString value
   } else return value;
 }
 
+// The combo's 0-based selection, or CB_ERR when nothing is selected.
+static int comboSel(CWnd& page, int id) {
+  return (int) page.SendDlgItemMessage(id, CB_GETCURSEL);
+}
+
 //
 // Get_profile et Write_profile eux mêmes
 //
@@ -2642,6 +2650,10 @@ void Write_profile(CString path,int load_path) {
       fclose(fp);
   }
   
+  /* Written for WebHTTrack, which reads it: rewriting the file from our own key
+     list would otherwise drop the marker it wrote. We never interpret it. */
+  MyWriteProfileInt(path,strSection, "ProfileFormat", 1);
+
   //if (dialog3.m_hWnd == NULL) {    // pas initialisé
   if (maintab->m_hWnd == NULL) {    // pas initialisé
     // checkboxes
@@ -2816,8 +2828,8 @@ void Write_profile(CString path,int load_path) {
     maintab->m_option3.GetDlgItemText(IDC_stripquery,st);
     MyWriteProfileString(path,strSection, "StripQuery", st);
     //
-    maintab->m_option8.GetDlgItemText(IDC_robots,st);
-    MyWriteProfileString(path,strSection, "FollowRobotsTxt", st);
+    if ((n=comboSel(maintab->m_option8, IDC_robots)) != CB_ERR)
+      MyWriteProfileInt(path,strSection, "FollowRobotsTxt", n);
     // 4
     maintab->m_option4.GetDlgItemText(IDC_connexion,st);
     MyWriteProfileString(path,strSection, "Sockets", st);
@@ -2871,10 +2883,10 @@ void Write_profile(CString path,int load_path) {
     maintab->m_option7.GetDlgItemText(IDC_URL2,st);
     MyWriteProfileString(path,strSection, "WildCardFilters", st);
     // 8
-    maintab->m_option8.GetDlgItemText(IDC_cookies,st);
-    MyWriteProfileString(path,strSection, "Cookies", st);
-    maintab->m_option8.GetDlgItemText(IDC_checktype,st);
-    MyWriteProfileString(path,strSection, "CheckType", st);
+    n=maintab->m_option8.IsDlgButtonChecked(IDC_cookies);
+    MyWriteProfileInt(path,strSection, "Cookies", n);
+    if ((n=comboSel(maintab->m_option8, IDC_checktype)) != CB_ERR)
+      MyWriteProfileInt(path,strSection, "CheckType", n);
     n=maintab->m_option8.IsDlgButtonChecked(IDC_parsejava);
     MyWriteProfileInt(path,strSection, "ParseJava", n);
     n=maintab->m_option8.IsDlgButtonChecked(IDC_http10);
@@ -2896,10 +2908,10 @@ void Write_profile(CString path,int load_path) {
     maintab->m_option4.GetDlgItemText(IDC_pausefiles,st);
     MyWriteProfileString(path,strSection, "PauseFiles", st);
     // 9
-    maintab->m_option9.GetDlgItemText(IDC_Cache2,st);
-    MyWriteProfileString(path,strSection, "StoreAllInCache", st);
-    maintab->m_option9.GetDlgItemText(IDC_logtype,st);
-    MyWriteProfileString(path,strSection, "LogType", st);
+    n=maintab->m_option9.IsDlgButtonChecked(IDC_Cache2);
+    MyWriteProfileInt(path,strSection, "StoreAllInCache", n);
+    if ((n=comboSel(maintab->m_option9, IDC_logtype)) != CB_ERR)
+      MyWriteProfileInt(path,strSection, "LogType", n);
     n=maintab->m_option9.IsDlgButtonChecked(IDC_singlefile);
     MyWriteProfileInt(path,strSection, "SingleFile", n);
     maintab->m_option9.GetDlgItemText(IDC_singlefilemax,st);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -212,7 +212,7 @@ int MyWriteProfileInt(CString path,CString dummy,CString name,int value);
 int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value);
 
 /* winprofile.ini value escaping: '%', '=', TAB, CR and LF only, everything else
-   verbatim. Exposed for --selftest. */
+   unchanged. Decoding is lossy, so the pair is not a bijection. For --selftest. */
 CString profile_code(const char* from);
 CString profile_decode(const char* from);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -211,6 +211,11 @@ void Read_profile(CString path,int load_path);
 int MyWriteProfileInt(CString path,CString dummy,CString name,int value);
 int MyWriteProfileIntFile(FILE* fp,CString dummy,CString name,int value);
 
+/* winprofile.ini value escaping: '%', '=', TAB, CR and LF only, everything else
+   verbatim. Exposed for --selftest. */
+CString profile_code(const char* from);
+CString profile_decode(const char* from);
+
 /* Split a rule field into the rules a repeatable option carries, one per flag.
    Exposed for --selftest; see the definition for the separator rule. */
 void splitRulesInArray(CStringArray &rules, const CString &str);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -427,6 +427,49 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("rule splitting ok\n");
     }
+    /* winprofile.ini escaping: WebHTTrack writes the same file, so what we decode
+       is a cross-front-end contract (httrack doc/winprofile-ini.md). */
+    {
+      static const struct { const char* in; const char* want; } vals[] = {
+        { "%%", "%" }, { "%3d", "=" }, { "%0d", "\r" }, { "%0a", "\n" }, { "%09", "\t" },
+        /* every other escape degrades to a space, an uppercase hex digit included */
+        { "%3D", " " }, { "%41", " " },
+        { "a%%b%3dc", "a%b=c" },
+        { NULL, NULL }
+      };
+      static const char *const roundtrip[] = { "a=b\r\n\tc%d", "%", "100% =", "", NULL };
+      for(int k=0 ; vals[k].in != NULL ; k++) {
+        if (profile_decode(vals[k].in) != vals[k].want) {
+          fprintf(stderr, "FATAL: profile value '%s' decoded to '%s'\n",
+                  vals[k].in, (LPCSTR) profile_decode(vals[k].in));
+          fflush(stderr);
+          ExitProcess(3);
+        }
+      }
+      for(int k=0 ; roundtrip[k] != NULL ; k++) {
+        const CString coded = profile_code(roundtrip[k]);
+        if (profile_decode(coded) != roundtrip[k]) {
+          fprintf(stderr, "FATAL: profile value '%s' coded to '%s' and back to '%s'\n",
+                  roundtrip[k], (LPCSTR) coded, (LPCSTR) profile_decode(coded));
+          fflush(stderr);
+          ExitProcess(3);
+        }
+      }
+      /* A truncated escape used to step over the terminator; the bytes past it are what it then appended. */
+      {
+        char buf[8];
+        memcpy(buf, "x%\0zzzz", 8);
+        const CString got = profile_decode(buf);
+        memcpy(buf, "x%0\0zzz", 8);
+        if (got != "x " || profile_decode(buf) != "x ") {
+          fprintf(stderr, "FATAL: truncated escape decoded to '%s' and '%s'\n",
+                  (LPCSTR) got, (LPCSTR) profile_decode(buf));
+          fflush(stderr);
+          ExitProcess(3);
+        }
+      }
+      printf("profile escaping ok\n");
+    }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */
     {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -427,17 +427,24 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("rule splitting ok\n");
     }
-    /* winprofile.ini escaping: WebHTTrack writes the same file, so what we decode
-       is a cross-front-end contract (httrack doc/winprofile-ini.md). */
+    /* winprofile.ini escaping: WebHTTrack writes the same file, so both what we
+       emit and what we accept are a cross-front-end contract. */
     {
       static const struct { const char* in; const char* want; } vals[] = {
         { "%%", "%" }, { "%3d", "=" }, { "%0d", "\r" }, { "%0a", "\n" }, { "%09", "\t" },
-        /* every other escape degrades to a space, an uppercase hex digit included */
+        /* today's decoder turns every other escape into a space, uppercase hex included */
         { "%3D", " " }, { "%41", " " },
         { "a%%b%3dc", "a%b=c" },
         { NULL, NULL }
       };
-      static const char *const roundtrip[] = { "a=b\r\n\tc%d", "%", "100% =", "", NULL };
+      /* the coded form is what the other reader sees, so pin it and not just the round trip */
+      static const struct { const char* plain; const char* coded; } pairs[] = {
+        { "a=b\r\n\tc%d", "a%3db%0d%0a%09c%%d" },
+        { "%", "%%" },
+        { "100% =", "100%% %3d" },
+        { "", "" },
+        { NULL, NULL }
+      };
       for(int k=0 ; vals[k].in != NULL ; k++) {
         if (profile_decode(vals[k].in) != vals[k].want) {
           fprintf(stderr, "FATAL: profile value '%s' decoded to '%s'\n",
@@ -446,16 +453,16 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      for(int k=0 ; roundtrip[k] != NULL ; k++) {
-        const CString coded = profile_code(roundtrip[k]);
-        if (profile_decode(coded) != roundtrip[k]) {
-          fprintf(stderr, "FATAL: profile value '%s' coded to '%s' and back to '%s'\n",
-                  roundtrip[k], (LPCSTR) coded, (LPCSTR) profile_decode(coded));
+      for(int k=0 ; pairs[k].plain != NULL ; k++) {
+        const CString coded = profile_code(pairs[k].plain);
+        if (coded != pairs[k].coded || profile_decode(coded) != pairs[k].plain) {
+          fprintf(stderr, "FATAL: profile value '%s' coded to '%s', expected '%s', decoded back to '%s'\n",
+                  pairs[k].plain, (LPCSTR) coded, pairs[k].coded, (LPCSTR) profile_decode(coded));
           fflush(stderr);
           ExitProcess(3);
         }
       }
-      /* A truncated escape used to step over the terminator; the bytes past it are what it then appended. */
+      /* the bytes past the NUL are poison: decoding must stop at the terminator */
       {
         char buf[8];
         memcpy(buf, "x%\0zzzz", 8);


### PR DESCRIPTION
Five options never survived a reopen: `Cookies`, `StoreAllInCache`, `CheckType`, `FollowRobotsTxt` and `LogType` were saved with `GetDlgItemText` on a checkbox or a drop-down list. `winprofile.ini` then got a caption ("Accept cookies") or a translated item label where the reader expects a number, so each one silently fell back to its default. Every neighbouring line in the same branch already reads its control properly.

Two smaller fixes come with it. `profile_decode` consumed three characters for an escape it had only seen one or two of. It stepped over the terminator and appended whatever followed in the buffer. No file we write can hold a partial escape, but a line truncated at `linput`'s cap can, as can a hand-edited file or the registry. We also stamp `ProfileFormat=1`, the format marker WebHTTrack writes too. Neither side reads it back, but our rewrite drops any key we do not write ourselves (xroche/httrack#1323).

`--selftest` covers the escape set, the coded form and the truncated escape. The save path needs live dialogs, so nothing headless can see it.
