### PR TITLE
Crash reports name the engine version, not the build that crashed

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -272,6 +272,10 @@ runs:
         if ("$so" -notmatch 'wizard scopes ok on 2 checks') {
           throw "selftest did not check the wizard host scopes"
         }
+        # A crash report names the build that crashed; nothing else in CI reads that header.
+        if ("$so" -notmatch 'crash report header ok on 3 checks') {
+          throw "selftest did not check the crash report header"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -45,10 +45,16 @@ Please visit our Website: http://www.httrack.com
 
 #include "htsglobal.h"
 
+#include "version.h"
 #include "SignatureCheck.h"
 
 /* Defined in WinHTTrack.cpp; set by --selftest. */
 extern int WhttSelfTest;
+
+/* The GUI ships ahead of the engine, so naming only the engine version points a report at the wrong tree; both matter. */
+const char *CrashReportHeader(void) {
+  return "WinHTTrack " WINHTTRACK_VERSION " (" WHTT_ARCH ", engine " HTTRACK_VERSIONID ")";
+}
 
 /* A report from a repackaged build has to say so: it redirects the investigation, and
    the reporter has no way of knowing it. */
@@ -372,24 +378,18 @@ static LONG CALLBACK FirstChanceHandler(PEXCEPTION_POINTERS ptrs) {
   return EXCEPTION_CONTINUE_SEARCH;
 }
 
-// An exception MFC caught and handled: log where it came from, no dialog, keep running.
-void CrashReportLogException(const char* msg) {
-  static char buffer[8192];
+// Append one entry to %TEMP%\WinHTTrack-exception.txt; trace may be NULL. Uses no dbghelp,
+// so the stack-overflow path can call it on what stack it has left.
+static void AppendExceptionReport(const char *const event, const char *const msg,
+                                  const char *const trace, const BOOL thrown) {
   const size_t filename_max = 32;
   CHAR path[MAX_PATH + 1 + filename_max];
-  char *trace = NULL;
 
-  const BOOL thrown = ThrowStackCount != 0;
-  if (PrintStack(buffer, sizeof(buffer),
-                 thrown ? ThrowStack : NULL, ThrowStackCount)) {
-    trace = buffer;
-  }
-  ThrowStackCount = 0;    // consumed; never blame a later exception on this one
   if (GetTempPath(sizeof(path) - filename_max, path) != 0) {
     FILE *fp;
     strcat(path, "WinHTTrack-exception.txt");
     if ((fp = fopen(path, "ab")) != NULL) {
-      fprintf(fp, "HTTrack " HTTRACK_VERSIONID " caught: %s\r\n",
+      fprintf(fp, "%s %s: %s\r\n", CrashReportHeader(), event,
               msg != NULL ? msg : "(no description)");
       ReportBuild(fp);
       if (trace != NULL) {
@@ -401,6 +401,20 @@ void CrashReportLogException(const char* msg) {
       fclose(fp);
     }
   }
+}
+
+// An exception MFC caught and handled: log where it came from, no dialog, keep running.
+void CrashReportLogException(const char* msg) {
+  static char buffer[8192];
+  char *trace = NULL;
+
+  const BOOL thrown = ThrowStackCount != 0;
+  if (PrintStack(buffer, sizeof(buffer),
+                 thrown ? ThrowStack : NULL, ThrowStackCount)) {
+    trace = buffer;
+  }
+  ThrowStackCount = 0;    // consumed; never blame a later exception on this one
+  AppendExceptionReport("caught", msg, trace, thrown);
 }
 
 void CrashReportReportEx(const char* msg, const char* file, int line, const char *trace) {
@@ -420,7 +434,7 @@ void CrashReportReportEx(const char* msg, const char* file, int line, const char
     FILE *fp;
     strcat(path, "CRASH.TXT");
     if ((fp = fopen(path, "wb")) != NULL) {
-      fprintf(fp, "HTTrack " HTTRACK_VERSIONID " closed at '%s', line %d\r\n",
+      fprintf(fp, "%s closed at '%s', line %d\r\n", CrashReportHeader(),
         file, line);
       fprintf(fp, "Reason: %s\r\n", msg);
       ReportBuild(fp);
@@ -456,7 +470,17 @@ void CrashReportReport(const char* msg, const char* file, int line) {
 }
 
 static LONG WINAPI GlobalExceptionHandler(PEXCEPTION_POINTERS pExceptPtrs) {
-  switch(pExceptPtrs->ExceptionRecord->ExceptionCode) {
+  const EXCEPTION_RECORD *const record = pExceptPtrs->ExceptionRecord;
+  char msg[128];
+
+  // Which fault, and where: the record is all a top-level filter is ever told.
+  _snprintf_s(msg, sizeof(msg), _TRUNCATE, "Top-level exception 0x%08lX at 0x%p",
+              (unsigned long) record->ExceptionCode, record->ExceptionAddress);
+  switch(record->ExceptionCode) {
+    case EXCEPTION_STACK_OVERFLOW:
+      // Symbol-walking would re-fault on the exhausted stack: append the record, nothing more.
+      AppendExceptionReport("died on", msg, NULL, FALSE);
+      return EXCEPTION_CONTINUE_SEARCH;
     case EXCEPTION_ACCESS_VIOLATION:
     case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
     case EXCEPTION_DATATYPE_MISALIGNMENT:
@@ -464,13 +488,10 @@ static LONG WINAPI GlobalExceptionHandler(PEXCEPTION_POINTERS pExceptPtrs) {
     case EXCEPTION_IN_PAGE_ERROR:
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
     case EXCEPTION_PRIV_INSTRUCTION:
-    case EXCEPTION_STACK_OVERFLOW:
-      CrashReportReport("Top-level exception caught", "unknown", 0);
+      CrashReportReport(msg, "unknown", 0);
       return EXCEPTION_CONTINUE_SEARCH;
-      break;
     default:
       return EXCEPTION_CONTINUE_SEARCH;
-      break;
   }
 }
 

--- a/WinHTTrack/CrashReport.cpp
+++ b/WinHTTrack/CrashReport.cpp
@@ -46,10 +46,20 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 
 #include "version.h"
+#include "CrashReport.h"
 #include "SignatureCheck.h"
 
 /* Defined in WinHTTrack.cpp; set by --selftest. */
 extern int WhttSelfTest;
+
+/* Named in every report, so an x86 report is not read as an x64 one. */
+#if defined(_M_X64)
+#define WHTT_ARCH "x64"
+#elif defined(_M_IX86)
+#define WHTT_ARCH "x86"
+#else
+#define WHTT_ARCH "unknown"
+#endif
 
 /* The GUI ships ahead of the engine, so naming only the engine version points a report at the wrong tree; both matter. */
 const char *CrashReportHeader(void) {
@@ -469,17 +479,24 @@ void CrashReportReport(const char* msg, const char* file, int line) {
   CrashReportReportEx(msg, file, line, trace);
 }
 
-static LONG WINAPI GlobalExceptionHandler(PEXCEPTION_POINTERS pExceptPtrs) {
-  const EXCEPTION_RECORD *const record = pExceptPtrs->ExceptionRecord;
-  char msg[128];
+// Which fault, and where: the record is all a top-level filter is ever told. The buffer is
+// static so the stack-overflow path spends none of the stack it has left on it.
+static const char *ExceptionLine(const EXCEPTION_RECORD *const record) {
+  static char msg[80];
 
-  // Which fault, and where: the record is all a top-level filter is ever told.
   _snprintf_s(msg, sizeof(msg), _TRUNCATE, "Top-level exception 0x%08lX at 0x%p",
               (unsigned long) record->ExceptionCode, record->ExceptionAddress);
+  return msg;
+}
+
+static LONG WINAPI GlobalExceptionHandler(PEXCEPTION_POINTERS pExceptPtrs) {
+  const EXCEPTION_RECORD *const record = pExceptPtrs->ExceptionRecord;
+
   switch(record->ExceptionCode) {
     case EXCEPTION_STACK_OVERFLOW:
-      // Symbol-walking would re-fault on the exhausted stack: append the record, nothing more.
-      AppendExceptionReport("died on", msg, NULL, FALSE);
+      // Symbol-walking would re-fault on the stack that has just run out. Only the record is
+      // written: this path raises no dialog and writes no CRASH.TXT.
+      AppendExceptionReport("died on", ExceptionLine(record), NULL, FALSE);
       return EXCEPTION_CONTINUE_SEARCH;
     case EXCEPTION_ACCESS_VIOLATION:
     case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
@@ -488,7 +505,7 @@ static LONG WINAPI GlobalExceptionHandler(PEXCEPTION_POINTERS pExceptPtrs) {
     case EXCEPTION_IN_PAGE_ERROR:
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
     case EXCEPTION_PRIV_INSTRUCTION:
-      CrashReportReport(msg, "unknown", 0);
+      CrashReportReport(ExceptionLine(record), "unknown", 0);
       return EXCEPTION_CONTINUE_SEARCH;
     default:
       return EXCEPTION_CONTINUE_SEARCH;

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -31,16 +31,7 @@ Please visit our Website: http://www.httrack.com
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
-// Architecture the reports name, so an x86 report is not read as the x64 one.
-#if defined(_M_X64)
-#define WHTT_ARCH "x64"
-#elif defined(_M_IX86)
-#define WHTT_ARCH "x86"
-#else
-#define WHTT_ARCH "unknown"
-#endif
-
-// The line every report opens with: the GUI build, then the engine version apart from it.
+// The line every report opens with: the GUI version and architecture, then the engine's.
 const char *CrashReportHeader(void);
 
 // Initialize crash reporter.

--- a/WinHTTrack/CrashReport.h
+++ b/WinHTTrack/CrashReport.h
@@ -31,6 +31,18 @@ Please visit our Website: http://www.httrack.com
 /* Author: Xavier Roche                                         */
 /* ------------------------------------------------------------ */
 
+// Architecture the reports name, so an x86 report is not read as the x64 one.
+#if defined(_M_X64)
+#define WHTT_ARCH "x64"
+#elif defined(_M_IX86)
+#define WHTT_ARCH "x86"
+#else
+#define WHTT_ARCH "unknown"
+#endif
+
+// The line every report opens with: the GUI build, then the engine version apart from it.
+const char *CrashReportHeader(void);
+
 // Initialize crash reporter.
 void CrashReportInit(void);
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1007,6 +1007,30 @@ BOOL CWinHTTrackApp::InitInstance()
       QLANG_T(saved);
       LANG_LOAD(NULL, 0);
     }
+    /* A bug report's only statement of what crashed, and nothing else here can see it. */
+    {
+      const char *const header = CrashReportHeader();
+      static const char *const want[] = {
+        "WinHTTrack ", WINHTTRACK_VERSION, WHTT_ARCH, "engine ", HTTRACK_VERSIONID, NULL
+      };
+      int nchecks = 0;
+      for(int k=0 ; want[k] != NULL ; k++) {
+        if (strstr(header, want[k]) == NULL) {
+          fprintf(stderr, "FATAL: crash report header '%s' does not name '%s'\n", header, want[k]);
+          fflush(stderr);
+          ExitProcess(7);
+        } else
+          nchecks++;
+      }
+      /* The GUI version is the subject and the engine's the labelled aside, not the reverse. */
+      if (strstr(header, WINHTTRACK_VERSION) > strstr(header, "engine ")) {
+        fprintf(stderr, "FATAL: crash report header '%s' leads with the engine version\n", header);
+        fflush(stderr);
+        ExitProcess(7);
+      } else
+        nchecks++;
+      printf("crash report header ok on %d checks\n", nchecks);
+    }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking
        report that names nothing. Only throwing proves the chain resolves. */
@@ -1019,7 +1043,8 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       CrashReportLogException(reason);
     } END_CATCH_ALL
-    printf("WinHTTrack %s: startup ok\n", WINHTTRACK_VERSION);
+    /* Through the reporter's own header, so the line CI pins runs it. */
+    printf("%s: startup ok\n", CrashReportHeader());
     fflush(stdout);
     ExitProcess(0);
   }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1007,28 +1007,43 @@ BOOL CWinHTTrackApp::InitInstance()
       QLANG_T(saved);
       LANG_LOAD(NULL, 0);
     }
-    /* A bug report's only statement of what crashed, and nothing else here can see it. */
+    /* The header is a bug report's only statement of what crashed, and no other check sees it. */
     {
+      static const char lead[] = "WinHTTrack " WINHTTRACK_VERSION " (";
       const char *const header = CrashReportHeader();
-      static const char *const want[] = {
-        "WinHTTrack ", WINHTTRACK_VERSION, WHTT_ARCH, "engine ", HTTRACK_VERSIONID, NULL
-      };
+      /* From sizeof(void*), not from the macro the header is built from: a compiler ladder
+         that mis-fires prints "unknown" on both builds, and only an outside oracle sees it. */
+      const char *const arch = (sizeof(void*) == 8) ? "x64" : "x86";
+      const size_t archlen = strlen(arch);
       int nchecks = 0;
-      for(int k=0 ; want[k] != NULL ; k++) {
-        if (strstr(header, want[k]) == NULL) {
-          fprintf(stderr, "FATAL: crash report header '%s' does not name '%s'\n", header, want[k]);
-          fflush(stderr);
-          ExitProcess(7);
-        } else
-          nchecks++;
-      }
-      /* The GUI version is the subject and the engine's the labelled aside, not the reverse. */
-      if (strstr(header, WINHTTRACK_VERSION) > strstr(header, "engine ")) {
-        fprintf(stderr, "FATAL: crash report header '%s' leads with the engine version\n", header);
+
+      /* Anchored, not searched: the engine reaching 3.50.x makes its version a substring
+         of ours, and a search would then take either version for the other. */
+      if (strncmp(header, lead, sizeof(lead) - 1) != 0) {
+        fprintf(stderr, "FATAL: crash report header '%s' does not open with '%s'\n", header, lead);
         fflush(stderr);
-        ExitProcess(7);
+        ExitProcess(3);
       } else
         nchecks++;
+      if (strncmp(header + sizeof(lead) - 1, arch, archlen) != 0) {
+        fprintf(stderr, "FATAL: crash report header '%s' does not name the %s build\n", header, arch);
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+      if (strcmp(header + sizeof(lead) - 1 + archlen, ", engine " HTTRACK_VERSIONID ")") != 0) {
+        fprintf(stderr, "FATAL: crash report header '%s' does not end on engine "
+                HTTRACK_VERSIONID "\n", header);
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+      /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
+      if (nchecks != 3) {
+        fprintf(stderr, "FATAL: crash report header ran %d checks, expected 3\n", nchecks);
+        fflush(stderr);
+        ExitProcess(3);
+      }
       printf("crash report header ok on %d checks\n", nchecks);
     }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
@@ -1043,7 +1058,7 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       CrashReportLogException(reason);
     } END_CATCH_ALL
-    /* Through the reporter's own header, so the line CI pins runs it. */
+    /* Printed through the reporter's own header, so the line CI checks exercises it. */
     printf("%s: startup ok\n", CrashReportHeader());
     fflush(stdout);
     ExitProcess(0);


### PR DESCRIPTION
Crash reports were headed with the engine version, so a crash in the 3.50 GUI read as "HTTrack 3.49.23"; they now open with a shared header carrying the GUI version, the architecture and the engine version, and the top-level handler records the exception code and faulting address it used to discard. A stack overflow no longer goes into the dbghelp symbol walk, which re-faults on the stack that has just run out. `--selftest` pins the header so it cannot quietly go back to the engine's.

Deliberate removal, worth knowing about: a stack overflow now leaves one line in the exception log and nothing else. The CRASH.TXT file, the stack trace and the message box are gone from that path.

Known follow-up, not fixed here: that one line still goes out through fopen/fprintf, which allocate. An overflow raised inside the allocator leaves the heap lock held mid-unlink, and the filter re-enters the same heap on the same thread. Master is worse in the same way and adds dbghelp and a message box on top, so this narrows the window rather than opening it; the fix is CreateFileA(FILE_APPEND_DATA) with WriteFile and a hand-rolled formatter, on the overflow case only.
