### PR TITLE
Say what a cancelled shutdown really does to the mirror

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -287,7 +287,7 @@ runs:
         }
 
         # No CI can log off, so this count is the only proof the session-end stop ran.
-        if ("$so" -notmatch 'session end ok on 6 checks') {
+        if ("$so" -notmatch 'session end ok on 7 checks') {
           throw "selftest did not check the session-end stop"
         }
 

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -197,9 +197,9 @@ void CMainFrame::OnClose()
   }
 }
 
-/* A logoff otherwise kills the engine mid-write. Asked here and not at WM_ENDSESSION
-   because the engine's only unwind time is the rest of the shutdown sequence; the cost is
-   that a shutdown vetoed after this point leaves the mirror stopping anyway. */
+/* A logoff otherwise kills the engine mid-write. Asked here, not at WM_ENDSESSION,
+   because the engine's only unwind time is the rest of the shutdown sequence.
+   A shutdown cancelled after this point still leaves the mirror stopping. */
 BOOL CMainFrame::OnQueryEndSession()
 {
 	const BOOL ending = CMDIFrameWnd::OnQueryEndSession();

--- a/WinHTTrack/MainFrm.cpp
+++ b/WinHTTrack/MainFrm.cpp
@@ -198,7 +198,8 @@ void CMainFrame::OnClose()
 }
 
 /* A logoff otherwise kills the engine mid-write. Asked here and not at WM_ENDSESSION
-   because the engine's only unwind time is the rest of the shutdown sequence. */
+   because the engine's only unwind time is the rest of the shutdown sequence; the cost is
+   that a shutdown vetoed after this point leaves the mirror stopping anyway. */
 BOOL CMainFrame::OnQueryEndSession()
 {
 	const BOOL ending = CMDIFrameWnd::OnQueryEndSession();

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -214,7 +214,8 @@ typedef enum {
 WhttMirrorStop RequestMirrorStop();
 
 /* The decision both session-end handlers share: ask at most once per mirror, and never
-   wait. bEnding is WM_ENDSESSION's flag, FALSE for a shutdown the user cancelled.
+   wait. bEnding is the query handler's own answer, so the ask precedes any veto: a
+   cancelled shutdown leaves the mirror stopping, and nothing can un-ask it.
    @return what the mirror was doing, and whether this call asked it to stop. */
 WhttMirrorStop SessionEndStop(BOOL bEnding);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -214,8 +214,8 @@ typedef enum {
 WhttMirrorStop RequestMirrorStop();
 
 /* The decision both session-end handlers share: ask at most once per mirror, and never
-   wait. bEnding is our answer at WM_QUERYENDSESSION, then WM_ENDSESSION's flag, so the
-   ask precedes any cancellation, which the running mirror does not survive.
+   wait. bEnding is our answer at WM_QUERYENDSESSION, then WM_ENDSESSION's flag: a
+   cancellation reaching us first asks nothing, one arriving after leaves the mirror stopping.
    @return what the mirror was doing, and whether this call asked it to stop. */
 WhttMirrorStop SessionEndStop(BOOL bEnding);
 

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -214,8 +214,8 @@ typedef enum {
 WhttMirrorStop RequestMirrorStop();
 
 /* The decision both session-end handlers share: ask at most once per mirror, and never
-   wait. bEnding is the query handler's own answer, so the ask precedes any veto: a
-   cancelled shutdown leaves the mirror stopping, and nothing can un-ask it.
+   wait. bEnding is our answer at WM_QUERYENDSESSION, then WM_ENDSESSION's flag, so the
+   ask precedes any cancellation, which the running mirror does not survive.
    @return what the mirror was doing, and whether this call asked it to stop. */
 WhttMirrorStop SessionEndStop(BOOL bEnding);
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1232,7 +1232,7 @@ BOOL CWinHTTrackApp::InitInstance()
       /* state.stop is what hts_request_stop() sets; nothing exported reads it back. */
       if (SessionEndStop(FALSE) != WHTT_STOP_NOT_ENDING || soft_term_requested
           || global_opt->state.stop) {
-        fprintf(stderr, "FATAL: a cancelled session end stopped the mirror\n");
+        fprintf(stderr, "FATAL: a FALSE session-end flag asked the mirror to stop\n");
         fflush(stderr);
         ExitProcess(3);
       } else
@@ -1262,6 +1262,16 @@ BOOL CWinHTTrackApp::InitInstance()
       termine = termine_requested = shell_terminated = soft_term_requested = 0;
       if (SessionEndStop(TRUE) != WHTT_STOP_ASKED || !global_opt->state.stop) {
         fprintf(stderr, "FATAL: a cancelled shutdown consumed the next mirror's stop\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      /* Nothing un-asks the query-phase stop, so the cancelled shutdown above is the
+         only one the mirror survives: this one is already on its way down. */
+      if (SessionEndStop(FALSE) != WHTT_STOP_NOT_ENDING || !soft_term_requested
+          || !global_opt->state.stop) {
+        fprintf(stderr, "FATAL: a veto after the query phase claimed to leave the mirror running\n");
         fflush(stderr);
         ExitProcess(3);
       } else

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1267,10 +1267,13 @@ BOOL CWinHTTrackApp::InitInstance()
       } else
         nchecks++;
 
-      /* Nothing un-asks the query-phase stop, so the cancelled shutdown above is the
-         only one the mirror survives: this one is already on its way down. */
-      if (!soft_term_requested || !global_opt->state.stop) {
-        fprintf(stderr, "FATAL: the post-ask case lost the ask it runs on\n");
+      /* The order Windows really sends: the query phase asks, the cancellation follows,
+         and nothing un-asks it. On its own mirror, so no ordering can carry this case. */
+      hts_free_opt(global_opt);
+      global_opt = hts_create_opt();
+      termine = termine_requested = shell_terminated = soft_term_requested = 0;
+      if (SessionEndStop(TRUE) != WHTT_STOP_ASKED) {
+        fprintf(stderr, "FATAL: the post-ask case could not arm its own ask\n");
         fflush(stderr);
         ExitProcess(3);
       }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1269,9 +1269,14 @@ BOOL CWinHTTrackApp::InitInstance()
 
       /* Nothing un-asks the query-phase stop, so the cancelled shutdown above is the
          only one the mirror survives: this one is already on its way down. */
+      if (!soft_term_requested || !global_opt->state.stop) {
+        fprintf(stderr, "FATAL: the post-ask case lost the ask it runs on\n");
+        fflush(stderr);
+        ExitProcess(3);
+      }
       if (SessionEndStop(FALSE) != WHTT_STOP_NOT_ENDING || !soft_term_requested
           || !global_opt->state.stop) {
-        fprintf(stderr, "FATAL: a veto after the query phase claimed to leave the mirror running\n");
+        fprintf(stderr, "FATAL: a cancellation after the query phase claimed to leave the mirror running\n");
         fflush(stderr);
         ExitProcess(3);
       } else
@@ -1280,6 +1285,12 @@ BOOL CWinHTTrackApp::InitInstance()
       hts_free_opt(global_opt);
       global_opt = NULL;
       termine = soft_term_requested = 0;
+      /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
+      if (nchecks != 7) {
+        fprintf(stderr, "FATAL: session end ran %d checks, expected 7\n", nchecks);
+        fflush(stderr);
+        ExitProcess(3);
+      }
       printf("session end ok on %d checks\n", nchecks);
     }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a


### PR DESCRIPTION
`SessionEndStop`'s contract named `bEnding` as `WM_ENDSESSION`'s flag, but `OnQueryEndSession` passes its own answer to the query, which is settled before any other application has voted. The engine is therefore asked to stop during the query phase, and a shutdown vetoed after that leaves the mirror stopping with nothing able to un-ask it: `soft_term_requested` clears only in `init_lance()`, for the next mirror.

The behaviour stays. Asking in the query phase is what buys the engine the query-to-end interval to unwind, which is the mid-write kill #141 exists to prevent, and a stopped mirror resumes from `interrupted.lock`. Only the claim changes, in the contract and at the call site.

The selftest case that read as covering a cancelled shutdown called `SessionEndStop(FALSE)` from a clean state, a sequence Windows never produces, so it passed on either behaviour. A seventh case runs the real order instead, query-phase ask then veto, and pins that the mirror is already on its way down. No unit test can see which argument the handler passes, so the call-site comment is the guard there.