### PR TITLE
Pin the checkbox gating that no test could see

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -225,9 +225,8 @@ runs:
         if ("$so" -notmatch 'profile escaping ok on 8 decodes, 4 round trips and 2 terminators') {
           throw "selftest did not check the winprofile.ini escaping"
         }
-        # An unticked box whose field is filled must emit nothing: the engine turns each
-        # value option on by itself, so a leak here silently mirrors under the wrong mode.
-        if ("$so" -notmatch 'option gating ok on 10 checks') {
+        # Pins the checkbox-gating contract (see WinHTTrack/Shell.h).
+        if ("$so" -notmatch 'option gating ok on 14 checks') {
           throw "selftest did not check the checkbox gating"
         }
         # The grammar lives in the engine, so a change there has to land here, not in a mirror.

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -225,6 +225,11 @@ runs:
         if ("$so" -notmatch 'profile escaping ok on 8 decodes, 4 round trips and 2 terminators') {
           throw "selftest did not check the winprofile.ini escaping"
         }
+        # An unticked box whose field is filled must emit nothing: the engine turns each
+        # value option on by itself, so a leak here silently mirrors under the wrong mode.
+        if ("$so" -notmatch 'option gating ok on 10 checks') {
+          throw "selftest did not check the checkbox gating"
+        }
         # The grammar lives in the engine, so a change there has to land here, not in a mirror.
         if ("$so" -notmatch 'host-alias rules ok on 34 checks') {
           throw "selftest did not check the host-alias grammar"

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1965,6 +1965,45 @@ static BOOL isAllDigits(const CString &value) {
   return !value.IsEmpty();
 }
 
+void addGatedOptions(const CShellOptions &opt, CStringArray &args) {
+  // WARC: emit --warc as its own token, not in the compacted -%... string, whose
+  // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
+  if (opt.warc.GetLength() != 0) {
+    args.Add("--warc");
+    // neither sub-option names an archive on its own, so both stay gated on --warc
+    if (opt.warccdx.GetLength() != 0) {
+      args.Add("--warc-cdx");
+    }
+    if (opt.wacz.GetLength() != 0) {
+      args.Add("--wacz");
+    }
+  }
+
+  // Long forms, own tokens: same reason as --warc above.
+  if (opt.sitemap.GetLength() != 0) {
+    CString sitemapurl = opt.sitemapurl;
+    sitemapurl.Trim();
+    // an address given here replaces the robots.txt then /sitemap.xml probe
+    if (isEngineArgument(sitemapurl, HTS_URLMAXSIZE)) {
+      args.Add("--sitemap-url");
+      args.Add(sitemapurl);
+    } else {
+      args.Add("--sitemap");
+    }
+  }
+
+  if (opt.singlefile.GetLength() != 0) {
+    args.Add("--single-file");
+    CString singlefilemax = opt.singlefilemax;
+    singlefilemax.Trim();
+    // the cap implies --single-file, so it must not leak out on its own
+    if (isAllDigits(singlefilemax) && isEngineArgument(singlefilemax, HTS_URLMAXSIZE)) {
+      args.Add("--single-file-max-size");
+      args.Add(singlefilemax);
+    }
+  }
+}
+
 // Lancement
 void lance(void) {
   char **argv;
@@ -2057,42 +2096,12 @@ void lance(void) {
   single += ShellOptions->proxyftp;  
   single += "#f";  // flush
 
-  // WARC: emit --warc as its own token, not in the compacted -%... string, whose
-  // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
-  if (ShellOptions->warc.GetLength() != 0) {
-    args.Add("--warc");
-    // neither sub-option names an archive on its own, so both stay gated on --warc
-    if (ShellOptions->warccdx.GetLength() != 0) {
-      args.Add("--warc-cdx");
-    }
-    if (ShellOptions->wacz.GetLength() != 0) {
-      args.Add("--wacz");
-    }
-  }
+  {
+    CStringArray gated;
 
-  // Long forms, own tokens: same reason as --warc above. Each option's own checkbox
-  // gates it, so an unticked box never reaches the engine through a field left filled.
-  if (ShellOptions->sitemap.GetLength() != 0) {
-    CString sitemapurl = ShellOptions->sitemapurl;
-    sitemapurl.Trim();
-    // an address given here replaces the robots.txt then /sitemap.xml probe
-    if (isEngineArgument(sitemapurl, HTS_URLMAXSIZE)) {
-      args.Add("--sitemap-url");
-      args.Add(sitemapurl);
-    } else {
-      args.Add("--sitemap");
-    }
-  }
-
-  if (ShellOptions->singlefile.GetLength() != 0) {
-    args.Add("--single-file");
-    CString singlefilemax = ShellOptions->singlefilemax;
-    singlefilemax.Trim();
-    // the cap implies --single-file, so it must not leak out on its own
-    if (isAllDigits(singlefilemax) && isEngineArgument(singlefilemax, HTS_URLMAXSIZE)) {
-      args.Add("--single-file-max-size");
-      args.Add(singlefilemax);
-    }
+    addGatedOptions(*ShellOptions, gated);
+    for(INT_PTR i=0 ; i<gated.GetSize() ; i++)
+      args.Add(gated[i]);
   }
 
   if (ShellOptions->changes.GetLength() != 0) {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1965,12 +1965,12 @@ static BOOL isAllDigits(const CString &value) {
   return !value.IsEmpty();
 }
 
-void addGatedOptions(const CShellOptions &opt, CStringArray &args) {
+void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt) {
   // WARC: emit --warc as its own token, not in the compacted -%... string, whose
   // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
   if (opt.warc.GetLength() != 0) {
     args.Add("--warc");
-    // neither sub-option names an archive on its own, so both stay gated on --warc
+    // child boxes of the WARC one: the parent box is the user's on/off for the group
     if (opt.warccdx.GetLength() != 0) {
       args.Add("--warc-cdx");
     }
@@ -2096,13 +2096,7 @@ void lance(void) {
   single += ShellOptions->proxyftp;  
   single += "#f";  // flush
 
-  {
-    CStringArray gated;
-
-    addGatedOptions(*ShellOptions, gated);
-    for(INT_PTR i=0 ; i<gated.GetSize() ; i++)
-      args.Add(gated[i]);
-  }
+  addGatedOptions(args, *ShellOptions);
 
   if (ShellOptions->changes.GetLength() != 0) {
     args.Add("--changes");

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -296,6 +296,11 @@ public:
 /* Class options */
 extern CShellOptions* ShellOptions;
 
+/* Append the checkbox-gated options (the WARC group, sitemap, single-file) to args.
+   Each value option enables its feature by itself in the engine, so a field left
+   filled under a clear box must emit nothing. Shared with --selftest. */
+void addGatedOptions(const CShellOptions &opt, CStringArray &args);
+
 
 /////////////////////////////////////////////////////////////////////////////
 // CShellApp:

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -36,6 +36,8 @@ Please visit our Website: http://www.httrack.com
 	#error include 'stdafx.h' before including this file for PCH
 #endif
 
+#include <atlsimpcoll.h>   /* CSimpleArray, the argv array lance() builds */
+
 /* basic HTTrack defs */
 #include "htsnet.h"
 #include "htsopt.h"
@@ -297,9 +299,9 @@ public:
 extern CShellOptions* ShellOptions;
 
 /* Append the checkbox-gated options (the WARC group, sitemap, single-file) to args.
-   Each value option enables its feature by itself in the engine, so a field left
-   filled under a clear box must emit nothing. Shared with --selftest. */
-void addGatedOptions(const CShellOptions &opt, CStringArray &args);
+   A field left filled under a clear box must emit nothing, since a value option
+   can enable its feature by itself. Shared with --selftest. */
+void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt);
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -494,6 +494,59 @@ BOOL CWinHTTrackApp::InitInstance()
       printf("profile escaping ok on %d decodes, %d round trips and %d terminators\n",
              ndecodes, nroundtrips, nterminators);
     }
+    /* A value option is inert under a clear box — the contract all three front ends
+       now share. lance() is out of reach here, so this is the only pin on it. */
+    {
+      static const struct {
+        const char *warc, *warccdx, *wacz, *sitemap, *sitemapurl,
+                   *singlefile, *singlefilemax;
+        const char *want;
+      } gated[] = {
+        /* every box clear with its field filled: the state the front ends read apart */
+        { "", "1", "1", "", "http://e/sitemap.xml", "", "1000", "" },
+        { "", "1", "1", "", "", "", "", "" },
+        { "", "", "", "", "http://e/sitemap.xml", "", "", "" },
+        { "", "", "", "", "", "", "1000", "" },
+        /* ticked, so the very same fields must come through: else the rows above pass vacuously */
+        { "1", "1", "1", "", "", "", "", "--warc|--warc-cdx|--wacz" },
+        { "1", "", "", "", "", "", "", "--warc" },
+        { "", "", "", "1", "http://e/sitemap.xml", "", "", "--sitemap-url|http://e/sitemap.xml" },
+        /* a blank address falls back to the probe, never --sitemap-url "" */
+        { "", "", "", "1", " \t ", "", "", "--sitemap" },
+        { "", "", "", "", "", "1", "1000", "--single-file|--single-file-max-size|1000" },
+        /* a cap the engine would reject still enables single-file there, so drop it here */
+        { "", "", "", "", "", "1", "abc", "--single-file" },
+        { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
+      };
+      int nchecks = 0;
+      for(int k=0 ; gated[k].want != NULL ; k++) {
+        CShellOptions opt;
+        CStringArray got;
+        CString joined;
+
+        opt.warc = gated[k].warc;
+        opt.warccdx = gated[k].warccdx;
+        opt.wacz = gated[k].wacz;
+        opt.sitemap = gated[k].sitemap;
+        opt.sitemapurl = gated[k].sitemapurl;
+        opt.singlefile = gated[k].singlefile;
+        opt.singlefilemax = gated[k].singlefilemax;
+        addGatedOptions(opt, got);
+        for(INT_PTR j=0 ; j<got.GetSize() ; j++) {
+          if (j != 0)
+            joined += "|";
+          joined += got[j];
+        }
+        if (joined != gated[k].want) {
+          fprintf(stderr, "FATAL: gated row %d emitted '%s', expected '%s'\n",
+                  k, (LPCSTR) joined, gated[k].want);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      printf("option gating ok on %d checks\n", nchecks);
+    }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */
     {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -494,8 +494,8 @@ BOOL CWinHTTrackApp::InitInstance()
       printf("profile escaping ok on %d decodes, %d round trips and %d terminators\n",
              ndecodes, nroundtrips, nterminators);
     }
-    /* A value option is inert under a clear box — the contract all three front ends
-       now share. lance() is out of reach here, so this is the only pin on it. */
+    /* lance() is out of reach here, so this is the only pin on the gating
+       contract declared in Shell.h. */
     {
       static const struct {
         const char *warc, *warccdx, *wacz, *sitemap, *sitemapurl,
@@ -514,14 +514,22 @@ BOOL CWinHTTrackApp::InitInstance()
         /* a blank address falls back to the probe, never --sitemap-url "" */
         { "", "", "", "1", " \t ", "", "", "--sitemap" },
         { "", "", "", "", "", "1", "1000", "--single-file|--single-file-max-size|1000" },
-        /* a cap the engine would reject still enables single-file there, so drop it here */
+        /* a cap that fails validation is dropped, and the box still emits --single-file */
         { "", "", "", "", "", "1", "abc", "--single-file" },
+        /* one sub-option only, so swapping the two branch bodies cannot pass */
+        { "1", "1", "", "", "", "", "", "--warc|--warc-cdx" },
+        /* all three groups at once: pins their order, and that they are not exclusive */
+        { "1", "", "", "1", "http://e/sitemap.xml", "1", "1000",
+          "--warc|--sitemap-url|http://e/sitemap.xml|--single-file|--single-file-max-size|1000" },
+        { "", "", "", "", "", "1", " 1000 ", "--single-file|--single-file-max-size|1000" },
+        /* a leading dash reads to the engine as the argument being missing */
+        { "", "", "", "1", "-http://e/", "", "", "--sitemap" },
         { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
       };
       int nchecks = 0;
       for(int k=0 ; gated[k].want != NULL ; k++) {
         CShellOptions opt;
-        CStringArray got;
+        CSimpleArray<CString> got;
         CString joined;
 
         opt.warc = gated[k].warc;
@@ -531,15 +539,17 @@ BOOL CWinHTTrackApp::InitInstance()
         opt.sitemapurl = gated[k].sitemapurl;
         opt.singlefile = gated[k].singlefile;
         opt.singlefilemax = gated[k].singlefilemax;
-        addGatedOptions(opt, got);
-        for(INT_PTR j=0 ; j<got.GetSize() ; j++) {
+        addGatedOptions(got, opt);
+        for(int j=0 ; j<got.GetSize() ; j++) {
           if (j != 0)
             joined += "|";
           joined += got[j];
         }
         if (joined != gated[k].want) {
-          fprintf(stderr, "FATAL: gated row %d emitted '%s', expected '%s'\n",
-                  k, (LPCSTR) joined, gated[k].want);
+          fprintf(stderr, "FATAL: gated row %d [%s,%s,%s,%s,%s,%s,%s] emitted '%s', expected '%s'\n",
+                  k, gated[k].warc, gated[k].warccdx, gated[k].wacz, gated[k].sitemap,
+                  gated[k].sitemapurl, gated[k].singlefile, gated[k].singlefilemax,
+                  (LPCSTR) joined, gated[k].want);
           fflush(stderr);
           ExitProcess(3);
         } else


### PR DESCRIPTION
WinHTTrack gates each value option on its own checkbox: `--sitemap-url`, `--single-file-max-size` and `--wacz` each turn their feature on by themselves in the engine, and the WARC sub-options are nested under the WARC box in the dialog. Nothing tested that. The emission sits inside `lance()`, which `--selftest` cannot reach, so a rework could drop a gate and leave the build green.

This extracts those blocks into `addGatedOptions()` and pins them over a 14-row table. Four rows are the box-clear, field-filled state that WebHTTrack read the other way until engine PR #1335, and the ticked rows sit beside them so the empty expectations cannot pass vacuously. The rest came out of the review: without them, swapping the two WARC sub-option branches or making the three groups mutually exclusive still passed.

One note for review: it touches `.github/actions/smoke-test/action.yml`, a signing-privileged path, only to move the pinned check count.
