### PR TITLE
Drop a single-file cap the engine will not take

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -226,8 +226,12 @@ runs:
           throw "selftest did not check the winprofile.ini escaping"
         }
         # Pins the checkbox-gating contract (see WinHTTrack/Shell.h).
-        if ("$so" -notmatch 'option gating ok on 19 checks') {
+        if ("$so" -notmatch 'option gating ok on 16 checks') {
           throw "selftest did not check the checkbox gating"
+        }
+        # A cap the engine refuses aborts the mirror, so the shell must never build one.
+        if ("$so" -notmatch 'single-file caps ok on 7 checks') {
+          throw "selftest did not check the single-file cap"
         }
         # The grammar lives in the engine, so a change there has to land here, not in a mirror.
         if ("$so" -notmatch 'host-alias rules ok on 34 checks') {

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -226,7 +226,7 @@ runs:
           throw "selftest did not check the winprofile.ini escaping"
         }
         # Pins the checkbox-gating contract (see WinHTTrack/Shell.h).
-        if ("$so" -notmatch 'option gating ok on 14 checks') {
+        if ("$so" -notmatch 'option gating ok on 19 checks') {
           throw "selftest did not check the checkbox gating"
         }
         # The grammar lives in the engine, so a change there has to land here, not in a mirror.

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1965,9 +1965,8 @@ static BOOL isAllDigits(const CString &value) {
   return !value.IsEmpty();
 }
 
-// TRUE if VALUE is a cap the engine accepts; it aborts the mirror on one it does not.
-// Anything accepted is 19 digits at most, hence no length or leading-dash test.
-static BOOL isSingleFileMaxArgument(const CString &value) {
+// see Shell.h
+BOOL isSingleFileMaxArgument(const CString &value) {
   char *end;
   LLint v;
 
@@ -1975,7 +1974,8 @@ static BOOL isSingleFileMaxArgument(const CString &value) {
     return FALSE;
   errno = 0;
   v = strtoll((LPCSTR) value, &end, 10);
-  return *end == '\0' && errno != ERANGE && v > 0;
+  // leading zeros keep the value small however long the string is, so argv still caps it
+  return *end == '\0' && errno != ERANGE && v > 0 && fitsEngineArgument(value, HTS_CDLMAXSIZE);
 }
 
 void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt) {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1965,6 +1965,19 @@ static BOOL isAllDigits(const CString &value) {
   return !value.IsEmpty();
 }
 
+// TRUE if VALUE is a cap the engine accepts; it aborts the mirror on one it does not.
+// Anything accepted is 19 digits at most, hence no length or leading-dash test.
+static BOOL isSingleFileMaxArgument(const CString &value) {
+  char *end;
+  LLint v;
+
+  if (!isAllDigits(value))   // strtoll would otherwise take a sign or leading spaces
+    return FALSE;
+  errno = 0;
+  v = strtoll((LPCSTR) value, &end, 10);
+  return *end == '\0' && errno != ERANGE && v > 0;
+}
+
 void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt) {
   // WARC: emit --warc as its own token, not in the compacted -%... string, whose
   // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
@@ -1997,7 +2010,7 @@ void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt) {
     CString singlefilemax = opt.singlefilemax;
     singlefilemax.Trim();
     // the cap implies --single-file, so it must not leak out on its own
-    if (isAllDigits(singlefilemax) && isEngineArgument(singlefilemax, HTS_URLMAXSIZE)) {
+    if (isSingleFileMaxArgument(singlefilemax)) {
       args.Add("--single-file-max-size");
       args.Add(singlefilemax);
     }

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -226,6 +226,10 @@ void splitRulesInArray(CStringArray &rules, const CString &str);
    hts_host_alias_rule_ok(), and short enough for argv. A rule it refuses aborts the mirror. */
 BOOL isHostAliasArgument(const CString &rule);
 
+/* TRUE if VALUE may be handed to --single-file-max-size: positive, in range, and short
+   enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
+BOOL isSingleFileMaxArgument(const CString &value);
+
 /* TRUE if VALUE may be handed to the option each one names: short enough once converted,
    and not opening with a dash. Exposed for --selftest. */
 BOOL isUserAgentArgument(const CString &value);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -516,6 +516,14 @@ BOOL CWinHTTrackApp::InitInstance()
         { "", "", "", "", "", "1", "1000", "--single-file|--single-file-max-size|1000" },
         /* a cap that fails validation is dropped, and the box still emits --single-file */
         { "", "", "", "", "", "1", "abc", "--single-file" },
+        /* the engine aborts the mirror on a cap it cannot use, so none may leave here */
+        { "", "", "", "", "", "1", "0", "--single-file" },
+        { "", "", "", "", "", "1", "0000", "--single-file" },
+        { "", "", "", "", "", "1", "99999999999999999999", "--single-file" },
+        /* in range despite its length, so the guard cannot be a digit count */
+        { "", "", "", "", "", "1", "0000000000000000000001",
+          "--single-file|--single-file-max-size|0000000000000000000001" },
+        { "", "", "", "", "", "1", "1", "--single-file|--single-file-max-size|1" },
         /* one sub-option only, so swapping the two branch bodies cannot pass */
         { "1", "1", "", "", "", "", "", "--warc|--warc-cdx" },
         /* all three groups at once: pins their order, and that they are not exclusive */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -516,14 +516,10 @@ BOOL CWinHTTrackApp::InitInstance()
         { "", "", "", "", "", "1", "1000", "--single-file|--single-file-max-size|1000" },
         /* a cap that fails validation is dropped, and the box still emits --single-file */
         { "", "", "", "", "", "1", "abc", "--single-file" },
-        /* the engine aborts the mirror on a cap it cannot use, so none may leave here */
         { "", "", "", "", "", "1", "0", "--single-file" },
-        { "", "", "", "", "", "1", "0000", "--single-file" },
-        { "", "", "", "", "", "1", "99999999999999999999", "--single-file" },
-        /* in range despite its length, so the guard cannot be a digit count */
+        /* in range despite its length, so length alone must not drop it */
         { "", "", "", "", "", "1", "0000000000000000000001",
           "--single-file|--single-file-max-size|0000000000000000000001" },
-        { "", "", "", "", "", "1", "1", "--single-file|--single-file-max-size|1" },
         /* one sub-option only, so swapping the two branch bodies cannot pass */
         { "1", "1", "", "", "", "", "", "--warc|--warc-cdx" },
         /* all three groups at once: pins their order, and that they are not exclusive */
@@ -607,6 +603,38 @@ BOOL CWinHTTrackApp::InitInstance()
           nchecks++;
       }
       printf("host-alias rules ok on %d checks\n", nchecks);
+    }
+    /* The cap rides argv as its own token, so its length costs the mirror as surely as its
+       value: the engine refuses an argument of HTS_CDLMAXSIZE bytes before parsing it. */
+    {
+      static const struct { const char *lead; int repeat; const char *tail; BOOL want; } caps[] = {
+        { "", 0, "1000", TRUE },
+        { "", 0, "+1000", FALSE },   /* strtoll would take the sign, the engine will not */
+        { "", 0, "3000000000", TRUE },   /* over 2 GB, so a 32-bit parse cannot pass this */
+        { "9", 19, "", FALSE },   /* overflows LLint at a length the rows below still allow */
+        { "0", 4, "", FALSE },   /* zero, however it is written */
+        /* leading zeros keep the value at 1, so only the length decides these two */
+        { "0", HTS_CDLMAXSIZE - 2, "1", TRUE },
+        { "0", HTS_CDLMAXSIZE - 1, "1", FALSE },
+        { NULL, 0, NULL, FALSE }
+      };
+      int nchecks = 0;
+      for(int k=0 ; caps[k].lead != NULL ; k++) {
+        CString value;
+
+        for(int n=0 ; n<caps[k].repeat ; n++)
+          value += caps[k].lead;
+        value += caps[k].tail;
+        if (isSingleFileMaxArgument(value) != caps[k].want) {
+          fprintf(stderr, "FATAL: single-file cap '%s' (%d chars) judged %s\n",
+                  (LPCSTR) value.Left(40), (int) value.GetLength(),
+                  caps[k].want ? "bad, expected good" : "good, expected bad");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      printf("single-file caps ok on %d checks\n", nchecks);
     }
     /* Pin what the shell agrees to hand the options it quotes, per option: a value the engine
        refuses costs the whole mirror, and each field carries its own cap. */


### PR DESCRIPTION
The size field on the options page is ES_NUMBER, so the only bad caps a user can type are 0 and a digit run past LLint. Both pass the existing all-digits guard and reach the engine, which ignores them today. Engine PR #1335 turns them into a refusal that stops the mirror before it starts. The guard here now mirrors that parse, so a cap it would reject never leaves the GUI and the mirror keeps the default cap.

Length counts as much as value: the engine refuses an argv token of HTS_CDLMAXSIZE bytes before it parses anything, and leading zeros keep a value small however long the string is. A hand-edited or foreign winprofile.ini can carry such a field, because only the dialog limits what is typed. The predicate sits in Shell.h beside its siblings with its own `--selftest` block, pinning both edges of the argv cap.