### PR TITLE
Fail a tagged build whose tag does not match the version

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -244,10 +244,19 @@ jobs:
         env:
           ENGINE_REF: ${{ vars.HTTRACK_ENGINE_REF }}
           GH_REF: ${{ github.ref }}
+          GH_TAG: ${{ github.ref_name }}
         run: |
           $sha = (git -C httrack rev-parse HEAD).Trim()
           Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='$env:ENGINE_REF')"
           "sha=$sha" | Out-File -Append $env:GITHUB_OUTPUT
+          # Nothing else compares the two, so a mistyped tag would build and sign under a name no binary reports.
+          if ($env:GH_REF -like 'refs/tags/*') {
+            $vh = Get-Content 'httrack-windows\WinHTTrack\version.h' -Raw
+            if ($vh -notmatch '#define\s+WINHTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSION' }
+            $gui = $Matches[1]
+            if ($env:GH_TAG -cne $gui) { throw "tag '$env:GH_TAG' does not match WINHTTRACK_VERSION '$gui'" }
+            Write-Host "::notice::tag $env:GH_TAG matches WINHTTRACK_VERSION"
+          }
           # Two thirds of what we sign is built from the engine tree, so a tag that floats
           # cannot say what it shipped. A branch name is not a pin, so require a full SHA.
           if ($env:GH_REF -like 'refs/tags/*' -and $env:ENGINE_REF -notmatch '^[0-9a-f]{40}$') {

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The guard itself only fires on a tag, so this table is what actually proves it.
+      - name: Tag/version guard cases
+        shell: pwsh
+        run: ./tools/Test-TagVersion.ps1
       # Byte-exact on purpose: sources are UTF-8, the .rc/tooling inputs stay
       # Latin-1, and a shell guard can't tell them apart. Python decodes strictly.
       - name: Encoding and line endings
@@ -249,12 +253,14 @@ jobs:
           $sha = (git -C httrack rev-parse HEAD).Trim()
           Write-Host "::notice::engine $sha (HTTRACK_ENGINE_REF='$env:ENGINE_REF')"
           "sha=$sha" | Out-File -Append $env:GITHUB_OUTPUT
-          # Nothing else compares the two, so a mistyped tag would build and sign under a name no binary reports.
+          # Nothing else compares the two, so a mistyped tag would build and sign under a name no
+          # binary reports. Bare tags only: a v-prefixed one fails here even though on.push accepts it.
           if ($env:GH_REF -like 'refs/tags/*') {
-            $vh = Get-Content 'httrack-windows\WinHTTrack\version.h' -Raw
-            if ($vh -notmatch '#define\s+WINHTTRACK_VERSION\s+"([^"]+)"') { throw 'cannot read WINHTTRACK_VERSION' }
-            $gui = $Matches[1]
-            if ($env:GH_TAG -cne $gui) { throw "tag '$env:GH_TAG' does not match WINHTTRACK_VERSION '$gui'" }
+            . httrack-windows/tools/TagVersion.ps1
+            $gui = Get-GuiVersion -Path 'httrack-windows/WinHTTrack/version.h'
+            if (-not (Test-TagMatchesVersion -Tag $env:GH_TAG -Version $gui)) {
+              throw "tag '$env:GH_TAG' does not match WINHTTRACK_VERSION '$gui'"
+            }
             Write-Host "::notice::tag $env:GH_TAG matches WINHTTRACK_VERSION"
           }
           # Two thirds of what we sign is built from the engine tree, so a tag that floats

--- a/tools/TagVersion.ps1
+++ b/tools/TagVersion.ps1
@@ -1,0 +1,21 @@
+# Shared by the tagged-build guard and its test, so the release path and the table
+# that proves it can never drift apart.
+
+# The GUI version string from WinHTTrack/version.h. Throws if the macro is unreadable:
+# a silent empty result would compare unequal and read as a mistyped tag.
+function Get-GuiVersion {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { throw "no version header at $Path" }
+    $vh = Get-Content -LiteralPath $Path -Raw
+    # \s+ cannot match the _ or I that follow, so VERSION_H, VERSIONID and VERSION_NUM never bind.
+    if ($vh -notmatch '#define\s+WINHTTRACK_VERSION\s+"([^"]+)"') { throw "cannot read WINHTTRACK_VERSION from $Path" }
+    return $Matches[1]
+}
+
+# Ordinal, not -ceq: PowerShell's case-sensitive operators compare through ICU, which
+# ignores default-ignorable code points, so a tag carrying a soft hyphen would pass.
+function Test-TagMatchesVersion {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$Tag,
+          [Parameter(Mandatory)][AllowEmptyString()][string]$Version)
+    return [string]::Equals($Tag, $Version, [StringComparison]::Ordinal)
+}

--- a/tools/Test-TagVersion.ps1
+++ b/tools/Test-TagVersion.ps1
@@ -41,7 +41,7 @@ $v = '3.50-beta-7'
 $cases = @(
     @{ tag = '3.50-beta-7';        want = $true;  why = 'exact match' }
     @{ tag = '3.50-beta-6';        want = $false; why = 'the number this round nearly shipped' }
-    @{ tag = 'v3.50-beta-7';       want = $true;  why = 'NEGATIVE CONTROL: deliberately wrong, must fail' }
+    @{ tag = 'v3.50-beta-7';       want = $false; why = 'v-prefix: Android tags carry one, we do not' }
     @{ tag = '3.05-beta-7';        want = $false; why = 'transposed digits' }
     @{ tag = '3.50-BETA-7';        want = $false; why = 'case differs' }
     @{ tag = '3.50-beta-70';       want = $false; why = 'superstring' }

--- a/tools/Test-TagVersion.ps1
+++ b/tools/Test-TagVersion.ps1
@@ -1,0 +1,59 @@
+#!/usr/bin/env pwsh
+# Table test for the tagged-build guard. Runs on every push and PR, where no tag
+# exists, so the release path is proven without pushing one.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'TagVersion.ps1')
+
+$fail = 0
+function Check($what, $got, $want) {
+    if ($got -ne $want) { Write-Host "  FAIL $what : got $got, wanted $want"; $script:fail++ }
+    else { Write-Host "  ok   $what" }
+}
+
+# A header shaped like the real one: the three decoy macros are the point.
+$dir = Join-Path ([IO.Path]::GetTempPath()) ("tagver-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $dir | Out-Null
+$full = Join-Path $dir 'version.h'
+Set-Content -LiteralPath $full -Value @'
+#ifndef WINHTTRACK_VERSION_H
+#define WINHTTRACK_VERSION_H
+#define WINHTTRACK_VERSION "3.50-beta-7"
+#define WINHTTRACK_VERSIONID "3.49.99.7"
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7
+#endif
+'@
+
+Write-Host "--- Get-GuiVersion binds to the right macro ---"
+Check 'picks WINHTTRACK_VERSION, not VERSIONID/NUM/_H' (Get-GuiVersion -Path $full) '3.50-beta-7'
+
+Write-Host "--- Get-GuiVersion refuses what it cannot read ---"
+$bare = Join-Path $dir 'novers.h'
+Set-Content -LiteralPath $bare -Value '#define WINHTTRACK_VERSIONID "3.49.99.7"'
+foreach ($case in @(@{n='absent macro'; p=$bare}, @{n='missing file'; p=(Join-Path $dir 'nope.h')})) {
+    $threw = $false
+    try { Get-GuiVersion -Path $case.p | Out-Null } catch { $threw = $true }
+    Check $case.n $threw $true
+}
+
+Write-Host "--- Test-TagMatchesVersion ---"
+$v = '3.50-beta-7'
+$cases = @(
+    @{ tag = '3.50-beta-7';        want = $true;  why = 'exact match' }
+    @{ tag = '3.50-beta-6';        want = $false; why = 'the number this round nearly shipped' }
+    @{ tag = 'v3.50-beta-7';       want = $false; why = 'v-prefix: Android tags carry one, we do not' }
+    @{ tag = '3.05-beta-7';        want = $false; why = 'transposed digits' }
+    @{ tag = '3.50-BETA-7';        want = $false; why = 'case differs' }
+    @{ tag = '3.50-beta-70';       want = $false; why = 'superstring' }
+    @{ tag = '3.50-beta-';         want = $false; why = 'prefix' }
+    @{ tag = '3.50-beta-7 ';       want = $false; why = 'trailing space' }
+    @{ tag = ' 3.50-beta-7';       want = $false; why = 'leading space' }
+    @{ tag = '';                   want = $false; why = 'empty tag' }
+    # Ordinal, not ICU: -ceq treats a default-ignorable code point as equal and would pass this.
+    @{ tag = "3.50-beta-7$([char]0x00AD)"; want = $false; why = 'trailing soft hyphen' }
+)
+foreach ($c in $cases) { Check $c.why (Test-TagMatchesVersion -Tag $c.tag -Version $v) $c.want }
+
+Remove-Item -Recurse -Force $dir
+if ($fail) { throw "$fail tag/version case(s) failed" }
+Write-Host "::notice::tag/version guard: $($cases.Count + 3) cases pass"

--- a/tools/Test-TagVersion.ps1
+++ b/tools/Test-TagVersion.ps1
@@ -41,7 +41,7 @@ $v = '3.50-beta-7'
 $cases = @(
     @{ tag = '3.50-beta-7';        want = $true;  why = 'exact match' }
     @{ tag = '3.50-beta-6';        want = $false; why = 'the number this round nearly shipped' }
-    @{ tag = 'v3.50-beta-7';       want = $false; why = 'v-prefix: Android tags carry one, we do not' }
+    @{ tag = 'v3.50-beta-7';       want = $true;  why = 'NEGATIVE CONTROL: deliberately wrong, must fail' }
     @{ tag = '3.05-beta-7';        want = $false; why = 'transposed digits' }
     @{ tag = '3.50-BETA-7';        want = $false; why = 'case differs' }
     @{ tag = '3.50-beta-70';       want = $false; why = 'superstring' }


### PR DESCRIPTION
Nothing in CI compared the pushed tag against `WINHTTRACK_VERSION`, so a mistyped tag built, signed and published under a name no binary reports. Cutting 3.50-beta-7 leaned on reading the two side by side by hand, right after the number had changed under us, which is where this gap gets expensive.

The check sits before the engine-pin check so a typo is reported ahead of missing infrastructure state, and it compares case-sensitively.

Draft for a reason worth stating: **green CI here proves nothing about this change.** The guard only runs on a tag build, so no branch build reaches it. It needs a deliberate throwaway tag to demonstrate the failure, which is Xavier's call to authorise.

Touches a signing-privileged file (`.github/workflows/**`). It adds no network access, no secret, and no `environment:` line.