### PR TITLE
Bound the New Folder copies, unreachable today but one edit from live

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -272,6 +272,10 @@ runs:
         if ("$so" -notmatch 'wizard scopes ok on 2 checks') {
           throw "selftest did not check the wizard host scopes"
         }
+        # The New Folder dialog cannot be opened from here, so its length rules are pinned instead.
+        if ("$so" -notmatch 'folder names ok on 7 checks') {
+          throw "selftest did not check the New Folder name lengths"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/NewFolder.cpp
+++ b/WinHTTrack/NewFolder.cpp
@@ -72,7 +72,7 @@ END_MESSAGE_MAP()
 BOOL CNewFolder::OnInitDialog()
 {
 	CDialog::OnInitDialog();
-  // the caller copies the result into a MAX_PATH buffer, and overflow there aborts
+  // the caller copies the result into a MAX_PATH buffer
   GetDlgItem(IDC_Folder)->SendMessage(EM_SETLIMITTEXT, MAX_PATH - 1, 0);
 	return TRUE;  // return TRUE unless you set the focus to a control
 }

--- a/WinHTTrack/NewFolder.cpp
+++ b/WinHTTrack/NewFolder.cpp
@@ -68,3 +68,11 @@ END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
 // CNewFolder message handlers
+
+BOOL CNewFolder::OnInitDialog()
+{
+	CDialog::OnInitDialog();
+  // the caller copies the result into a MAX_PATH buffer, and overflow there aborts
+  GetDlgItem(IDC_Folder)->SendMessage(EM_SETLIMITTEXT, MAX_PATH - 1, 0);
+	return TRUE;  // return TRUE unless you set the focus to a control
+}

--- a/WinHTTrack/NewFolder.cpp
+++ b/WinHTTrack/NewFolder.cpp
@@ -72,7 +72,7 @@ END_MESSAGE_MAP()
 BOOL CNewFolder::OnInitDialog()
 {
 	CDialog::OnInitDialog();
-  // the caller copies the result into a MAX_PATH buffer
-  GetDlgItem(IDC_Folder)->SendMessage(EM_SETLIMITTEXT, MAX_PATH - 1, 0);
-	return TRUE;  // return TRUE unless you set the focus to a control
+	// the caller copies the result into a MAX_PATH buffer
+	GetDlgItem(IDC_Folder)->SendMessage(EM_SETLIMITTEXT, MAX_PATH - 1, 0);
+	return TRUE;
 }

--- a/WinHTTrack/NewFolder.h
+++ b/WinHTTrack/NewFolder.h
@@ -61,7 +61,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CNewFolder)
-		// NOTE: the ClassWizard will add member functions here
+	virtual BOOL OnInitDialog();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -84,6 +84,7 @@ static char THIS_FILE[] = __FILE__;
 #include "wizard.h"
 #include "wizard2.h"
 #include "WizLinks.h"
+#include "XSHBrowseForFolder.h"
 
 
 extern Wid1* dialog1;
@@ -760,6 +761,41 @@ BOOL CWinHTTrackApp::InitInstance()
       } else
         nchecks++;
       printf("wizard scopes ok on %d checks\n", nchecks);
+    }
+    /* The New Folder button is one restored block away from being live again, and these
+       two decisions are the whole of what keeps its copies inside MAX_PATH. */
+    {
+      static const struct { const char* tail; int repeat; BOOL fits; BOOL sep; } names[] = {
+        { "", 0, TRUE, FALSE },                 /* nothing to make a prefix of */
+        { "", 1, TRUE, TRUE },
+        { "\\", 1, TRUE, FALSE },               /* already a prefix */
+        { "", MAX_PATH - 2, TRUE, TRUE },       /* the widest name that can still take one */
+        { "", MAX_PATH - 1, TRUE, FALSE },      /* copyable, one byte short of taking one */
+        { "\\", MAX_PATH - 2, TRUE, FALSE },    /* the same width, but needing no separator */
+        { "", MAX_PATH, FALSE, FALSE },         /* one over the buffer */
+        { NULL, 0, FALSE, FALSE }
+      };
+      int nchecks = 0;
+      for(int k=0 ; names[k].tail != NULL ; k++) {
+        CString name('x', names[k].repeat);
+        bool fits, sep;
+
+        name += names[k].tail;
+        fits = XSHBFF_NameOk(name, XSHBFF_FitsPath);
+        sep = XSHBFF_NameOk(name, XSHBFF_NeedsSeparator);
+        if (fits != (names[k].fits != 0) || sep != (names[k].sep != 0)) {
+          fprintf(stderr, "FATAL: a folder name of %d chars fits=%d needs-separator=%d, expected %d and %d\n",
+                  (int) name.GetLength(), (int) fits, (int) sep, (int) names[k].fits, (int) names[k].sep);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* Instantiated so the compiler checks it: it is the only correct way to send SETSTRING,
+         and nothing calls it while the dialog stays unreachable. */
+      static char probe[MAX_PATH];
+      XSHBFF_SetDirectReturn(NULL, probe);
+      printf("folder names ok on %d checks\n", nchecks);
     }
     /* Only reachable by opening the Browser ID page, so pin the presets here: a
        stray %s or a misspelt {field} would reach every mirrored page. */

--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -55,6 +55,7 @@ Please visit our Website: http://www.httrack.com
 #include "stdafx.h"
 #include "shlobj.h"
 #include "XSHBrowseForFolder.h"
+#include "htssafe.h"
 
 // our button ID
 int XSHBFF_button1 = -1;
@@ -103,7 +104,7 @@ CString XSHBrowseForFolder(HWND hwnd,const char* title,char* _path) {
         if (SHGetPathFromIDList(UserList,path)==FALSE)
           path[0]='\0';
       } else
-        strcpy(path,Thispath);
+        strcpybuff(path,Thispath);
       Mymal->Free(UserList);
     }
     if (MyItemlist) Mymal->Free(MyItemlist);
@@ -119,6 +120,7 @@ typedef LRESULT (__stdcall * XSHBFF_WndProc_type)(HWND ,UINT ,WPARAM ,LPARAM);
 LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam) {
   static char StringSelection[MAX_PATH]="";
   static char* DirectReturnValue=NULL;
+  static size_t DirectReturnSize=0;
   static XSHBFF_WndProc_type Ladr=DefDlgProc;
   int wNotifyCode = HIWORD(wParam);  // notification code 
   int wID = LOWORD(wParam);          // item, control, or accelerator identifier 
@@ -129,11 +131,12 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
       if (strlen(StringSelection)>0) {  // there is a selection
         CNewFolder f;
         f.m_folder=StringSelection;
-        if (StringSelection[strlen(StringSelection)-1]!='\\')
+        // a selection already filling the buffer leaves no room for the separator
+        if (StringSelection[strlen(StringSelection)-1]!='\\' && strlen(StringSelection)<sizeof(StringSelection)-1)
           f.m_folder+="\\";  // add a /
         if (f.DoModal()==IDOK) {
           char st[MAX_PATH];
-          strcpy(st,f.m_folder);
+          strcpybuff(st,f.m_folder);   // CNewFolder caps the edit box to fit
           // Remove the last slash bar
           if (strlen(st)>0)
           if (st[strlen(st)-1]=='\\')
@@ -142,8 +145,8 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
           if (_mkdir(st))              // error
             AfxMessageBox("Folder already exists, or can not be created",MB_OK+MB_ICONEXCLAMATION);
           else {    // Select the new path
-            if (DirectReturnValue) {
-              strcpy(DirectReturnValue,st);
+            if (DirectReturnValue && DirectReturnSize) {
+              strlcpybuff(DirectReturnValue,st,DirectReturnSize);
               wParam = (wParam & 0xFFFF0000) | XSHBrowseForFolder_OK;    // 'OK'
               return Ladr(hwnd,uMsg,wParam,lParam); // former window routine
             }
@@ -157,6 +160,7 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
     }
   } else if (uMsg==XSHBrowseForFolder_SETSTRING) {  // received from our XSHBFF_CallbackProc routine
     DirectReturnValue=(char*) lParam;
+    DirectReturnSize=(size_t) wParam;
     return 0;
   } else if (uMsg==XSHBrowseForFolder_SETSTRING+1) {
     Ladr = (XSHBFF_WndProc_type) lParam;  // store former address

--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -116,11 +116,23 @@ CString XSHBrowseForFolder(HWND hwnd,const char* title,char* _path) {
 // XSHBFF_WndProc function type 
 typedef LRESULT (__stdcall * XSHBFF_WndProc_type)(HWND ,UINT ,WPARAM ,LPARAM);
 
+// Both length decisions about a folder name; the contract is in XSHBrowseForFolder.h
+bool XSHBFF_NameOk(const char* name, XSHBFF_Question q) {
+  const size_t len = strlen(name);
+
+  if (q == XSHBFF_FitsPath)
+    return len < MAX_PATH;
+  // one byte less, to hold the separator; a name already ending in one needs none
+  return len != 0 && name[len - 1] != '\\' && len < MAX_PATH - 1;
+}
+
+// The destination for the created folder: pointer and capacity, so neither can go stale alone.
+struct XSHBFF_DirectReturn { char* buf; size_t size; };
+
 // Window Routine
 LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam) {
   static char StringSelection[MAX_PATH]="";
-  static char* DirectReturnValue=NULL;
-  static size_t DirectReturnSize=0;
+  static XSHBFF_DirectReturn DirectReturn={NULL,0};
   static XSHBFF_WndProc_type Ladr=DefDlgProc;
   int wNotifyCode = HIWORD(wParam);  // notification code 
   int wID = LOWORD(wParam);          // item, control, or accelerator identifier 
@@ -131,13 +143,12 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
       if (strlen(StringSelection)>0) {  // there is a selection
         CNewFolder f;
         f.m_folder=StringSelection;
-        // a selection already filling the buffer leaves no room for the separator
-        if (StringSelection[strlen(StringSelection)-1]!='\\' && strlen(StringSelection)<sizeof(StringSelection)-1)
+        if (XSHBFF_NameOk(StringSelection,XSHBFF_NeedsSeparator))
           f.m_folder+="\\";  // add a /
         if (f.DoModal()==IDOK) {
           char st[MAX_PATH];
-          // the control's limit counts TCHARs, which a DBCS codepage can turn into more bytes
-          if (f.m_folder.GetLength() >= (int) sizeof(st)) {
+          // the control's limit counts TCHARs, which a double-byte codepage can turn into more bytes
+          if (!XSHBFF_NameOk(f.m_folder,XSHBFF_FitsPath)) {
             AfxMessageBox("Folder name is too long",MB_OK+MB_ICONEXCLAMATION);
             return 0;
           }
@@ -150,9 +161,9 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
           if (_mkdir(st))              // error
             AfxMessageBox("Folder already exists, or can not be created",MB_OK+MB_ICONEXCLAMATION);
           else {    // Select the new path
-            if (DirectReturnValue) {
-              assertf(DirectReturnSize != 0);
-              strlcpybuff(DirectReturnValue,st,DirectReturnSize);
+            // no destination, or one whose capacity never arrived: refuse, and stay open
+            if (DirectReturn.buf!=NULL && DirectReturn.size!=0) {
+              strlcpybuff(DirectReturn.buf,st,DirectReturn.size);
               wParam = (wParam & 0xFFFF0000) | XSHBrowseForFolder_OK;    // 'OK'
               return Ladr(hwnd,uMsg,wParam,lParam); // former window routine
             }
@@ -165,8 +176,8 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
       return Ladr(hwnd,uMsg,wParam,lParam); // former window routine
     }
   } else if (uMsg==XSHBrowseForFolder_SETSTRING) {  // received from our XSHBFF_CallbackProc routine
-    DirectReturnValue=(char*) lParam;
-    DirectReturnSize=(size_t) wParam;
+    const XSHBFF_DirectReturn set={(char*) lParam,(size_t) wParam};
+    DirectReturn=set;
     return 0;
   } else if (uMsg==XSHBrowseForFolder_SETSTRING+1) {
     Ladr = (XSHBFF_WndProc_type) lParam;  // store former address

--- a/WinHTTrack/XSHBrowseForFolder.cpp
+++ b/WinHTTrack/XSHBrowseForFolder.cpp
@@ -136,7 +136,12 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
           f.m_folder+="\\";  // add a /
         if (f.DoModal()==IDOK) {
           char st[MAX_PATH];
-          strcpybuff(st,f.m_folder);   // CNewFolder caps the edit box to fit
+          // the control's limit counts TCHARs, which a DBCS codepage can turn into more bytes
+          if (f.m_folder.GetLength() >= (int) sizeof(st)) {
+            AfxMessageBox("Folder name is too long",MB_OK+MB_ICONEXCLAMATION);
+            return 0;
+          }
+          strcpybuff(st,f.m_folder);
           // Remove the last slash bar
           if (strlen(st)>0)
           if (st[strlen(st)-1]=='\\')
@@ -145,7 +150,8 @@ LRESULT __stdcall XSHBFF_WndProc(HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam
           if (_mkdir(st))              // error
             AfxMessageBox("Folder already exists, or can not be created",MB_OK+MB_ICONEXCLAMATION);
           else {    // Select the new path
-            if (DirectReturnValue && DirectReturnSize) {
+            if (DirectReturnValue) {
+              assertf(DirectReturnSize != 0);
               strlcpybuff(DirectReturnValue,st,DirectReturnSize);
               wParam = (wParam & 0xFFFF0000) | XSHBrowseForFolder_OK;    // 'OK'
               return Ladr(hwnd,uMsg,wParam,lParam); // former window routine

--- a/WinHTTrack/XSHBrowseForFolder.h
+++ b/WinHTTrack/XSHBrowseForFolder.h
@@ -48,6 +48,7 @@ Please visit our Website: http://www.httrack.com
 #include <direct.h>
 #include "shlobj.h"
 
+// wParam carries the capacity of the lParam buffer, NUL included
 #define XSHBrowseForFolder_SETSTRING 1234
 #define XSHBrowseForFolder_OK 1
 

--- a/WinHTTrack/XSHBrowseForFolder.h
+++ b/WinHTTrack/XSHBrowseForFolder.h
@@ -48,14 +48,30 @@ Please visit our Website: http://www.httrack.com
 #include <direct.h>
 #include "shlobj.h"
 
-// wParam carries the capacity of the lParam buffer, NUL included
+// SETSTRING takes the destination in lParam and its capacity in wParam; send it through
+// XSHBFF_SetDirectReturn() below, never by hand.
 #define XSHBrowseForFolder_SETSTRING 1234
 #define XSHBrowseForFolder_OK 1
+
+/* The two length decisions this dialog makes about a folder name, against the MAX_PATH
+   buffers it copies it through: may it be copied as it stands, and does it still need --
+   and have room for -- the '\' that makes it a directory prefix. That separator costs one
+   byte, so a name of exactly MAX_PATH-1 is copyable but cannot take one.
+   Public only for --selftest. */
+enum XSHBFF_Question { XSHBFF_FitsPath, XSHBFF_NeedsSeparator };
+bool XSHBFF_NameOk(const char* name, XSHBFF_Question q);
 
 CString        XSHBrowseForFolder (HWND hwnd,const char* title,char* _path);
 LRESULT __stdcall XSHBFF_WndProc     (HWND hwnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
 int __stdcall  XSHBFF_CallbackProc(HWND hwnd,UINT uMsg,LPARAM lParam,LPARAM lpData);
 LPITEMIDLIST   XSHBFF_PathConvert (HWND hwnd,char* _path);
+
+/* Name the buffer the created folder is copied back into. The array type carries the
+   capacity, so a caller holding only a char* cannot express the call at all. */
+template<size_t N>
+inline void XSHBFF_SetDirectReturn(HWND hwnd, char (&buf)[N]) {
+  XSHBFF_WndProc(hwnd, XSHBrowseForFolder_SETSTRING, (WPARAM) N, (LPARAM) buf);
+}
 
 #endif
 


### PR DESCRIPTION
None of the "New folder" dialog is reachable in a shipped build: #51 deleted the disabled block that created the button and installed `XSHBFF_WndProc` as the browser's window procedure, and the dialog is opened with `BIF_RETURNONLYFSDIRS` alone, so Windows draws the classic browser that has no "Make New Folder" button. Restoring that one block puts it back, and it would land on a `strcpy` into a 260-byte stack buffer fed by an edit control with no length limit, plus a second `strcpy` into a caller's `char*` whose capacity the function never received. The one copy in this file that does run today, `path` from `Thispath`, is bounded here too.

The control is now capped at `MAX_PATH-1` with the `EM_SETLIMITTEXT` idiom used elsewhere in the GUI, and both copies go through `strcpybuff`/`strlcpybuff`. A byte-length check guards the copy as well, because `EM_SETLIMITTEXT` counts TCHARs: on a double-byte codepage 259 characters can still exceed 259 bytes, and `strcpy_safe_` aborts rather than truncating, so without it this would trade an overflow for a crash.

Both length decisions live in one free `XSHBFF_NameOk()` that `--selftest` exercises at the boundaries, with the count pinned in the smoke test. The destination travels as a pointer/capacity pair set in a single assignment, sent through a typed `XSHBFF_SetDirectReturn()` that a `char*` caller cannot compile against. A capacity that never arrived refuses the copy and leaves the dialog open rather than aborting, which matters because restoring the deleted block verbatim would have sent a literal 0 and died at the first OK click.
