### PR TITLE
Radio groups with no tab stop leave two dialogs mouse-only

### DIFF
--- a/WinHTTrack/WinHTTrack.rc
+++ b/WinHTTrack/WinHTTrack.rc
@@ -186,7 +186,7 @@ FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     GROUPBOX        "",IDC_STATIC_connect,7,6,242,158
     CONTROL         "Please adjust connection parameters if necessary,\nthen press FINISH to launch the mirroring operation.",IDC_select_start,
-                    "Button",BS_AUTORADIOBUTTON | BS_MULTILINE,12,16,233,23
+                    "Button",BS_AUTORADIOBUTTON | BS_MULTILINE | WS_GROUP | WS_TABSTOP,12,16,233,23
     GROUPBOX        "Remote connect",IDC_STATIC_ras,20,42,225,70
     LTEXT           "Connect to this provider",IDC_cnx,25,51,215,8,WS_DISABLED
     COMBOBOX        IDC_rasid,25,63,215,64,CBS_DROPDOWNLIST | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
@@ -199,7 +199,7 @@ BEGIN
     EDITTEXT        IDC_ss,60,143,16,12,ES_AUTOHSCROLL | ES_NUMBER
     GROUPBOX        "",IDC_STATIC_save,7,167,242,31
     CONTROL         "Save settings only, do not launch download now.",IDC_select_save,
-                    "Button",BS_AUTORADIOBUTTON | BS_MULTILINE,12,174,233,20
+                    "Button",BS_AUTORADIOBUTTON | BS_MULTILINE | WS_TABSTOP,12,174,233,20
 END
 
 IDD_wizard DIALOG  0, 0, 190, 98
@@ -327,7 +327,7 @@ FONT 8, "MS Sans Serif"
 BEGIN
     EDITTEXT        IDC_URL,7,7,306,32,ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | WS_VSCROLL | NOT WS_TABSTOP
     GROUPBOX        "Choose a rule",IDC_STATIC_rule,7,46,306,76
-    CONTROL         "Ignore this link",IDC_ch1,"Button",BS_AUTORADIOBUTTON | WS_GROUP,14,58,140,10
+    CONTROL         "Ignore this link",IDC_ch1,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,14,58,140,10
     CONTROL         "Ignore links in this subdir",IDC_ch2,"Button",BS_AUTORADIOBUTTON,14,70,140,10
     CONTROL         "Ignore all domain",IDC_ch3,"Button",BS_AUTORADIOBUTTON,14,82,140,10
     CONTROL         "Get this page only",IDC_ch4,"Button",BS_AUTORADIOBUTTON,162,58,145,10
@@ -468,7 +468,7 @@ FONT 8, "MS Sans Serif"
 BEGIN
     EDITTEXT        IDC_urladr,105,8,141,12,ES_AUTOHSCROLL
     EDITTEXT        IDC_urllogin,106,43,56,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_urlpass,106,59,56,12,ES_AUTOHSCROLL
+    EDITTEXT        IDC_urlpass,106,59,56,12,ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON      "Capture URL...",ID_capt,164,85,95,14
     PUSHBUTTON      "Cancel",IDCANCEL,7,121,50,14
     DEFPUSHBUTTON   "OK",IDOK,209,121,50,14


### PR DESCRIPTION
The eight rule radios on the "Link detected" dialog and the two choices on the wizard's last page have no WS_TABSTOP, so the dialog manager never lets focus into either group and both decisions are mouse-only, including "Save settings only, do not launch download now". IDD_wizard_lnk was already bracketed properly and needed the tab stop on its first radio; IDD_Debut's two radios sit at opposite ends of the page with a combo and three arrow-eating edits between them, so the group is marked at IDC_select_start and both radios get a tab stop. Insert URL's password box also gains the `ES_PASSWORD` that the proxy dialog already carries.

Only style tokens change, and undoing them reproduces the file byte for byte, so the screenshot walk covers the layout; the keyboard behaviour itself still needs a VM pass.