### PR TITLE
Fail the build when a radio group has no way in from the keyboard

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -126,10 +126,12 @@ jobs:
 
           rc = open('WinHTTrack/WinHTTrack.rc', 'rb').read().decode('latin-1')
 
-          owners, dialogs = {}, {}
-          for name, body in re.findall(r'^(IDD_\w+) DIALOGE?X? .*?\r?\n(.*?)^END\r?$',
+          owners, dialogs, bodies = {}, {}, {}
+          for name, body in re.findall(r'^(IDD_\w+) DIALOGE?X? .*?^BEGIN\r?\n(.*?)^END\r?$',
                                        rc, re.M | re.S):
-              ids = set(re.findall(r'\b(IDC_\w+)\b', re.sub(r',\r?\n\s+', ',', body)))
+              # One control per line: fold the continuations the resource editor wrapped.
+              bodies[name] = body = re.sub(r',\r?\n\s+', ',', body)
+              ids = set(re.findall(r'\b(IDC_\w+)\b', body))
               dialogs[name] = ids
               for i in ids:
                   owners.setdefault(i, set()).add(name)
@@ -169,9 +171,8 @@ jobs:
               if not dlg.startswith('IDD_OPTION'):
                   continue
               head = re.search(r'^%s DIALOGE?X? +0, 0, (\d+), (\d+)' % dlg, rc, re.M)
-              body = re.search(r'^%s DIALOGE?X? .*?\r?\n(.*?)^END\r?$' % dlg, rc, re.M | re.S)
               w, h = (int(x) for x in head.groups())
-              for line in re.sub(r',\r?\n\s+', ',', body.group(1)).splitlines():
+              for line in bodies[dlg].splitlines():
                   m = re.search(r'(IDC_\w+)\b.*?,(\d+),(\d+),(\d+),(\d+)\s*(?:,[^,]*)?$', line.strip())
                   if not m:
                       continue
@@ -181,16 +182,23 @@ jobs:
                   if x + cw > w or y + ch > h:
                       bad.append('%s: %s falls outside the %dx%d page' % (dlg, m.group(1), w, h))
 
-          # Focus enters a radio group only at its first control, so a group holding
-          # radios must start with one carrying both WS_GROUP and WS_TABSTOP.
+          # Focus reaches a radio group only through its first radio, which needs WS_TABSTOP.
           ctl = (r'(CONTROL|GROUPBOX|[LCR]TEXT|EDITTEXT|COMBOBOX|LISTBOX|PUSHBUTTON'
                  r'|DEFPUSHBUTTON|CHECKBOX|RADIOBUTTON|AUTORADIOBUTTON|AUTOCHECKBOX'
                  r'|AUTO3STATE|STATE3|ICON|SCROLLBAR)\s')
           radio = r'\bBS_(AUTO)?RADIOBUTTON\b|^(AUTO)?RADIOBUTTON\s'
-          for name, body in re.findall(r'^(IDD_\w+) DIALOGE?X? .*?^BEGIN\r?\n(.*?)^END\r?$',
-                                       rc, re.M | re.S):
+          # An id ending in pass/pwd holds a secret; a word that merely ends that
+          # way (compass, bypass) does not.
+          pwid = r'(?i)^ID\w+(?<!com)(?<!by)(?<!sur)(?:pass|pwd)$'
+
+          def named(line):
+              # Id plus caption: a control id may be IDC_STATIC or -1, neither of them unique.
+              m = re.match(r'\w+\s+(?:("(?:[^"]|"")*")\s*,\s*)?([-\w]+)', line)
+              return (m.group(2), m.group(1) or '""') if m else (line[:20], '""')
+
+          for name in sorted(dialogs):
               groups = []
-              for line in re.sub(r',\r?\n\s+', ',', body).splitlines():
+              for line in bodies[name].splitlines():
                   line = re.sub(r'NOT\s+WS_\w+', '', line.strip())
                   if not re.match(ctl, line):
                       continue
@@ -198,20 +206,17 @@ jobs:
                       groups.append([])
                   groups[-1].append(line)
                   # Same pass, cheap: a password edit that shows what is typed.
-                  m = re.match(r'EDITTEXT\s+(\w*(?i:pass|pwd)\w*)', line)
-                  if m and 'ES_PASSWORD' not in line:
-                      bad.append('%s: %s takes a password without ES_PASSWORD' % (name, m.group(1)))
+                  ident = named(line)[0]
+                  edit = re.match(r'EDITTEXT\s', line) or re.search(r',\s*"Edit"\s*,', line, re.I)
+                  if edit and re.search(pwid, ident) and 'ES_PASSWORD' not in line:
+                      bad.append('%s: %s takes a password without ES_PASSWORD' % (name, ident))
               for g in groups:
-                  if not any(re.search(radio, l) for l in g):
+                  first = next((l for l in g if re.search(radio, l)), None)
+                  if first is None or 'WS_TABSTOP' in first:
                       continue
-                  lead = re.search(r'\b(ID\w+)\b', re.sub(r'"[^"]*"', '', g[0]))
-                  lead = lead.group(1) if lead else g[0][:20]
-                  if not (re.search(radio, g[0]) and 'WS_GROUP' in g[0]):
-                      bad.append('%s: radio group leader %s has no WS_GROUP/WS_TABSTOP'
-                                 % (name, lead))
-                  elif 'WS_TABSTOP' not in g[0]:
-                      bad.append('%s: radio group starting at %s has no WS_TABSTOP'
-                                 % (name, lead))
+                  ident, cap = named(first)
+                  bad.append('%s: %s %s starts a radio group and has no WS_TABSTOP'
+                             % (name, ident, cap))
 
           if bad:
               print('\n'.join(sorted(bad)))

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -181,6 +181,38 @@ jobs:
                   if x + cw > w or y + ch > h:
                       bad.append('%s: %s falls outside the %dx%d page' % (dlg, m.group(1), w, h))
 
+          # Focus enters a radio group only at its first control, so a group holding
+          # radios must start with one carrying both WS_GROUP and WS_TABSTOP.
+          ctl = (r'(CONTROL|GROUPBOX|[LCR]TEXT|EDITTEXT|COMBOBOX|LISTBOX|PUSHBUTTON'
+                 r'|DEFPUSHBUTTON|CHECKBOX|RADIOBUTTON|AUTORADIOBUTTON|AUTOCHECKBOX'
+                 r'|AUTO3STATE|STATE3|ICON|SCROLLBAR)\s')
+          radio = r'\bBS_(AUTO)?RADIOBUTTON\b|^(AUTO)?RADIOBUTTON\s'
+          for name, body in re.findall(r'^(IDD_\w+) DIALOGE?X? .*?^BEGIN\r?\n(.*?)^END\r?$',
+                                       rc, re.M | re.S):
+              groups = []
+              for line in re.sub(r',\r?\n\s+', ',', body).splitlines():
+                  line = re.sub(r'NOT\s+WS_\w+', '', line.strip())
+                  if not re.match(ctl, line):
+                      continue
+                  if 'WS_GROUP' in line or not groups:
+                      groups.append([])
+                  groups[-1].append(line)
+                  # Same pass, cheap: a password edit that shows what is typed.
+                  m = re.match(r'EDITTEXT\s+(\w*(?i:pass|pwd)\w*)', line)
+                  if m and 'ES_PASSWORD' not in line:
+                      bad.append('%s: %s takes a password without ES_PASSWORD' % (name, m.group(1)))
+              for g in groups:
+                  if not any(re.search(radio, l) for l in g):
+                      continue
+                  lead = re.search(r'\b(ID\w+)\b', re.sub(r'"[^"]*"', '', g[0]))
+                  lead = lead.group(1) if lead else g[0][:20]
+                  if not (re.search(radio, g[0]) and 'WS_GROUP' in g[0]):
+                      bad.append('%s: radio group leader %s has no WS_GROUP/WS_TABSTOP'
+                                 % (name, lead))
+                  elif 'WS_TABSTOP' not in g[0]:
+                      bad.append('%s: radio group starting at %s has no WS_TABSTOP'
+                                 % (name, lead))
+
           if bad:
               print('\n'.join(sorted(bad)))
               sys.exit(1)


### PR DESCRIPTION
The encoding job already reads `WinHTTrack.rc` dialog by dialog, so it now also splits each dialog on `WS_GROUP` and looks at the first radio button in each group. That radio is where focus lands, so if it has no `WS_TABSTOP` the keyboard never reaches the group. The same pass flags an edit box whose id ends in pass or pwd and has no `ES_PASSWORD`, whether it is written as `EDITTEXT` or as a `CONTROL` of class `Edit`.

Nothing else here could catch either bug. `--selftest` runs before any window exists, so it has no HWND to ask, and the screenshot walk drives controls by resource id without ever sending a key. Against `be0e5f2~1` the check prints the three defects #139 fixed and exits 1; against master it is silent. It looks at that one radio rather than counting tab stops per group because a one-per-group rule flags `IDC_select_save`, which shares a group with `IDC_select_start` on purpose.

Two shapes it cannot see. A second radio set appended to an existing group merges into that group, so only the first set's entry point gets checked. And a dialog written with `{` and `}` instead of `BEGIN` and `END` is skipped whole, though none exist today.