### PR TITLE
Assert the selftest report lines nothing was matching

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -213,6 +213,26 @@ runs:
         if ("$so" -notmatch 'footer presets ok') {
           throw "selftest did not check the footer presets"
         }
+        # A rule the splitter mangles reaches the engine as --host-alias "" and aborts the mirror.
+        if ("$so" -notmatch 'rule splitting ok on [1-9]\d* fields') {
+          throw "selftest did not check the Experts rule splitter"
+        }
+        # winprofile.ini is a cross-front-end contract: WebHTTrack and Android read what we write.
+        if ("$so" -notmatch 'profile escaping ok on [1-9]\d* values and [1-9]\d* round trips') {
+          throw "selftest did not check the winprofile.ini escaping"
+        }
+        # The grammar lives in the engine, so a change there has to land here, not in a mirror.
+        if ("$so" -notmatch 'host-alias rules ok on [1-9]\d* rules') {
+          throw "selftest did not check the host-alias grammar"
+        }
+        # A wrong wizard answer quietly applies the wrong filter rather than failing.
+        if ("$so" -notmatch 'wizard answers ok on [1-9]\d* rows') {
+          throw "selftest did not check the wizard answers"
+        }
+        # The answer indexes this menu, so it must stay the engine's list in the engine's order.
+        if ("$so" -notmatch 'wizard scopes ok') {
+          throw "selftest did not check the wizard host scopes"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -409,7 +409,8 @@ BOOL CWinHTTrackApp::InitInstance()
         { "", "" },
         { NULL, NULL }
       };
-      for(int k=0 ; rules[k].field != NULL ; k++) {
+      int k;
+      for(k=0 ; rules[k].field != NULL ; k++) {
         CStringArray got;
         CString joined;
         splitRulesInArray(got, rules[k].field);
@@ -425,7 +426,7 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      printf("rule splitting ok\n");
+      printf("rule splitting ok on %d fields\n", k);
     }
     /* winprofile.ini escaping: WebHTTrack writes the same file, so both what we
        emit and what we accept are a cross-front-end contract. */
@@ -445,19 +446,20 @@ BOOL CWinHTTrackApp::InitInstance()
         { "", "" },
         { NULL, NULL }
       };
-      for(int k=0 ; vals[k].in != NULL ; k++) {
-        if (profile_decode(vals[k].in) != vals[k].want) {
+      int nvals, npairs;
+      for(nvals=0 ; vals[nvals].in != NULL ; nvals++) {
+        if (profile_decode(vals[nvals].in) != vals[nvals].want) {
           fprintf(stderr, "FATAL: profile value '%s' decoded to '%s'\n",
-                  vals[k].in, (LPCSTR) profile_decode(vals[k].in));
+                  vals[nvals].in, (LPCSTR) profile_decode(vals[nvals].in));
           fflush(stderr);
           ExitProcess(3);
         }
       }
-      for(int k=0 ; pairs[k].plain != NULL ; k++) {
-        const CString coded = profile_code(pairs[k].plain);
-        if (coded != pairs[k].coded || profile_decode(coded) != pairs[k].plain) {
+      for(npairs=0 ; pairs[npairs].plain != NULL ; npairs++) {
+        const CString coded = profile_code(pairs[npairs].plain);
+        if (coded != pairs[npairs].coded || profile_decode(coded) != pairs[npairs].plain) {
           fprintf(stderr, "FATAL: profile value '%s' coded to '%s', expected '%s', decoded back to '%s'\n",
-                  pairs[k].plain, (LPCSTR) coded, pairs[k].coded, (LPCSTR) profile_decode(coded));
+                  pairs[npairs].plain, (LPCSTR) coded, pairs[npairs].coded, (LPCSTR) profile_decode(coded));
           fflush(stderr);
           ExitProcess(3);
         }
@@ -475,7 +477,7 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      printf("profile escaping ok\n");
+      printf("profile escaping ok on %d values and %d round trips\n", nvals, npairs);
     }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */
@@ -507,7 +509,8 @@ BOOL CWinHTTrackApp::InitInstance()
         { "-legacy.example.com=example.com", TRUE },
         { NULL, FALSE }
       };
-      for(int k=0 ; aliases[k].rule != NULL ; k++) {
+      int k;
+      for(k=0 ; aliases[k].rule != NULL ; k++) {
         if (isHostAliasArgument(aliases[k].rule) != aliases[k].want) {
           fprintf(stderr, "FATAL: host-alias rule '%s' judged %s\n",
                   aliases[k].rule, aliases[k].want ? "bad, expected good"
@@ -516,7 +519,7 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      printf("host-alias rules ok\n");
+      printf("host-alias rules ok on %d rules\n", k);
     }
     /* Pin what the shell agrees to hand the options it quotes, per option: a value the engine
        refuses costs the whole mirror, and each field carries its own cap. */
@@ -577,7 +580,8 @@ BOOL CWinHTTrackApp::InitInstance()
         { -1, -1, "" }, { -1, 0, "" }, { 8, 0, "" },      /* nothing selected */
         { 0, 0, NULL }
       };
-      for(int k=0 ; answers[k].want != NULL ; k++) {
+      int k;
+      for(k=0 ; answers[k].want != NULL ; k++) {
         char got[16] = "unset";
         const bool ok = WizLinkAnswer(answers[k].lnk, answers[k].scope, got, sizeof(got));
         if (ok != (answers[k].want[0] != '\0') || strcmp(got, answers[k].want) != 0) {
@@ -595,7 +599,7 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      printf("wizard answers ok\n");
+      printf("wizard answers ok on %d rows\n", k);
     }
     /* The answer is an index into this menu, so it must be the engine's list in the
        engine's order. Same cases as the engine's 292_engine-wizard-scope.test. */


### PR DESCRIPTION
WinHTTrack.exe `--selftest` prints twelve report lines and the smoke test grepped seven of them, so the rule splitter, the `winprofile.ini` escaping, the host-alias grammar and both wizard checks could have stopped running with every leg green. This asserts the missing five. The four that walk a case table now print how many cases they ran, matched as `[1-9]\d*`, so a table emptied to nothing can no longer pass by printing its line. That is the shape the language-list assertion already used.

Came out of answering the engine session's cross-front-end `winprofile.ini` proposal, where a selftest line nobody greps is now one of the consumer rules. I checked the patterns by mutation: drop any one of the twelve lines from the recorded output of the last green master run and exactly one assertion fires, so none is dead or satisfied by a neighbouring line.