### PR TITLE
Set the GUI version to 3.50-beta-7

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-6"
+#define WINHTTRACK_VERSION "3.50-beta-7"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.6"
+#define WINHTTRACK_VERSIONID "3.49.99.7"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 6
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7
 
 #endif


### PR DESCRIPTION
Renames the pending beta from 3.50-beta-6 to 3.50-beta-7. httrack-android tagged `v3.50-beta-6` yesterday against a 3.49.22 engine, so shipping ours under that name would give one beta number two different builds and make any user report ambiguous. Windows, Android and macOS align on beta-7 instead.

Same three macros in `version.h` as #133, nothing else moves, and the engine pin stays `1f2c4cf8` (3.49.23).

Draft until Xavier confirms the number in my session: the choice reached me through a peer.