### PR TITLE
The user-defined build structure is crawled as a URL instead of naming files

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -257,7 +257,7 @@ runs:
           throw "selftest did not check the checkbox gating"
         }
         # The entry count is the .rc's and the catalog's, so it is pinned alongside the rows.
-        if ("$so" -notmatch 'build structure ok on 25 checks and 15 combo entries(?! \(accented)') {
+        if ("$so" -notmatch 'build structure ok on 26 checks and 15 combo entries(?! \(accented)') {
           throw "selftest did not check the Build tab's naming structure"
         }
         # A cap the engine refuses aborts the mirror, so the shell must never build one.

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -256,6 +256,10 @@ runs:
         if ("$so" -notmatch 'option gating ok on 16 checks') {
           throw "selftest did not check the checkbox gating"
         }
+        # The entry count is the .rc's and the catalog's, so it is pinned alongside the rows.
+        if ("$so" -notmatch 'build structure ok on 25 checks and 15 combo entries(?! \(accented)') {
+          throw "selftest did not check the Build tab's naming structure"
+        }
         # A cap the engine refuses aborts the mirror, so the shell must never build one.
         if ("$so" -notmatch 'single-file caps ok on 7 checks') {
           throw "selftest did not check the single-file cap"

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -595,26 +595,8 @@ void compute_options() {
   else if(maintab->m_option9.m_logtype==2) ShellOptions->logtype = "Z";
   if (maintab->m_option3.m_windebug) ShellOptions->logtype += "%H";      // debug headers
   
-  ShellOptions->build = "";
-  if      (maintab->m_option2.m_build==0) ShellOptions->build = "N0";
-  else if (maintab->m_option2.m_build==1) ShellOptions->build = "N1";
-  else if (maintab->m_option2.m_build==2) ShellOptions->build = "N2";
-  else if (maintab->m_option2.m_build==3) ShellOptions->build = "N3";
-  else if (maintab->m_option2.m_build==4) ShellOptions->build = "N4";
-  else if (maintab->m_option2.m_build==5) ShellOptions->build = "N5";
-  else if (maintab->m_option2.m_build==6) ShellOptions->build = "N100";
-  else if (maintab->m_option2.m_build==7) ShellOptions->build = "N101";
-  else if (maintab->m_option2.m_build==8) ShellOptions->build = "N102";
-  else if (maintab->m_option2.m_build==9) ShellOptions->build = "N103";
-  else if (maintab->m_option2.m_build==10) ShellOptions->build = "N104";
-  else if (maintab->m_option2.m_build==11) ShellOptions->build = "N105";
-  else if (maintab->m_option2.m_build==12) ShellOptions->build = "N99";
-  else if (maintab->m_option2.m_build==13) ShellOptions->build = "N199";
-  else if (maintab->m_option2.m_build==14) {
-    ShellOptions->build = "-N \"";
-    ShellOptions->build += maintab->m_option2.Bopt.m_BuildString;
-    ShellOptions->build += "\"";
-  }
+  buildOptionsForStructure(maintab->m_option2.m_build, maintab->m_option2.Bopt.m_BuildString,
+                           ShellOptions->build, ShellOptions->buildstring);
   
   ShellOptions->filtre = "";
   if      (maintab->m_option3.m_filter==0) ShellOptions->filtre = "p0";
@@ -1978,6 +1960,41 @@ BOOL isSingleFileMaxArgument(const CString &value) {
   return *end == '\0' && errno != ERANGE && v > 0 && fitsEngineArgument(value, HTS_CDLMAXSIZE);
 }
 
+// TRUE if VALUE may be handed to -N as its format; one the engine refuses aborts the mirror.
+static BOOL isBuildStringArgument(const CString &value) {
+  return isEngineArgument(value, BUILDSTRING_MAXSIZE);
+}
+
+// see Shell.h
+void buildOptionsForStructure(int structure, const CString &userdef,
+                              CString &flag, CString &format) {
+  // IDC_build's items, in the combo's own order; the one past them takes a format instead
+  static const char *const flags[] = {
+    "N0", "N1", "N2", "N3", "N4", "N5", "N100",
+    "N101", "N102", "N103", "N104", "N105", "N99", "N199"
+  };
+  const int fixed = (int) (sizeof(flags) / sizeof(flags[0]));
+
+  flag = "";
+  format = "";
+  if (structure >= 0 && structure < fixed)
+    flag = flags[structure];
+  // a format the engine refuses aborts the mirror, so fall back to its default naming
+  else if (structure == fixed && isBuildStringArgument(userdef))
+    format = userdef;
+}
+
+// see Shell.h
+void addBuildOption(CSimpleArray<CString> &args, CString &single, const CShellOptions &opt) {
+  // the engine matches "-N" exactly and takes the format from the token after it
+  if (opt.buildstring.GetLength() != 0) {
+    args.Add("-N");
+    args.Add(opt.buildstring);
+  } else {
+    single += opt.build;
+  }
+}
+
 void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt) {
   // WARC: emit --warc as its own token, not in the compacted -%... string, whose
   // trailing flag would collide with the engine's %r siblings (%rf/%rs/...).
@@ -2077,11 +2094,7 @@ void lance(void) {
   
   // si get, ne pas faire
   if (strcmp(ShellOptions->choixdeb,"g")!=0) {
-    if(ShellOptions->build[0]=='-') {
-      args.Add(ShellOptions->build);
-    } else {
-      single += ShellOptions->build;
-    }
+    addBuildOption(args, single, *ShellOptions);
   }
   single += ShellOptions->dos;
   single += ShellOptions->index;

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -1968,7 +1968,8 @@ static BOOL isBuildStringArgument(const CString &value) {
 // see Shell.h
 void buildOptionsForStructure(int structure, const CString &userdef,
                               CString &flag, CString &format) {
-  // IDC_build's items, in the combo's own order; the one past them takes a format instead
+  // The index into this array IS IDC_build's item order in the .rc: reorder one, reorder
+  // both, or every saved project changes structure. The item past them takes a format.
   static const char *const flags[] = {
     "N0", "N1", "N2", "N3", "N4", "N5", "N100",
     "N101", "N102", "N103", "N104", "N105", "N99", "N199"

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -595,8 +595,14 @@ void compute_options() {
   else if(maintab->m_option9.m_logtype==2) ShellOptions->logtype = "Z";
   if (maintab->m_option3.m_windebug) ShellOptions->logtype += "%H";      // debug headers
   
-  buildOptionsForStructure(maintab->m_option2.m_build, maintab->m_option2.Bopt.m_BuildString,
-                           ShellOptions->build, ShellOptions->buildstring);
+  // tell the user, rather than mirroring silently under the engine's default naming
+  if (buildOptionsForStructure(maintab->m_option2.m_build, maintab->m_option2.Bopt.m_BuildString,
+                               ShellOptions->build, ShellOptions->buildstring)
+      == BuildStructureRejected) {
+    AfxMessageBox("The user-defined build structure was refused: it is empty, too long, or "
+                  "starts with a dash.\nThe mirror will use the default naming.",
+                  MB_OK | MB_ICONWARNING);
+  }
   
   ShellOptions->filtre = "";
   if      (maintab->m_option3.m_filter==0) ShellOptions->filtre = "p0";
@@ -1960,39 +1966,42 @@ BOOL isSingleFileMaxArgument(const CString &value) {
   return *end == '\0' && errno != ERANGE && v > 0 && fitsEngineArgument(value, HTS_CDLMAXSIZE);
 }
 
-// TRUE if VALUE may be handed to -N as its format; one the engine refuses aborts the mirror.
-static BOOL isBuildStringArgument(const CString &value) {
+// see Shell.h
+BOOL isBuildStringArgument(const CString &value) {
   return isEngineArgument(value, BUILDSTRING_MAXSIZE);
 }
 
 // see Shell.h
-void buildOptionsForStructure(int structure, const CString &userdef,
-                              CString &flag, CString &format) {
-  // The index into this array IS IDC_build's item order in the .rc: reorder one, reorder
-  // both, or every saved project changes structure. The item past them takes a format.
+enum BuildStructure buildOptionsForStructure(int structure, const CString &userdef,
+                                             CString &flag, CString &format) {
+  // The index into this array IS IDC_build's item order: reorder one, reorder both, or
+  // every saved project changes structure. The row past them takes a format.
   static const char *const flags[] = {
     "N0", "N1", "N2", "N3", "N4", "N5", "N100",
     "N101", "N102", "N103", "N104", "N105", "N99", "N199"
   };
-  const int fixed = (int) (sizeof(flags) / sizeof(flags[0]));
+  static_assert(sizeof(flags) / sizeof(flags[0]) == BUILD_STRUCTURE_USERDEF,
+                "the user-defined row must sit right past the fixed structures");
 
   flag = "";
   format = "";
-  if (structure >= 0 && structure < fixed)
+  if (structure >= 0 && structure < BUILD_STRUCTURE_USERDEF) {
     flag = flags[structure];
-  // a format the engine refuses aborts the mirror, so fall back to its default naming
-  else if (structure == fixed && isBuildStringArgument(userdef))
+    return BuildStructureFixed;
+  }
+  if (structure == BUILD_STRUCTURE_USERDEF && isBuildStringArgument(userdef)) {
     format = userdef;
+    return BuildStructureUserDefined;
+  }
+  return BuildStructureRejected;
 }
 
 // see Shell.h
 void addBuildOption(CSimpleArray<CString> &args, CString &single, const CShellOptions &opt) {
-  // the engine matches "-N" exactly and takes the format from the token after it
-  if (opt.buildstring.GetLength() != 0) {
+  single += opt.build;
+  if (!opt.buildstring.IsEmpty()) {   // the engine matches "-N" exactly, format in the next token
     args.Add("-N");
     args.Add(opt.buildstring);
-  } else {
-    single += opt.build;
   }
 }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -598,8 +598,8 @@ void compute_options() {
   // tell the user, rather than mirroring silently under the engine's default naming
   if (buildOptionsForStructure(maintab->m_option2.m_build, maintab->m_option2.Bopt.m_BuildString,
                                ShellOptions->build, ShellOptions->buildstring)
-      == BuildStructureRejected) {
-    AfxMessageBox("The user-defined build structure was refused: it is empty, too long, or "
+      == BuildStructureBadTemplate) {
+    AfxMessageBox("The user-defined build structure was not used: it is empty, too long, or "
                   "starts with a dash.\nThe mirror will use the default naming.",
                   MB_OK | MB_ICONWARNING);
   }
@@ -1989,11 +1989,13 @@ enum BuildStructure buildOptionsForStructure(int structure, const CString &userd
     flag = flags[structure];
     return BuildStructureFixed;
   }
-  if (structure == BUILD_STRUCTURE_USERDEF && isBuildStringArgument(userdef)) {
+  if (structure == BUILD_STRUCTURE_USERDEF) {
+    if (!isBuildStringArgument(userdef))
+      return BuildStructureBadTemplate;
     format = userdef;
     return BuildStructureUserDefined;
   }
-  return BuildStructureRejected;
+  return BuildStructureNoSuchRow;
 }
 
 // see Shell.h

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -318,12 +318,14 @@ void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt);
 #define BUILD_STRUCTURE_USERDEF 14
 #define BUILD_STRUCTURE_COUNT (BUILD_STRUCTURE_USERDEF + 1)
 
-/* What buildOptionsForStructure() made of the combo's index. */
-enum BuildStructure { BuildStructureFixed, BuildStructureUserDefined, BuildStructureRejected };
+/* What buildOptionsForStructure() made of the combo's index. A short catalog leaves the combo
+   missing rows, so NoSuchRow is routine; only BadTemplate is something the user typed. */
+enum BuildStructure { BuildStructureFixed, BuildStructureUserDefined, BuildStructureNoSuchRow,
+                      BuildStructureBadTemplate };
 
 /* Split the Build tab's structure combo into its two argv-bound halves: FLAG the compacted
    -N fragment of a fixed structure, FORMAT the user-defined template. Returns which half it
-   filled; Rejected fills neither, and covers an index naming no row as well as a bad template. */
+   filled; the two other outcomes fill neither and leave the engine its default naming. */
 enum BuildStructure buildOptionsForStructure(int structure, const CString &userdef,
                                              CString &flag, CString &format);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -230,6 +230,9 @@ BOOL isHostAliasArgument(const CString &rule);
    enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
 BOOL isSingleFileMaxArgument(const CString &value);
 
+/* -N's format cap in the engine, exclusive; it exports no macro for this one. */
+#define BUILDSTRING_MAXSIZE 127
+
 /* TRUE if VALUE may be handed to the option each one names: short enough once converted,
    and not opening with a dash. Exposed for --selftest. */
 BOOL isUserAgentArgument(const CString &value);
@@ -294,7 +297,7 @@ public:
     _RasString, accept_language, other_headers, default_referer,
     cookiesfile, pausefiles, keepwww, keepslashes, keepqueryorder,
     stripquery, hostalias, sitemap, sitemapurl, singlefile, singlefilemax,
-    changes, warccdx, wacz;
+    changes, warccdx, wacz, buildstring;
   CString LINE_back;
   RASDIALPARAMS _dial;
 };
@@ -306,6 +309,16 @@ extern CShellOptions* ShellOptions;
    A field left filled under a clear box must emit nothing, since a value option
    can enable its feature by itself. Shared with --selftest. */
 void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt);
+
+/* Split the Build tab's structure combo into its two argv-bound halves: FLAG the compacted
+   -N fragment of a fixed structure, FORMAT the user-defined template. An index outside the
+   combo, or a template the engine would refuse, leaves both empty. */
+void buildOptionsForStructure(int structure, const CString &userdef,
+                              CString &flag, CString &format);
+
+/* Emit the naming structure: the format as its own token after "-N", or the compacted
+   fragment appended to SINGLE. Shared with --selftest. */
+void addBuildOption(CSimpleArray<CString> &args, CString &single, const CShellOptions &opt);
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -230,7 +230,8 @@ BOOL isHostAliasArgument(const CString &rule);
    enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
 BOOL isSingleFileMaxArgument(const CString &value);
 
-/* -N's format cap in the engine, exclusive; it exports no macro for this one. */
+/* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its
+   htscoremain.c, which exports no macro for this one, so the two can drift apart. */
 #define BUILDSTRING_MAXSIZE 127
 
 /* TRUE if VALUE may be handed to the option each one names: short enough once converted,
@@ -239,6 +240,8 @@ BOOL isUserAgentArgument(const CString &value);
 BOOL isFooterArgument(const CString &value);
 BOOL isLangIsoArgument(const CString &value);
 BOOL isRefererArgument(const CString &value);
+/* Same for -N's format; one the engine refuses aborts the mirror. */
+BOOL isBuildStringArgument(const CString &value);
 
 void Build_TopIndex(BOOL check_empty=TRUE);
 
@@ -310,14 +313,22 @@ extern CShellOptions* ShellOptions;
    can enable its feature by itself. Shared with --selftest. */
 void addGatedOptions(CSimpleArray<CString> &args, const CShellOptions &opt);
 
-/* Split the Build tab's structure combo into its two argv-bound halves: FLAG the compacted
-   -N fragment of a fixed structure, FORMAT the user-defined template. An index outside the
-   combo, or a template the engine would refuse, leaves both empty. */
-void buildOptionsForStructure(int structure, const CString &userdef,
-                              CString &flag, CString &format);
+/* IDC_build's user-defined row, past the fixed structures, and the whole row count. That
+   order lives in the .rc's DLGINIT and the catalog's LISTDEF_3, so only --selftest can check it. */
+#define BUILD_STRUCTURE_USERDEF 14
+#define BUILD_STRUCTURE_COUNT (BUILD_STRUCTURE_USERDEF + 1)
 
-/* Emit the naming structure: the format as its own token after "-N", or the compacted
-   fragment appended to SINGLE. Shared with --selftest. */
+/* What buildOptionsForStructure() made of the combo's index. */
+enum BuildStructure { BuildStructureFixed, BuildStructureUserDefined, BuildStructureRejected };
+
+/* Split the Build tab's structure combo into its two argv-bound halves: FLAG the compacted
+   -N fragment of a fixed structure, FORMAT the user-defined template. Returns which half it
+   filled; Rejected fills neither, and covers an index naming no row as well as a bad template. */
+enum BuildStructure buildOptionsForStructure(int structure, const CString &userdef,
+                                             CString &flag, CString &format);
+
+/* Emit whichever half buildOptionsForStructure() filled: the format as its own token after
+   "-N", the compacted fragment appended to SINGLE. Shared with --selftest. */
 void addBuildOption(CSimpleArray<CString> &args, CString &single, const CShellOptions &opt);
 
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -572,8 +572,8 @@ BOOL CWinHTTrackApp::InitInstance()
     }
     /* The Build tab's structure combo, from its index to the argv the engine reads. */
     {
-      static const struct { int structure; const char *userdef; int repeat;
-                            const char *single; const char *args; } builds[] = {
+      static const struct BuildRow { int structure; const char *userdef; int repeat;
+                                     const char *single; const char *args; } builds[] = {
         /* the fixed structures, in the combo's order: a table shifted by one shows up here */
         { 0,  "", 1, "N0",   "" },   { 1,  "", 1, "N1",   "" },
         { 2,  "", 1, "N2",   "" },   { 3,  "", 1, "N3",   "" },
@@ -597,40 +597,55 @@ BOOL CWinHTTrackApp::InitInstance()
         { 15, "%h%p/%n%q.%t", 1, "", "" },
         { -1, "%h%p/%n%q.%t", 1, "", "" },
         { 0, NULL, 0, NULL, NULL }
+      },
+        /* 0xE9 is one character and two UTF-8 bytes, so a cap counting characters takes both */
+        accented[] = {
+        { 14, "\xE9", (BUILDSTRING_MAXSIZE - 1) / 2, "", "-N|*" },
+        { 14, "\xE9", (BUILDSTRING_MAXSIZE + 1) / 2, "", "" },
+        { 0, NULL, 0, NULL, NULL }
       };
+      /* Under a UTF-8 ANSI codepage the conversion is a copy, and those rows count as ASCII. */
+      const BOOL mbcs = GetACP() != CP_UTF8;
+      const struct BuildRow *const tables[2] = { builds, mbcs ? accented : NULL };
       int nchecks = 0;
-      for(int k=0 ; builds[k].userdef != NULL ; k++) {
-        CShellOptions opt;
-        CSimpleArray<CString> got;
-        CString userdef, single, joined, expect(builds[k].args);
+      for(int t=0 ; t<2 ; t++) {
+        for(int k=0 ; tables[t] != NULL && tables[t][k].userdef != NULL ; k++) {
+          const struct BuildRow *const row = &tables[t][k];
+          CShellOptions opt;
+          CSimpleArray<CString> got;
+          CString userdef, single, joined, expect(row->args);
 
-        for(int n=0 ; n<builds[k].repeat ; n++)
-          userdef += builds[k].userdef;
-        buildOptionsForStructure(builds[k].structure, userdef, opt.build, opt.buildstring);
-        addBuildOption(got, single, opt);
-        for(int j=0 ; j<got.GetSize() ; j++) {
-          if (j != 0)
-            joined += "|";
-          joined += got[j];
+          for(int n=0 ; n<row->repeat ; n++)
+            userdef += row->userdef;
+          buildOptionsForStructure(row->structure, userdef, opt.build, opt.buildstring);
+          addBuildOption(got, single, opt);
+          for(int j=0 ; j<got.GetSize() ; j++) {
+            if (j != 0)
+              joined += "|";
+            joined += got[j];
+          }
+          expect.Replace("*", userdef);
+          if (single != row->single || joined != expect) {
+            fprintf(stderr, "FATAL: build row %d.%d (structure %d, %d chars) emitted '%s' and '%s',"
+                    " expected '%s' and '%s'\n", t, k, row->structure, (int) userdef.GetLength(),
+                    (LPCSTR) single, (LPCSTR) joined.Left(60),
+                    row->single, (LPCSTR) expect.Left(60));
+            fflush(stderr);
+            ExitProcess(3);
+          } else
+            nchecks++;
         }
-        expect.Replace("*", userdef);
-        if (single != builds[k].single || joined != expect) {
-          fprintf(stderr, "FATAL: build row %d (structure %d, %d chars) emitted '%s' and '%s',"
-                  " expected '%s' and '%s'\n", k, builds[k].structure, (int) userdef.GetLength(),
-                  (LPCSTR) single, (LPCSTR) joined.Left(60),
-                  builds[k].single, (LPCSTR) expect.Left(60));
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
       }
       /* Pinned here, not in the workflow that pins its siblings: that file is signing-privileged. */
-      if (nchecks != 23) {
-        fprintf(stderr, "FATAL: build structure ran %d checks, expected 23\n", nchecks);
+      const int want = mbcs ? 25 : 23;
+      if (nchecks != want) {
+        fprintf(stderr, "FATAL: build structure ran %d checks, expected %d\n", nchecks, want);
         fflush(stderr);
         ExitProcess(3);
       }
-      printf("build structure ok on %d checks\n", nchecks);
+      /* Count before the suffix, so a skip stays visible to the CI guard. */
+      printf("build structure ok on %d checks%s\n", nchecks,
+             mbcs ? "" : " (accented cases skipped)");
     }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -572,9 +572,11 @@ BOOL CWinHTTrackApp::InitInstance()
     }
     /* The Build tab's structure combo, from its index to the argv the engine reads. */
     {
+      /* Named, unlike its sibling tables here, so both walk through one pointer below. */
       static const struct BuildRow { int structure; const char *userdef; int repeat;
-                                     const char *single; const char *args; } builds[] = {
-        /* the fixed structures, in the combo's order: a table shifted by one shows up here */
+                                     const char *expectSingle; const char *expectArgs; } builds[] = {
+        /* the fixed structures, in the combo's order: reorder the table or the combo
+           alone and every row below checks a structure other than the one it names */
         { 0,  "", 1, "N0",   "" },   { 1,  "", 1, "N1",   "" },
         { 2,  "", 1, "N2",   "" },   { 3,  "", 1, "N3",   "" },
         { 4,  "", 1, "N4",   "" },   { 5,  "", 1, "N5",   "" },
@@ -585,35 +587,35 @@ BOOL CWinHTTrackApp::InitInstance()
         /* a fixed structure ignores the template the user-defined box still holds */
         { 3, "%h%p/%n%q.%t", 1, "N3", "" },
         /* two tokens, unquoted: pasted into one, a '/' makes the engine read it as a URL */
-        { 14, "%h%p/%n%q.%t", 1, "", "-N|%h%p/%n%q.%t" },
-        { 14, "%n%q.%t", 1, "", "-N|%n%q.%t" },
+        { BUILD_STRUCTURE_USERDEF, "%h%p/%n%q.%t", 1, "", "-N|%h%p/%n%q.%t" },
+        { BUILD_STRUCTURE_USERDEF, "%n%q.%t", 1, "", "-N|%n%q.%t" },
         /* dropped to the engine's default naming: empty, a leading dash, over the cap */
-        { 14, "", 1, "", "" },
-        { 14, "-%h%p/%n", 1, "", "" },
-        { 14, "x", BUILDSTRING_MAXSIZE, "", "" },
+        { BUILD_STRUCTURE_USERDEF, "", 1, "", "" },
+        { BUILD_STRUCTURE_USERDEF, "-%h%p/%n", 1, "", "" },
+        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE, "", "" },
         /* '*' stands for the value the row builds, one byte under the engine's cap */
-        { 14, "x", BUILDSTRING_MAXSIZE - 1, "", "-N|*" },
+        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE - 1, "", "-N|*" },
         /* no such combo entry, so neither half may be filled */
-        { 15, "%h%p/%n%q.%t", 1, "", "" },
+        { BUILD_STRUCTURE_COUNT, "%h%p/%n%q.%t", 1, "", "" },
         { -1, "%h%p/%n%q.%t", 1, "", "" },
         { 0, NULL, 0, NULL, NULL }
       },
         /* 0xE9 is one character and two UTF-8 bytes, so a cap counting characters takes both */
         accented[] = {
-        { 14, "\xE9", (BUILDSTRING_MAXSIZE - 1) / 2, "", "-N|*" },
-        { 14, "\xE9", (BUILDSTRING_MAXSIZE + 1) / 2, "", "" },
+        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE - 1) / 2, "", "-N|*" },
+        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE + 1) / 2, "", "" },
         { 0, NULL, 0, NULL, NULL }
       };
       /* Under a UTF-8 ANSI codepage the conversion is a copy, and those rows count as ASCII. */
-      const BOOL mbcs = GetACP() != CP_UTF8;
-      const struct BuildRow *const tables[2] = { builds, mbcs ? accented : NULL };
-      int nchecks = 0;
+      const BOOL ansiNotUtf8 = GetACP() != CP_UTF8;
+      const struct BuildRow *const tables[2] = { builds, ansiNotUtf8 ? accented : NULL };
+      int nchecks = 0, nentries = 0;
       for(int t=0 ; t<2 ; t++) {
         for(int k=0 ; tables[t] != NULL && tables[t][k].userdef != NULL ; k++) {
           const struct BuildRow *const row = &tables[t][k];
           CShellOptions opt;
           CSimpleArray<CString> got;
-          CString userdef, single, joined, expect(row->args);
+          CString userdef, single, joined, expect(row->expectArgs);
 
           for(int n=0 ; n<row->repeat ; n++)
             userdef += row->userdef;
@@ -625,27 +627,61 @@ BOOL CWinHTTrackApp::InitInstance()
             joined += got[j];
           }
           expect.Replace("*", userdef);
-          if (single != row->single || joined != expect) {
+          if (single != row->expectSingle || joined != expect) {
             fprintf(stderr, "FATAL: build row %d.%d (structure %d, %d chars) emitted '%s' and '%s',"
                     " expected '%s' and '%s'\n", t, k, row->structure, (int) userdef.GetLength(),
                     (LPCSTR) single, (LPCSTR) joined.Left(60),
-                    row->single, (LPCSTR) expect.Left(60));
+                    row->expectSingle, (LPCSTR) expect.Left(60));
             fflush(stderr);
             ExitProcess(3);
           } else
             nchecks++;
         }
       }
-      /* Pinned here, not in the workflow that pins its siblings: that file is signing-privileged. */
-      const int want = mbcs ? 25 : 23;
+      /* The .rc holds a bare COMBOBOX and SetCombo() refills it from LISTDEF_3, so the row
+         count reaches the table above through nothing the compiler sees. Count it here. */
+      {
+        const int saved = QLANG_T(-1);
+        const int en = LANG_INDEX_OF("en");
+        CString list;
+
+        if (en < 0) {
+          fprintf(stderr, "FATAL: lang.indexes knows no 'en'\n");
+          fflush(stderr);
+          ExitProcess(3);
+        }
+        QLANG_T(en);
+        LANG_LOAD(NULL, 0);
+        list = LISTDEF_3;
+        QLANG_T(saved);
+        LANG_LOAD(NULL, 0);
+        /* split as SetCombo() does, so an entry it would drop is not counted here either */
+        list.TrimLeft(); list.TrimRight();
+        while (list.GetLength()) {
+          const int pos = list.Find('\n');
+          CString item = (pos >= 0) ? list.Left(pos) : list;
+
+          list = (pos >= 0) ? list.Mid(pos + 1) : CString("");
+          item.TrimLeft(); item.TrimRight();
+          if (item.GetLength())
+            nentries++;
+        }
+        if (nentries != BUILD_STRUCTURE_COUNT) {
+          fprintf(stderr, "FATAL: IDC_build offers %d structures, the table names %d\n",
+                  nentries, BUILD_STRUCTURE_COUNT);
+          fflush(stderr);
+          ExitProcess(3);
+        }
+      }
+      const int want = ansiNotUtf8 ? 25 : 23;
       if (nchecks != want) {
         fprintf(stderr, "FATAL: build structure ran %d checks, expected %d\n", nchecks, want);
         fflush(stderr);
         ExitProcess(3);
       }
       /* Count before the suffix, so a skip stays visible to the CI guard. */
-      printf("build structure ok on %d checks%s\n", nchecks,
-             mbcs ? "" : " (accented cases skipped)");
+      printf("build structure ok on %d checks and %d combo entries%s\n", nchecks, nentries,
+             ansiNotUtf8 ? "" : " (accented cases skipped)");
     }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -574,37 +574,46 @@ BOOL CWinHTTrackApp::InitInstance()
     {
       /* Named, unlike its sibling tables here, so both walk through one pointer below. */
       static const struct BuildRow { int structure; const char *userdef; int repeat;
-                                     const char *expectSingle; const char *expectArgs; } builds[] = {
+                                     const char *expectSingle; const char *expectArgs;
+                                     enum BuildStructure expectOutcome; } builds[] = {
         /* the fixed structures, in the combo's order: reorder the table or the combo
            alone and every row below checks a structure other than the one it names */
-        { 0,  "", 1, "N0",   "" },   { 1,  "", 1, "N1",   "" },
-        { 2,  "", 1, "N2",   "" },   { 3,  "", 1, "N3",   "" },
-        { 4,  "", 1, "N4",   "" },   { 5,  "", 1, "N5",   "" },
-        { 6,  "", 1, "N100", "" },   { 7,  "", 1, "N101", "" },
-        { 8,  "", 1, "N102", "" },   { 9,  "", 1, "N103", "" },
-        { 10, "", 1, "N104", "" },   { 11, "", 1, "N105", "" },
-        { 12, "", 1, "N99",  "" },   { 13, "", 1, "N199", "" },
+        { 0,  "", 1, "N0",   "", BuildStructureFixed },
+        { 1,  "", 1, "N1",   "", BuildStructureFixed },
+        { 2,  "", 1, "N2",   "", BuildStructureFixed },
+        { 3,  "", 1, "N3",   "", BuildStructureFixed },
+        { 4,  "", 1, "N4",   "", BuildStructureFixed },
+        { 5,  "", 1, "N5",   "", BuildStructureFixed },
+        { 6,  "", 1, "N100", "", BuildStructureFixed },
+        { 7,  "", 1, "N101", "", BuildStructureFixed },
+        { 8,  "", 1, "N102", "", BuildStructureFixed },
+        { 9,  "", 1, "N103", "", BuildStructureFixed },
+        { 10, "", 1, "N104", "", BuildStructureFixed },
+        { 11, "", 1, "N105", "", BuildStructureFixed },
+        { 12, "", 1, "N99",  "", BuildStructureFixed },
+        { 13, "", 1, "N199", "", BuildStructureFixed },
         /* a fixed structure ignores the template the user-defined box still holds */
-        { 3, "%h%p/%n%q.%t", 1, "N3", "" },
+        { 3, "%h%p/%n%q.%t", 1, "N3", "", BuildStructureFixed },
         /* two tokens, unquoted: pasted into one, a '/' makes the engine read it as a URL */
-        { BUILD_STRUCTURE_USERDEF, "%h%p/%n%q.%t", 1, "", "-N|%h%p/%n%q.%t" },
-        { BUILD_STRUCTURE_USERDEF, "%n%q.%t", 1, "", "-N|%n%q.%t" },
-        /* dropped to the engine's default naming: empty, a leading dash, over the cap */
-        { BUILD_STRUCTURE_USERDEF, "", 1, "", "" },
-        { BUILD_STRUCTURE_USERDEF, "-%h%p/%n", 1, "", "" },
-        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE, "", "" },
+        { BUILD_STRUCTURE_USERDEF, "%h%p/%n%q.%t", 1, "", "-N|%h%p/%n%q.%t", BuildStructureUserDefined },
+        { BUILD_STRUCTURE_USERDEF, "%n%q.%t", 1, "", "-N|%n%q.%t", BuildStructureUserDefined },
+        /* dropped to the default naming, and the only outcome that warns: empty, dash, over the cap */
+        { BUILD_STRUCTURE_USERDEF, "", 1, "", "", BuildStructureBadTemplate },
+        { BUILD_STRUCTURE_USERDEF, "-%h%p/%n", 1, "", "", BuildStructureBadTemplate },
+        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE, "", "", BuildStructureBadTemplate },
         /* '*' stands for the value the row builds, one byte under the engine's cap */
-        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE - 1, "", "-N|*" },
-        /* no such combo entry, so neither half may be filled */
-        { BUILD_STRUCTURE_COUNT, "%h%p/%n%q.%t", 1, "", "" },
-        { -1, "%h%p/%n%q.%t", 1, "", "" },
-        { 0, NULL, 0, NULL, NULL }
+        { BUILD_STRUCTURE_USERDEF, "x", BUILDSTRING_MAXSIZE - 1, "", "-N|*", BuildStructureUserDefined },
+        /* no such entry: a short catalog has DDX write -1, which must fall back silently, not warn */
+        { BUILD_STRUCTURE_COUNT, "%h%p/%n%q.%t", 1, "", "", BuildStructureNoSuchRow },
+        { -1, "%h%p/%n%q.%t", 1, "", "", BuildStructureNoSuchRow },
+        { -1, "", 1, "", "", BuildStructureNoSuchRow },
+        { 0, NULL, 0, NULL, NULL, BuildStructureFixed }
       },
         /* 0xE9 is one character and two UTF-8 bytes, so a cap counting characters takes both */
         accented[] = {
-        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE - 1) / 2, "", "-N|*" },
-        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE + 1) / 2, "", "" },
-        { 0, NULL, 0, NULL, NULL }
+        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE - 1) / 2, "", "-N|*", BuildStructureUserDefined },
+        { BUILD_STRUCTURE_USERDEF, "\xE9", (BUILDSTRING_MAXSIZE + 1) / 2, "", "", BuildStructureBadTemplate },
+        { 0, NULL, 0, NULL, NULL, BuildStructureFixed }
       };
       /* Under a UTF-8 ANSI codepage the conversion is a copy, and those rows count as ASCII. */
       const BOOL ansiNotUtf8 = GetACP() != CP_UTF8;
@@ -619,7 +628,8 @@ BOOL CWinHTTrackApp::InitInstance()
 
           for(int n=0 ; n<row->repeat ; n++)
             userdef += row->userdef;
-          buildOptionsForStructure(row->structure, userdef, opt.build, opt.buildstring);
+          const enum BuildStructure outcome =
+            buildOptionsForStructure(row->structure, userdef, opt.build, opt.buildstring);
           addBuildOption(got, single, opt);
           for(int j=0 ; j<got.GetSize() ; j++) {
             if (j != 0)
@@ -627,11 +637,12 @@ BOOL CWinHTTrackApp::InitInstance()
             joined += got[j];
           }
           expect.Replace("*", userdef);
-          if (single != row->expectSingle || joined != expect) {
-            fprintf(stderr, "FATAL: build row %d.%d (structure %d, %d chars) emitted '%s' and '%s',"
-                    " expected '%s' and '%s'\n", t, k, row->structure, (int) userdef.GetLength(),
-                    (LPCSTR) single, (LPCSTR) joined.Left(60),
-                    row->expectSingle, (LPCSTR) expect.Left(60));
+          if (single != row->expectSingle || joined != expect || outcome != row->expectOutcome) {
+            fprintf(stderr, "FATAL: build row %d.%d (structure %d, %d chars) emitted '%s' and '%s'"
+                    " as outcome %d, expected '%s' and '%s' as %d\n",
+                    t, k, row->structure, (int) userdef.GetLength(),
+                    (LPCSTR) single, (LPCSTR) joined.Left(60), (int) outcome,
+                    row->expectSingle, (LPCSTR) expect.Left(60), (int) row->expectOutcome);
             fflush(stderr);
             ExitProcess(3);
           } else
@@ -673,7 +684,7 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         }
       }
-      const int want = ansiNotUtf8 ? 25 : 23;
+      const int want = ansiNotUtf8 ? 26 : 24;
       if (nchecks != want) {
         fprintf(stderr, "FATAL: build structure ran %d checks, expected %d\n", nchecks, want);
         fflush(stderr);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -570,6 +570,68 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("option gating ok on %d checks\n", nchecks);
     }
+    /* The Build tab's structure combo, from its index to the argv the engine reads. */
+    {
+      static const struct { int structure; const char *userdef; int repeat;
+                            const char *single; const char *args; } builds[] = {
+        /* the fixed structures, in the combo's order: a table shifted by one shows up here */
+        { 0,  "", 1, "N0",   "" },   { 1,  "", 1, "N1",   "" },
+        { 2,  "", 1, "N2",   "" },   { 3,  "", 1, "N3",   "" },
+        { 4,  "", 1, "N4",   "" },   { 5,  "", 1, "N5",   "" },
+        { 6,  "", 1, "N100", "" },   { 7,  "", 1, "N101", "" },
+        { 8,  "", 1, "N102", "" },   { 9,  "", 1, "N103", "" },
+        { 10, "", 1, "N104", "" },   { 11, "", 1, "N105", "" },
+        { 12, "", 1, "N99",  "" },   { 13, "", 1, "N199", "" },
+        /* a fixed structure ignores the template the user-defined box still holds */
+        { 3, "%h%p/%n%q.%t", 1, "N3", "" },
+        /* two tokens, unquoted: pasted into one, a '/' makes the engine read it as a URL */
+        { 14, "%h%p/%n%q.%t", 1, "", "-N|%h%p/%n%q.%t" },
+        { 14, "%n%q.%t", 1, "", "-N|%n%q.%t" },
+        /* dropped to the engine's default naming: empty, a leading dash, over the cap */
+        { 14, "", 1, "", "" },
+        { 14, "-%h%p/%n", 1, "", "" },
+        { 14, "x", BUILDSTRING_MAXSIZE, "", "" },
+        /* '*' stands for the value the row builds, one byte under the engine's cap */
+        { 14, "x", BUILDSTRING_MAXSIZE - 1, "", "-N|*" },
+        /* no such combo entry, so neither half may be filled */
+        { 15, "%h%p/%n%q.%t", 1, "", "" },
+        { -1, "%h%p/%n%q.%t", 1, "", "" },
+        { 0, NULL, 0, NULL, NULL }
+      };
+      int nchecks = 0;
+      for(int k=0 ; builds[k].userdef != NULL ; k++) {
+        CShellOptions opt;
+        CSimpleArray<CString> got;
+        CString userdef, single, joined, expect(builds[k].args);
+
+        for(int n=0 ; n<builds[k].repeat ; n++)
+          userdef += builds[k].userdef;
+        buildOptionsForStructure(builds[k].structure, userdef, opt.build, opt.buildstring);
+        addBuildOption(got, single, opt);
+        for(int j=0 ; j<got.GetSize() ; j++) {
+          if (j != 0)
+            joined += "|";
+          joined += got[j];
+        }
+        expect.Replace("*", userdef);
+        if (single != builds[k].single || joined != expect) {
+          fprintf(stderr, "FATAL: build row %d (structure %d, %d chars) emitted '%s' and '%s',"
+                  " expected '%s' and '%s'\n", k, builds[k].structure, (int) userdef.GetLength(),
+                  (LPCSTR) single, (LPCSTR) joined.Left(60),
+                  builds[k].single, (LPCSTR) expect.Left(60));
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* Pinned here, not in the workflow that pins its siblings: that file is signing-privileged. */
+      if (nchecks != 23) {
+        fprintf(stderr, "FATAL: build structure ran %d checks, expected 23\n", nchecks);
+        fflush(stderr);
+        ExitProcess(3);
+      }
+      printf("build structure ok on %d checks\n", nchecks);
+    }
     /* Pins the engine's grammar through the DLL, so a change to it lands here and
        not in a mirror. */
     {


### PR DESCRIPTION
The Build tab's user-defined naming structure never reached the engine. The GUI sent `-N` and the format as one argv token, but the engine reads the string form only when the token is exactly `-N` with the format in the next slot, and its option sniffer takes any token holding a slash for a URL. So `%h%p/%n%q.%t` was crawled as a site to mirror, and the naming fell back to the default.

The if/else ladder behind the combo is now a table and the format goes out on its own token, checked first against the engine's limits (under 127 UTF-8 bytes, no leading dash), since a value it refuses aborts the mirror. A refused template used to look exactly like a fixed structure to the caller, so the split now returns Fixed, UserDefined or Rejected, and the Rejected case warns instead of mirroring silently under the default naming. `--selftest` walks every fixed structure and the user-defined row, with an accented pair straddling the cap so the check counts bytes and not characters, and it counts the catalog's `LISTDEF_3` rows against the table, which is the only thing tying the combo's order to it; the smoke test pins that line with its exact counts. Two gaps left: `BUILDSTRING_MAXSIZE` is still a hand copy of a bare `127` in the engine's `htscoremain.c`, where an `HTS_BUILDSTRING_MAXSIZE` beside `HTS_FOOTER_MAXSIZE` belongs, and the `.rc`'s own DLGINIT copy of the list goes unchecked.
