### PR TITLE
Set the GUI version to 3.50-beta-6

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-5"
+#define WINHTTRACK_VERSION "3.50-beta-6"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.5"
+#define WINHTTRACK_VERSIONID "3.49.99.6"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 5
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 6
 
 #endif


### PR DESCRIPTION
Sets the GUI version to 3.50-beta-6 for a release against engine 3.49.23 (`1f2c4cf8`). `version.h` is the only place it lives; the `.rc`, the installer and CI all read it from there.

Draft on purpose: the ask to cut this round came through a peer session, not from Xavier here, so merge and tag wait for his word.