### PR TITLE
Pin the selftest counts exactly, and cover the help-path check

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -183,54 +183,57 @@ runs:
         if ($se) { Write-Host "  stderr: $($se.Trim())" }
         if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe --selftest exited $($p.ExitCode): the installation is incomplete" }
         if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
+        # The counts below are exact, not lower bounds: adding a case must move the number
+        # here too, since a deleted one otherwise hides behind a still-positive total.
         # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into
         # a dialog. --selftest exercises it; assert it actually RAN, or the check silently
         # skips (its ANSI-codepage guard) and proves nothing.
-        if ("$so" -notmatch 'MBCS->UTF-8 ok') {
+        if ("$so" -notmatch 'MBCS->UTF-8 ok on 2 checks') {
           throw "selftest did not exercise the MBCS->UTF-8 conversion"
         }
         # Every help button hands one of these to the browser: an unescaped space truncates
         # the path, an unescaped '#' names a file, since NTFS allows one in a filename.
-        if ("$so" -notmatch 'help URLs ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'help URLs ok on 5 checks') {
           throw "selftest did not check the help URLs"
         }
         # Guards the empty-name terminator (newlang.h); losing it hangs the first-run About
-        # box. [1-9] not \d: "after 0 entries" would pass while proving nothing.
+        # box. The only count left loose: it is the size of the engine's lang.def, so pinning
+        # it would turn an engine translation into a red build here.
         if ("$so" -notmatch 'language list ends after [1-9]\d* entries') {
           throw "selftest did not check that the language list terminates"
         }
         # lang.indexes counts from LANGUAGE_1 and our indices from 0: an unchecked
         # off-by-one would seed the first run in the neighbouring language.
-        if ("$so" -notmatch 'lang\.indexes offset checked on [1-9]\d* locales') {
+        if ("$so" -notmatch 'lang\.indexes offset checked on 4 locales and 9 checks') {
           throw "selftest did not check the lang.indexes offset"
         }
         # The option caps count UTF-8 bytes, so the accented value is the case that matters;
         # it carries an ANSI-codepage guard and names itself when it skips.
-        if ("$so" -notmatch 'quoted arguments ok on [1-9]\d* checks(?! \(accented)') {
+        if ("$so" -notmatch 'quoted arguments ok on 15 checks(?! \(accented)') {
           throw "selftest did not check the quoted arguments against an accented value"
         }
         # A footer preset is only reachable by opening the Browser ID page.
-        if ("$so" -notmatch 'footer presets ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'footer presets ok on 26 checks') {
           throw "selftest did not check the footer presets"
         }
         # A rule the splitter mangles reaches the engine as --host-alias "" and aborts the mirror.
-        if ("$so" -notmatch 'rule splitting ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'rule splitting ok on 12 checks') {
           throw "selftest did not check the Experts rule splitter"
         }
         # winprofile.ini is a cross-front-end contract: WebHTTrack and Android read what we write.
-        if ("$so" -notmatch 'profile escaping ok on [1-9]\d* decodes, [1-9]\d* round trips and [1-9]\d* terminators') {
+        if ("$so" -notmatch 'profile escaping ok on 8 decodes, 4 round trips and 2 terminators') {
           throw "selftest did not check the winprofile.ini escaping"
         }
         # The grammar lives in the engine, so a change there has to land here, not in a mirror.
-        if ("$so" -notmatch 'host-alias rules ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'host-alias rules ok on 34 checks') {
           throw "selftest did not check the host-alias grammar"
         }
         # A wrong wizard answer quietly applies the wrong filter rather than failing.
-        if ("$so" -notmatch 'wizard answers ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'wizard answers ok on 22 checks') {
           throw "selftest did not check the wizard answers"
         }
         # The answer indexes this menu, so it must stay the engine's list in the engine's order.
-        if ("$so" -notmatch 'wizard scopes ok on [1-9]\d* checks') {
+        if ("$so" -notmatch 'wizard scopes ok on 2 checks') {
           throw "selftest did not check the wizard host scopes"
         }
 

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -212,8 +212,9 @@ runs:
         if ("$so" -notmatch 'quoted arguments ok on 15 checks(?! \(accented)') {
           throw "selftest did not check the quoted arguments against an accented value"
         }
-        # A footer preset is only reachable by opening the Browser ID page.
-        if ("$so" -notmatch 'footer presets ok on 26 checks') {
+        # A footer preset is only reachable by opening the Browser ID page. The field count
+        # is loose: they come from the engine's default footer, not from our table.
+        if ("$so" -notmatch 'footer presets ok on 16 checks and [1-9]\d* fields') {
           throw "selftest did not check the footer presets"
         }
         # A rule the splitter mangles reaches the engine as --host-alias "" and aborts the mirror.

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -763,7 +763,8 @@ BOOL CWinHTTrackApp::InitInstance()
         { "pt_br", "Portugues-Brasil" }, { NULL, NULL }
       };
       const int saved = QLANG_T(-1);
-      int k, nchecks = 0;
+      int nchecks = 0;
+      int k;
       for(k=0 ; expect[k].tag != NULL ; k++) {
         char name[1024];
         const int index = LANG_INDEX_OF(expect[k].tag);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -656,7 +656,9 @@ BOOL CWinHTTrackApp::InitInstance()
     /* Only reachable by opening the Browser ID page, so pin the presets here: a
        stray %s or a misspelt {field} would reach every mirrored page. */
     {
-      int nchecks = 0;
+      /* Fields counted apart: HTS_DEFAULT_FOOTER is the engine's, so how many it names
+         is not ours to pin. */
+      int nchecks = 0, nfields = 0;
 
       /* "{}", "{{", an unterminated "{" and an over-long name all reach the engine as "" */
       if (hts_footer_field_ok("")) {
@@ -714,12 +716,12 @@ BOOL CWinHTTrackApp::InitInstance()
               fflush(stderr);
               ExitProcess(3);
             } else
-              nchecks++;
+              nfields++;
             p = end;
           }
         }
       }
-      printf("footer presets ok on %d checks\n", nchecks);
+      printf("footer presets ok on %d checks and %d fields\n", nchecks, nfields);
     }
     int nlangs = 0;
     /* Walk the languages as the About box does: losing LANG_LOAD()'s empty-name

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -342,15 +342,16 @@ BOOL CWinHTTrackApp::InitInstance()
       const int n = WideCharToMultiByte(CP_ACP, 0, wide, -1, ansi, sizeof(ansi),
                                         NULL, plost);
       if (n > 0 && !lost) {   /* skip where the ANSI codepage cannot hold it at all */
+        int nchecks = 0;
         char *got = strdupt_utf8(ansi);   /* freet() nulls it, so not const */
         if (got == NULL || strcmp(got, "caf\xc3\xa9") != 0) {
           fprintf(stderr, "FATAL: MBCS->UTF-8 gave '%s', expected caf\xc3\xa9\n",
                   got != NULL ? got : "(null)");
           fflush(stderr);
           ExitProcess(3);
-        }
+        } else
+          nchecks++;
         freet(got);
-        printf("MBCS->UTF-8 ok\n");
         /* The install path is where a non-ASCII byte reaches the help URL. */
         {
           char dir[64];
@@ -360,8 +361,11 @@ BOOL CWinHTTrackApp::InitInstance()
             fprintf(stderr, "FATAL: non-ASCII help path gave '%s'\n", (LPCSTR) url);
             fflush(stderr);
             ExitProcess(3);
-          }
+          } else
+            nchecks++;
         }
+        /* Printed after both checks, so neither can be dropped unnoticed. */
+        printf("MBCS->UTF-8 ok on %d checks\n", nchecks);
       }
     }
     /* An unescaped space truncates the path, and an unescaped '#' names a file rather
@@ -759,7 +763,7 @@ BOOL CWinHTTrackApp::InitInstance()
         { "pt_br", "Portugues-Brasil" }, { NULL, NULL }
       };
       const int saved = QLANG_T(-1);
-      int k;
+      int k, nchecks = 0;
       for(k=0 ; expect[k].tag != NULL ; k++) {
         char name[1024];
         const int index = LANG_INDEX_OF(expect[k].tag);
@@ -768,7 +772,8 @@ BOOL CWinHTTrackApp::InitInstance()
                   expect[k].tag, index);
           fflush(stderr);
           ExitProcess(5);
-        }
+        } else
+          nchecks++;
         QLANG_T(index);
         strcpybuff(name, "LANGUAGE_NAME");
         LANG_LOAD(name,sizeof(name));
@@ -777,15 +782,17 @@ BOOL CWinHTTrackApp::InitInstance()
                   expect[k].tag, name, expect[k].name);
           fflush(stderr);
           ExitProcess(5);
-        }
+        } else
+          nchecks++;
       }
       QLANG_T(saved);
       if (LANG_INDEX_OF("zz") >= 0) {
         fprintf(stderr, "FATAL: lang.indexes matched the bogus tag 'zz'\n");
         fflush(stderr);
         ExitProcess(5);
-      }
-      printf("lang.indexes offset checked on %d locales\n", k);
+      } else
+        nchecks++;
+      printf("lang.indexes offset checked on %d locales and %d checks\n", k, nchecks);
     }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking


### PR DESCRIPTION
A lower bound only rejects zero, so deleting one case among many still passed. Every count our own tables fix is now exact, which also means adding a case has to move the number in the action. Two stay loose on purpose, and for the same reason: the language-list count is the size of the engine's lang.def, and the footer field count walks the engine's default footer, so pinning either would turn an engine change into a red build here.

`MBCS->UTF-8 ok` also printed before the non-ASCII help-path check sitting below it, so that check could be dropped unnoticed. It now counts both and prints after them, and `lang.indexes` reports checks alongside locales so losing either check per locale shows up.
