### PR TITLE
Ask the engine to stop when the session ends

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -272,6 +272,10 @@ runs:
         if ("$so" -notmatch 'wizard scopes ok on 2 checks') {
           throw "selftest did not check the wizard host scopes"
         }
+        # No CI can log off, so this count is the only proof the session-end stop ran.
+        if ("$so" -notmatch 'session end ok on 6 checks') {
+          throw "selftest did not check the session-end stop"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -197,19 +197,19 @@ void CMainFrame::OnClose()
   }
 }
 
-/* A logoff or shutdown otherwise kills the engine thread mid-mirror: stop it cleanly
-   first, then let the session end. */
+/* A logoff otherwise kills the engine mid-write. Asked here and not at WM_ENDSESSION
+   because the engine's only unwind time is the rest of the shutdown sequence. */
 BOOL CMainFrame::OnQueryEndSession()
 {
 	const BOOL ending = CMDIFrameWnd::OnQueryEndSession();
 	if (ending)
-		StopMirrorForSessionEnd(m_hWnd, WHTT_ENDSESSION_TIMEOUT_MS);
+		StopMirrorForSessionEnd();
 	return ending;
 }
 
 void CMainFrame::OnEndSession(BOOL bEnding)
 {
 	if (bEnding)
-		StopMirrorForSessionEnd(m_hWnd, WHTT_ENDSESSION_TIMEOUT_MS);   // a forced end skips the query
+		StopMirrorForSessionEnd();   // an end that skipped the query; asking twice is a no-op
 	CMDIFrameWnd::OnEndSession(bEnding);
 }

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -209,7 +209,9 @@ BOOL CMainFrame::OnQueryEndSession()
 
 void CMainFrame::OnEndSession(BOOL bEnding)
 {
+	/* An end that skipped the query. A cancelled one (FALSE) needs no undo: the guard in
+	   StopMirrorForSessionEnd() is per mirror, so it cannot eat the next mirror's ask. */
 	if (bEnding)
-		StopMirrorForSessionEnd();   // an end that skipped the query; asking twice is a no-op
+		StopMirrorForSessionEnd();
 	CMDIFrameWnd::OnEndSession(bEnding);
 }

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -202,16 +202,12 @@ void CMainFrame::OnClose()
 BOOL CMainFrame::OnQueryEndSession()
 {
 	const BOOL ending = CMDIFrameWnd::OnQueryEndSession();
-	if (ending)
-		StopMirrorForSessionEnd();
+	SessionEndStop(ending);
 	return ending;
 }
 
 void CMainFrame::OnEndSession(BOOL bEnding)
 {
-	/* An end that skipped the query. A cancelled one (FALSE) needs no undo: the guard in
-	   StopMirrorForSessionEnd() is per mirror, so it cannot eat the next mirror's ask. */
-	if (bEnding)
-		StopMirrorForSessionEnd();
+	SessionEndStop(bEnding);   /* the end that skipped the query */
 	CMDIFrameWnd::OnEndSession(bEnding);
 }

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -39,6 +39,8 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	//{{AFX_MSG_MAP(CMainFrame)
 	ON_WM_CREATE()
 	ON_WM_CLOSE()
+	ON_WM_QUERYENDSESSION()
+	ON_WM_ENDSESSION()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -193,4 +195,21 @@ void CMainFrame::OnClose()
     if (AfxMessageBox(LANG(LANG_J1),MB_OKCANCEL)==IDOK)
   	  CMDIFrameWnd::OnClose();
   }
+}
+
+/* A logoff or shutdown otherwise kills the engine thread mid-mirror: stop it cleanly
+   first, then let the session end. */
+BOOL CMainFrame::OnQueryEndSession()
+{
+	const BOOL ending = CMDIFrameWnd::OnQueryEndSession();
+	if (ending)
+		StopMirrorForSessionEnd(m_hWnd, WHTT_ENDSESSION_TIMEOUT_MS);
+	return ending;
+}
+
+void CMainFrame::OnEndSession(BOOL bEnding)
+{
+	if (bEnding)
+		StopMirrorForSessionEnd(m_hWnd, WHTT_ENDSESSION_TIMEOUT_MS);   // a forced end skips the query
+	CMDIFrameWnd::OnEndSession(bEnding);
 }

--- a/WinHTTrack/MainFrm.h
+++ b/WinHTTrack/MainFrm.h
@@ -32,6 +32,8 @@ protected:
 	//{{AFX_MSG(CMainFrame)
 	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
 	afx_msg void OnClose();
+	afx_msg BOOL OnQueryEndSession();
+	afx_msg void OnEndSession(BOOL bEnding);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -293,13 +293,11 @@ void RequestMirrorStop() {
 }
 
 /* Ask, and get out of the way: waiting here would mean pumping, and the handlers a pump
-   reaches open modal boxes. Once per process, as a second request aborts abruptly. */
+   reaches open modal boxes. A second ask escalates to an abrupt abort, so guard on
+   soft_term_requested, which init_lance() clears: each mirror gets its own one ask. */
 BOOL StopMirrorForSessionEnd() {
-  static int requested = 0;
-
-  if (requested || global_opt == NULL || termine)
+  if (global_opt == NULL || termine || soft_term_requested)
     return FALSE;
-  requested = 1;
   RequestMirrorStop();
   return TRUE;
 }

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -280,26 +280,30 @@ BOOL LaunchMirror() {
   return 0;
 }
 
-/* The Cancel button's stop, minus its confirmation: a second call turns the engine's
-   soft stop into an immediate one. */
-void RequestMirrorStop() {
+/* The Cancel button's stop, minus its confirmation. */
+WhttMirrorStop RequestMirrorStop() {
   hts_setpause(global_opt, 0);
-  if (soft_term_requested)
+  if (soft_term_requested) {
     termine_requested=1;
-  else {
-    soft_term_requested=1;
-    hts_request_stop(global_opt, 0);
+    return WHTT_STOP_ABORTED;
   }
+  soft_term_requested=1;
+  hts_request_stop(global_opt, 0);
+  return WHTT_STOP_ASKED;
 }
 
-/* Ask, and get out of the way: waiting here would mean pumping, and the handlers a pump
-   reaches open modal boxes. A second ask escalates to an abrupt abort, so guard on
-   soft_term_requested, which init_lance() clears: each mirror gets its own one ask. */
-BOOL StopMirrorForSessionEnd() {
-  if (global_opt == NULL || termine || soft_term_requested)
-    return FALSE;
-  RequestMirrorStop();
-  return TRUE;
+/* No wait: waiting means pumping, and the handlers a pump reaches open modal boxes.
+   soft_term_requested guards the ask, and init_lance() clears it once per mirror. */
+WhttMirrorStop SessionEndStop(BOOL bEnding) {
+  if (!bEnding)
+    return WHTT_STOP_NOT_ENDING;
+  if (global_opt == NULL)
+    return WHTT_STOP_NO_MIRROR;
+  if (termine)
+    return WHTT_STOP_ENDED;
+  if (soft_term_requested)
+    return WHTT_STOP_PENDING;
+  return RequestMirrorStop();
 }
 
 // PATCH-->

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -292,44 +292,15 @@ void RequestMirrorStop() {
   }
 }
 
-/* Windows ends the session whatever we answer, so this is a bounded clean stop and
-   never a veto: ask the engine to stop, then give it timeoutMs to unwind. */
-BOOL StopMirrorForSessionEnd(HWND hWnd, DWORD timeoutMs) {
-  if (global_opt == NULL || termine)    /* no mirror in flight */
+/* Ask, and get out of the way: waiting here would mean pumping, and the handlers a pump
+   reaches open modal boxes. Once per process, as a second request aborts abruptly. */
+BOOL StopMirrorForSessionEnd() {
+  static int requested = 0;
+
+  if (requested || global_opt == NULL || termine)
     return FALSE;
-
-  /* Vista+, so resolved and not imported, like the other late APIs here. */
-  BOOL (WINAPI*const u32_BlockReasonCreate)(HWND, LPCWSTR) =
-    (BOOL (WINAPI *)(HWND, LPCWSTR))
-    GetProcAddress(GetModuleHandle("user32.dll"), "ShutdownBlockReasonCreate");
-  BOOL (WINAPI*const u32_BlockReasonDestroy)(HWND) =
-    (BOOL (WINAPI *)(HWND))
-    GetProcAddress(GetModuleHandle("user32.dll"), "ShutdownBlockReasonDestroy");
-  BOOL named = FALSE;
-
-  if (hWnd != NULL && u32_BlockReasonCreate != NULL) {
-    /* No lang.def key ships for this yet; English until the engine adds one. */
-    const char* reason = LANGSEL("LANG_ENDSESSION");
-    WCHAR wide[256];    /* MAX_STR_BLOCKREASON */
-    if (reason[0] == '\0')
-      reason = "WinHTTrack is finishing the mirror in progress.";
-    if (MultiByteToWideChar(CP_ACP, 0, reason, -1, wide, _countof(wide)) > 0)
-      named = u32_BlockReasonCreate(hWnd, wide);
-  }
-
+  requested = 1;
   RequestMirrorStop();
-
-  const DWORD start = GetTickCount();
-  while (!hts_has_stopped(global_opt) && GetTickCount() - start < timeoutMs) {
-    /* The engine thread ends the mirror through SendMessage: a bare Sleep would block
-       it here instead of letting it finish. */
-    MSG msg;
-    ::PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE);
-    ::Sleep(50);
-  }
-
-  if (named && u32_BlockReasonDestroy != NULL)
-    u32_BlockReasonDestroy(hWnd);
   return TRUE;
 }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -280,6 +280,58 @@ BOOL LaunchMirror() {
   return 0;
 }
 
+/* The Cancel button's stop, minus its confirmation: a second call turns the engine's
+   soft stop into an immediate one. */
+void RequestMirrorStop() {
+  hts_setpause(global_opt, 0);
+  if (soft_term_requested)
+    termine_requested=1;
+  else {
+    soft_term_requested=1;
+    hts_request_stop(global_opt, 0);
+  }
+}
+
+/* Windows ends the session whatever we answer, so this is a bounded clean stop and
+   never a veto: ask the engine to stop, then give it timeoutMs to unwind. */
+BOOL StopMirrorForSessionEnd(HWND hWnd, DWORD timeoutMs) {
+  if (global_opt == NULL || termine)    /* no mirror in flight */
+    return FALSE;
+
+  /* Vista+, so resolved and not imported, like the other late APIs here. */
+  BOOL (WINAPI*const u32_BlockReasonCreate)(HWND, LPCWSTR) =
+    (BOOL (WINAPI *)(HWND, LPCWSTR))
+    GetProcAddress(GetModuleHandle("user32.dll"), "ShutdownBlockReasonCreate");
+  BOOL (WINAPI*const u32_BlockReasonDestroy)(HWND) =
+    (BOOL (WINAPI *)(HWND))
+    GetProcAddress(GetModuleHandle("user32.dll"), "ShutdownBlockReasonDestroy");
+  BOOL named = FALSE;
+
+  if (hWnd != NULL && u32_BlockReasonCreate != NULL) {
+    /* No lang.def key ships for this yet; English until the engine adds one. */
+    const char* reason = LANGSEL("LANG_ENDSESSION");
+    WCHAR wide[256];    /* MAX_STR_BLOCKREASON */
+    if (reason[0] == '\0')
+      reason = "WinHTTrack is finishing the mirror in progress.";
+    if (MultiByteToWideChar(CP_ACP, 0, reason, -1, wide, _countof(wide)) > 0)
+      named = u32_BlockReasonCreate(hWnd, wide);
+  }
+
+  RequestMirrorStop();
+
+  const DWORD start = GetTickCount();
+  while (!hts_has_stopped(global_opt) && GetTickCount() - start < timeoutMs) {
+    /* The engine thread ends the mirror through SendMessage: a bare Sleep would block
+       it here instead of letting it finish. */
+    MSG msg;
+    ::PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE);
+    ::Sleep(50);
+  }
+
+  if (named && u32_BlockReasonDestroy != NULL)
+    u32_BlockReasonDestroy(hWnd);
+  return TRUE;
+}
 
 // PATCH-->
 // routines diverses

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -199,12 +199,24 @@ void  __cdecl httrackengine_filesave2(t_hts_callbackarg *carg, httrackp *opt, co
 
 extern httrackp *global_opt;
 
-/* Ask a running mirror to stop, the way the Cancel button does once confirmed. */
-void RequestMirrorStop();
+/* What a stop request did, or found already done. */
+typedef enum {
+  WHTT_STOP_NO_MIRROR = 0,  /* nothing is running */
+  WHTT_STOP_ENDED,          /* the mirror already finished */
+  WHTT_STOP_PENDING,        /* an earlier ask is still outstanding */
+  WHTT_STOP_ASKED,          /* the engine was asked to stop */
+  WHTT_STOP_ABORTED,        /* a second ask escalated to the abrupt abort */
+  WHTT_STOP_NOT_ENDING      /* the session end was cancelled: nothing was asked */
+} WhttMirrorStop;
 
-/* Request that stop for a Windows session end, at most once per mirror and never
-   waiting for it. @return TRUE if this call asked for the stop. */
-BOOL StopMirrorForSessionEnd();
+/* Ask a running mirror to stop, the way the Cancel button does once confirmed.
+   @return WHTT_STOP_ASKED, or WHTT_STOP_ABORTED when this ask escalated. */
+WhttMirrorStop RequestMirrorStop();
+
+/* The decision both session-end handlers share: ask at most once per mirror, and never
+   wait. bEnding is WM_ENDSESSION's flag, FALSE for a shutdown the user cancelled.
+   @return what the mirror was doing, and whether this call asked it to stop. */
+WhttMirrorStop SessionEndStop(BOOL bEnding);
 
 // profile
 int Save_current_profile(int ask);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -199,6 +199,18 @@ void  __cdecl httrackengine_filesave2(t_hts_callbackarg *carg, httrackp *opt, co
 
 extern httrackp *global_opt;
 
+/* Ask a running mirror to stop, the way the Cancel button does once confirmed. */
+void RequestMirrorStop();
+
+/* Stop a running mirror for a Windows session end and wait up to timeoutMs for the
+   engine to unwind, naming us on the shutdown screen meanwhile.
+   @return TRUE if a mirror was running. */
+BOOL StopMirrorForSessionEnd(HWND hWnd, DWORD timeoutMs);
+
+/* Long enough for the engine to drain its sockets and close the cache, short enough
+   that Windows does not kill us mid-unwind. */
+#define WHTT_ENDSESSION_TIMEOUT_MS 15000
+
 // profile
 int Save_current_profile(int ask);
 //

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -202,7 +202,7 @@ extern httrackp *global_opt;
 /* Ask a running mirror to stop, the way the Cancel button does once confirmed. */
 void RequestMirrorStop();
 
-/* Request that stop for a Windows session end, at most once per process and never
+/* Request that stop for a Windows session end, at most once per mirror and never
    waiting for it. @return TRUE if this call asked for the stop. */
 BOOL StopMirrorForSessionEnd();
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -202,14 +202,9 @@ extern httrackp *global_opt;
 /* Ask a running mirror to stop, the way the Cancel button does once confirmed. */
 void RequestMirrorStop();
 
-/* Stop a running mirror for a Windows session end and wait up to timeoutMs for the
-   engine to unwind, naming us on the shutdown screen meanwhile.
-   @return TRUE if a mirror was running. */
-BOOL StopMirrorForSessionEnd(HWND hWnd, DWORD timeoutMs);
-
-/* Long enough for the engine to drain its sockets and close the cache, short enough
-   that Windows does not kill us mid-unwind. */
-#define WHTT_ENDSESSION_TIMEOUT_MS 15000
+/* Request that stop for a Windows session end, at most once per process and never
+   waiting for it. @return TRUE if this call asked for the stop. */
+BOOL StopMirrorForSessionEnd();
 
 // profile
 int Save_current_profile(int ask);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1048,6 +1048,18 @@ BOOL CWinHTTrackApp::InitInstance()
       } else
         nchecks++;
 
+      /* A cancelled shutdown must not eat the next mirror's one ask, so redo what
+         init_lance() does per mirror and ask again. */
+      hts_free_opt(global_opt);
+      global_opt = hts_create_opt();
+      termine = termine_requested = shell_terminated = soft_term_requested = 0;
+      if (!StopMirrorForSessionEnd() || !global_opt->state.stop) {
+        fprintf(stderr, "FATAL: a cancelled shutdown consumed the next mirror's stop\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
       hts_free_opt(global_opt);
       global_opt = NULL;
       termine = soft_term_requested = 0;

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1013,7 +1013,7 @@ BOOL CWinHTTrackApp::InitInstance()
       int nchecks = 0;
       DWORD t0;
 
-      if (StopMirrorForSessionEnd() || soft_term_requested) {
+      if (SessionEndStop(TRUE) != WHTT_STOP_NO_MIRROR || soft_term_requested) {
         fprintf(stderr, "FATAL: session end acted on an idle WinHTTrack\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1022,7 +1022,7 @@ BOOL CWinHTTrackApp::InitInstance()
 
       global_opt = hts_create_opt();
       termine = 1;                 /* a mirror that already ended is not one to stop */
-      if (StopMirrorForSessionEnd() || soft_term_requested) {
+      if (SessionEndStop(TRUE) != WHTT_STOP_ENDED || soft_term_requested) {
         fprintf(stderr, "FATAL: session end acted on a finished mirror\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1030,10 +1030,18 @@ BOOL CWinHTTrackApp::InitInstance()
         nchecks++;
 
       termine = 0;                 /* and one that is still running */
-      t0 = GetTickCount();
       /* state.stop is what hts_request_stop() sets; nothing exported reads it back. */
-      if (!StopMirrorForSessionEnd() || !soft_term_requested || !global_opt->state.stop
-          || GetTickCount() - t0 > 1000) {
+      if (SessionEndStop(FALSE) != WHTT_STOP_NOT_ENDING || soft_term_requested
+          || global_opt->state.stop) {
+        fprintf(stderr, "FATAL: a cancelled session end stopped the mirror\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      t0 = GetTickCount();
+      if (SessionEndStop(TRUE) != WHTT_STOP_ASKED || !soft_term_requested
+          || !global_opt->state.stop || GetTickCount() - t0 > 1000) {
         fprintf(stderr, "FATAL: session end did not ask the running mirror to stop, or waited\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1041,7 +1049,7 @@ BOOL CWinHTTrackApp::InitInstance()
         nchecks++;
 
       /* Both handlers can fire; a second request would escalate to an abrupt abort. */
-      if (StopMirrorForSessionEnd() || termine_requested) {
+      if (SessionEndStop(TRUE) != WHTT_STOP_PENDING || termine_requested) {
         fprintf(stderr, "FATAL: session end asked twice\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1053,7 +1061,7 @@ BOOL CWinHTTrackApp::InitInstance()
       hts_free_opt(global_opt);
       global_opt = hts_create_opt();
       termine = termine_requested = shell_terminated = soft_term_requested = 0;
-      if (!StopMirrorForSessionEnd() || !global_opt->state.stop) {
+      if (SessionEndStop(TRUE) != WHTT_STOP_ASKED || !global_opt->state.stop) {
         fprintf(stderr, "FATAL: a cancelled shutdown consumed the next mirror's stop\n");
         fflush(stderr);
         ExitProcess(3);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1007,6 +1007,49 @@ BOOL CWinHTTrackApp::InitInstance()
       QLANG_T(saved);
       LANG_LOAD(NULL, 0);
     }
+    /* A real logoff is the only way to reach the session-end path, so pin it here:
+       it stops a mirror that is running, and returns at once when none is. */
+    {
+      const DWORD budget = 200;    /* the running case really waits this out */
+      int nchecks = 0;
+      DWORD t0;
+
+      t0 = GetTickCount();
+      if (StopMirrorForSessionEnd(NULL, budget) || soft_term_requested
+          || GetTickCount() - t0 >= budget) {
+        fprintf(stderr, "FATAL: session end acted on an idle WinHTTrack\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      global_opt = hts_create_opt();
+      termine = 1;                 /* a mirror that already ended is not one to stop */
+      t0 = GetTickCount();
+      if (StopMirrorForSessionEnd(NULL, budget) || soft_term_requested
+          || GetTickCount() - t0 >= budget) {
+        fprintf(stderr, "FATAL: session end acted on a finished mirror\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      termine = 0;                 /* and one that is still running */
+      t0 = GetTickCount();
+      /* state.stop is what hts_request_stop() sets; nothing exported reads it back. */
+      if (!StopMirrorForSessionEnd(NULL, budget) || !soft_term_requested
+          || !global_opt->state.stop || GetTickCount() - t0 < budget) {
+        fprintf(stderr, "FATAL: session end did not stop the mirror and wait for it\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      hts_free_opt(global_opt);
+      global_opt = NULL;
+      termine = soft_term_requested = 0;
+      printf("session end ok on %d checks\n", nchecks);
+    }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking
        report that names nothing. Only throwing proves the chain resolves. */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1007,16 +1007,13 @@ BOOL CWinHTTrackApp::InitInstance()
       QLANG_T(saved);
       LANG_LOAD(NULL, 0);
     }
-    /* A real logoff is the only way to reach the session-end path, so pin it here:
-       it stops a mirror that is running, and returns at once when none is. */
+    /* A real logoff is the only way to reach the session-end path, so pin it here: it
+       asks for the stop once, only while a mirror runs, and never waits for it. */
     {
-      const DWORD budget = 200;    /* the running case really waits this out */
       int nchecks = 0;
       DWORD t0;
 
-      t0 = GetTickCount();
-      if (StopMirrorForSessionEnd(NULL, budget) || soft_term_requested
-          || GetTickCount() - t0 >= budget) {
+      if (StopMirrorForSessionEnd() || soft_term_requested) {
         fprintf(stderr, "FATAL: session end acted on an idle WinHTTrack\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1025,9 +1022,7 @@ BOOL CWinHTTrackApp::InitInstance()
 
       global_opt = hts_create_opt();
       termine = 1;                 /* a mirror that already ended is not one to stop */
-      t0 = GetTickCount();
-      if (StopMirrorForSessionEnd(NULL, budget) || soft_term_requested
-          || GetTickCount() - t0 >= budget) {
+      if (StopMirrorForSessionEnd() || soft_term_requested) {
         fprintf(stderr, "FATAL: session end acted on a finished mirror\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1037,9 +1032,17 @@ BOOL CWinHTTrackApp::InitInstance()
       termine = 0;                 /* and one that is still running */
       t0 = GetTickCount();
       /* state.stop is what hts_request_stop() sets; nothing exported reads it back. */
-      if (!StopMirrorForSessionEnd(NULL, budget) || !soft_term_requested
-          || !global_opt->state.stop || GetTickCount() - t0 < budget) {
-        fprintf(stderr, "FATAL: session end did not stop the mirror and wait for it\n");
+      if (!StopMirrorForSessionEnd() || !soft_term_requested || !global_opt->state.stop
+          || GetTickCount() - t0 > 1000) {
+        fprintf(stderr, "FATAL: session end did not ask the running mirror to stop, or waited\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      /* Both handlers can fire; a second request would escalate to an abrupt abort. */
+      if (StopMirrorForSessionEnd() || termine_requested) {
+        fprintf(stderr, "FATAL: session end asked twice\n");
         fflush(stderr);
         ExitProcess(3);
       } else

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -51,7 +51,6 @@ extern CMainTab* maintab;
 
 extern int termine_requested;
 extern int termine;
-extern int soft_term_requested;
 extern HICON httrack_icon;
 extern int termine;
 
@@ -384,13 +383,7 @@ void Cinprogress::OnStopall()
     LANG(LANG_H1 /*"Stop WinHTTrack?",
            "Stopper WinHTTrack?"*/)
     ,MB_OKCANCEL+MB_ICONQUESTION)==IDOK) {
-    hts_setpause(global_opt, 0);
-    if (soft_term_requested)
-      termine_requested=1;
-    else {
-      soft_term_requested=1;
-      hts_request_stop(global_opt, 0);
-    }
+    RequestMirrorStop();
   }
 }
 


### PR DESCRIPTION
WinHTTrack ignores `WM_QUERYENDSESSION`, so logging off kills the engine thread mid-write. The frame now asks the engine to stop, the same request the Cancel button makes once confirmed, and returns TRUE straight away. It cannot wait for the stop: waiting means pumping messages, and the engine's end-of-mirror `SendMessage` then opens a modal box on top of the handler, which is the hang Windows force-kills. The engine unwinds on whatever time the rest of the shutdown leaves it, and `soft_term_requested` makes `lance()` write `interrupted.lock`, so the project reopens on "continue interrupted download".

Both handlers route through `SessionEndStop(bEnding)`. The ask is guarded on `soft_term_requested` rather than on a flag of our own, because `init_lance()` clears it before every mirror: `OnQueryEndSession` and `OnEndSession` firing together cannot escalate to `termine_requested` and abort abruptly, and a shutdown the user cancels still leaves the next mirror its own ask. The selftest covers six cases, the cancelled shutdown among them, where the mirror has to be left running.

CI cannot log off, so the unwind needs a VM: start a mirror on a large site, log off within five seconds, log back in, and check that no crash dialog appeared, that `hts-cache/interrupted.lock` exists, and that reopening the project preselects "continue interrupted download". Repeat after a minute of mirroring, so more than 32 KB is cached, and once more cancelling the shutdown at the confirmation prompt.
