### PR TITLE
Install over the existing copy, and count what is left behind

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -272,6 +272,35 @@ runs:
 
         Write-Host "::notice::WinHTTrack $env:APPVER (engine $env:ENGINEVER) installs, starts and runs ($($setup.Name))."
 
+        # Every run so far got a clean machine, so an upgrade that laid a second installation
+        # beside the first would never have shown up. Re-running this installer takes the path
+        # an upgrade takes: the encoding job asserts the premise, that the installer identity
+        # carries no version, so this cannot quietly stop standing in for one.
+        $p = Start-Process $setup.FullName -Wait -PassThru -ArgumentList `
+          '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$dir","/LOG=$PWD\reinstall.log"
+        if ($p.ExitCode -ne 0) { throw "installing over the existing copy exited $($p.ExitCode)" }
+        if (-not (Test-Path $exe)) { throw "installing over the existing copy removed WinHTTrack.exe" }
+        $p = Start-Process $exe -ArgumentList '--version' -Wait -PassThru -NoNewWindow
+        if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe exited $($p.ExitCode) after installing over" }
+
+        # Two entries in Add/Remove Programs is the failure, and exit 0 cannot see it.
+        $roots = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+                   'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+                   'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
+        $entries = @(foreach ($r in $roots) {
+          if (Test-Path $r) {
+            foreach ($k in Get-ChildItem $r) {
+              $dn = (Get-ItemProperty $k.PSPath -ErrorAction SilentlyContinue).DisplayName
+              if ($dn -like 'WinHTTrack*') { "$($k.PSChildName) = $dn" }
+            }
+          }
+        })
+        foreach ($e in $entries) { Write-Host "  uninstall entry: $e" }
+        if ($entries.Count -ne 1) {
+          throw "expected 1 uninstall entry after installing over, found $($entries.Count)"
+        }
+        Write-Host "::notice::installing $env:APPVER over itself upgrades in place, one uninstall entry"
+
         $unins = Get-ChildItem "$dir\unins*.exe" | Select-Object -First 1
         $p = Start-Process $unins.FullName -Wait -PassThru -ArgumentList '/VERYSILENT','/NORESTART'
         if ($p.ExitCode -ne 0) { throw "uninstaller exited $($p.ExitCode)" }

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -78,6 +78,25 @@ runs:
           if ($bad) { throw $bad }
         }
 
+        function Get-UninstallEntries {
+          $roots = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+                     'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+                     'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
+          return @(foreach ($r in $roots) {
+            if (Test-Path $r) {
+              foreach ($k in Get-ChildItem $r) {
+                # -LiteralPath: a key name containing [ ] would otherwise read as a wildcard and be skipped.
+                $dn = (Get-ItemProperty -LiteralPath $k.PSPath -ErrorAction SilentlyContinue).DisplayName
+                if ($dn -like 'WinHTTrack*') { "$($k.PSChildName) = $dn" }
+              }
+            }
+          })
+        }
+        # The sign job runs both arches on one runner, so start by proving nothing is left
+        # over: otherwise a key orphaned by the previous leg fails THIS one and blames it.
+        $before = Get-UninstallEntries
+        if ($before.Count -ne 0) { throw "$($before.Count) WinHTTrack uninstall entry already present before installing" }
+
         $p = Start-Process $setup.FullName -Wait -PassThru -ArgumentList `
           '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$dir","/LOG=$PWD\install.log"
         if ($p.ExitCode -ne 0) { throw "installer exited $($p.ExitCode)" }
@@ -280,26 +299,16 @@ runs:
           '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/DIR=$dir","/LOG=$PWD\reinstall.log"
         if ($p.ExitCode -ne 0) { throw "installing over the existing copy exited $($p.ExitCode)" }
         if (-not (Test-Path $exe)) { throw "installing over the existing copy removed WinHTTrack.exe" }
-        $p = Start-Process $exe -ArgumentList '--version' -Wait -PassThru -NoNewWindow
+        $vo = "$PWD\overversion.txt"
+        $p = Start-Process $exe -ArgumentList '--version' -Wait -PassThru -NoNewWindow -RedirectStandardOutput $vo
         if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe exited $($p.ExitCode) after installing over" }
+        if ((Get-Content $vo -Raw) -notmatch [regex]::Escape($env:APPVER)) {
+          throw "after installing over, WinHTTrack.exe does not report $env:APPVER"
+        }
 
         # Two entries in Add/Remove Programs is the failure, and exit 0 cannot see it.
         # x86 installs land under WOW6432Node, x64 under the native view; HKCU is listed
         # for completeness though PrivilegesRequired=admin means Inno never falls back to it.
-        function Get-UninstallEntries {
-          $roots = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
-                     'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
-                     'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
-          return @(foreach ($r in $roots) {
-            if (Test-Path $r) {
-              foreach ($k in Get-ChildItem $r) {
-                # -LiteralPath: a key name containing [ ] would otherwise read as a wildcard and be skipped.
-                $dn = (Get-ItemProperty -LiteralPath $k.PSPath -ErrorAction SilentlyContinue).DisplayName
-                if ($dn -like 'WinHTTrack*') { "$($k.PSChildName) = $dn" }
-              }
-            }
-          })
-        }
         $entries = Get-UninstallEntries
         foreach ($e in $entries) { Write-Host "  uninstall entry: $e" }
         if ($entries.Count -ne 1) {

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -284,17 +284,23 @@ runs:
         if ($p.ExitCode -ne 0) { throw "WinHTTrack.exe exited $($p.ExitCode) after installing over" }
 
         # Two entries in Add/Remove Programs is the failure, and exit 0 cannot see it.
-        $roots = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
-                   'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
-                   'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
-        $entries = @(foreach ($r in $roots) {
-          if (Test-Path $r) {
-            foreach ($k in Get-ChildItem $r) {
-              $dn = (Get-ItemProperty $k.PSPath -ErrorAction SilentlyContinue).DisplayName
-              if ($dn -like 'WinHTTrack*') { "$($k.PSChildName) = $dn" }
+        # x86 installs land under WOW6432Node, x64 under the native view; HKCU is listed
+        # for completeness though PrivilegesRequired=admin means Inno never falls back to it.
+        function Get-UninstallEntries {
+          $roots = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+                     'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+                     'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
+          return @(foreach ($r in $roots) {
+            if (Test-Path $r) {
+              foreach ($k in Get-ChildItem $r) {
+                # -LiteralPath: a key name containing [ ] would otherwise read as a wildcard and be skipped.
+                $dn = (Get-ItemProperty -LiteralPath $k.PSPath -ErrorAction SilentlyContinue).DisplayName
+                if ($dn -like 'WinHTTrack*') { "$($k.PSChildName) = $dn" }
+              }
             }
-          }
-        })
+          })
+        }
+        $entries = Get-UninstallEntries
         foreach ($e in $entries) { Write-Host "  uninstall entry: $e" }
         if ($entries.Count -ne 1) {
           throw "expected 1 uninstall entry after installing over, found $($entries.Count)"
@@ -306,3 +312,8 @@ runs:
         if ($p.ExitCode -ne 0) { throw "uninstaller exited $($p.ExitCode)" }
         Start-Sleep -Seconds 3
         if (Test-Path $exe) { throw "uninstall left WinHTTrack.exe behind" }
+        # Also the only place the counter above is seen reading anything but 1: a counter that
+        # always answered 1 would satisfy the check after the install and prove nothing.
+        $left = Get-UninstallEntries
+        foreach ($e in $left) { Write-Host "  orphaned entry: $e" }
+        if ($left.Count -ne 0) { throw "uninstall left $($left.Count) entry in Add/Remove Programs" }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -44,11 +44,12 @@ jobs:
         run: |
           python3 - <<'EOF'
           import re, sys
+          # re.I: Inno directive names are case-insensitive, so appid= must trip this too.
           iss = open('InnoSetup/httrack.iss', encoding='latin-1').read()
           bad = []
-          if re.search(r'^\s*AppId\s*=', iss, re.M):
+          if re.search(r'^\s*AppId\s*=', iss, re.M | re.I):
               bad.append('httrack.iss now sets AppId: the upgrade test no longer stands in for a version change')
-          m = re.search(r'^\s*AppName\s*=(.*)$', iss, re.M)
+          m = re.search(r'^\s*AppName\s*=(.*)$', iss, re.M | re.I)
           if not m:
               bad.append('httrack.iss has no AppName')
           elif re.search(r'\d|\{#', m.group(1)):

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -36,6 +36,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The install-over-previous smoke test re-runs ONE installer, which only stands in for
+      # an upgrade while the installer's identity carries no version. Assert that here, or the
+      # day someone templates a version into AppName the smoke test keeps passing and real
+      # upgrades start installing side by side.
+      - name: Installer identity carries no version
+        run: |
+          python3 - <<'EOF'
+          import re, sys
+          iss = open('InnoSetup/httrack.iss', encoding='latin-1').read()
+          bad = []
+          if re.search(r'^\s*AppId\s*=', iss, re.M):
+              bad.append('httrack.iss now sets AppId: the upgrade test no longer stands in for a version change')
+          m = re.search(r'^\s*AppName\s*=(.*)$', iss, re.M)
+          if not m:
+              bad.append('httrack.iss has no AppName')
+          elif re.search(r'\d|\{#', m.group(1)):
+              bad.append('AppName %r carries a version: upgrades would install side by side' % m.group(1).strip())
+          if bad:
+              sys.exit('\n'.join(bad))
+          print('installer identity is version-free:%s' % m.group(1))
+          EOF
       # Byte-exact on purpose: sources are UTF-8, the .rc/tooling inputs stay
       # Latin-1, and a shell guard can't tell them apart. Python decodes strictly.
       - name: Encoding and line endings


### PR DESCRIPTION
CI only ever installed onto a clean runner, so an upgrade that laid a second installation beside the first would have passed everything we have. `exit 0` cannot see that failure either, since it shows up as two entries in Add/Remove Programs, so the test counts them.

Re-running a single installer only stands in for a real version change while the installer identity carries no version. That premise is now asserted in the `encoding` job rather than assumed, because otherwise the proxy goes vacuous precisely when the bug appears: templating a version into `AppName` would keep this test passing while real upgrades started installing side by side.

Touches signing-privileged paths (`.github/workflows/**`, `.github/actions/**`). No network, no secret, no `environment:` change.