### PR TITLE
Decode the catalog before unescaping it, not after

### DIFF
--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -481,16 +481,18 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
               /* Add key */
               if (strnotempty(intkey)) {
                 /* Convert once here: most LANG_* sites bypass the SetDlgItemTextCP()
-                   wrappers, so converting at display time would miss them. */
-                char unescaped[8192];
-                conv_printf(value,unescaped);
-                len = (int) strlen(unescaped);
+                   wrappers, so converting at display time would miss them. Decode
+                   before conv_printf(), whose DBCS pairing reads CP_ACP and would
+                   take a UTF-8 byte for a lead byte and eat the escape after it. */
+                char decoded[8192];
+                if (IsValidUTF8(value,(int) strlen(value)))
+                  CopyTextUTF8ToCP(decoded,sizeof(decoded),value);
+                else
+                  lstrcpynA(decoded,value,sizeof(decoded));   /* legacy catalog: leave it alone */
+                len = (int) strlen(decoded);
                 buff = (char*)malloc(len+2);
                 if (buff) {
-                  if (IsValidUTF8(unescaped,len))
-                    CopyTextUTF8ToCP(buff,len+2,unescaped);
-                  else
-                    memcpy(buff,unescaped,len+1);   /* legacy catalog: leave it alone */
+                  conv_printf(decoded,buff);
                   coucal_add(NewLangStr,intkey,(intptr_t)buff);
                 }
               }

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -481,9 +481,8 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
               /* Add key */
               if (strnotempty(intkey)) {
                 /* Convert once here: most LANG_* sites bypass the SetDlgItemTextCP()
-                   wrappers, so converting at display time would miss them. Decode
-                   before conv_printf(), whose DBCS pairing reads CP_ACP and would
-                   take a UTF-8 byte for a lead byte and eat the escape after it. */
+                   wrappers, so converting at display time would miss them. Decode first:
+                   conv_printf()'s DBCS pairing reads CP_ACP and must not see UTF-8 bytes. */
                 char decoded[8192];
                 if (IsValidUTF8(value,(int) strlen(value)))
                   CopyTextUTF8ToCP(decoded,sizeof(decoded),value);


### PR DESCRIPTION
A defect in #144, found by httrack-windows-2956809 and confirmed here independently.

`conv_printf()` pairs bytes on `IsDBCSLeadByteEx(CP_ACP, ...)` so a Shift-JIS or BIG5 trail byte of `0x5C` is not mistaken for an escape. #144 ran it before the UTF-8 decode, which hands that guard bytes it was never designed for: on a DBCS system a UTF-8 byte in the lead range pairs with the backslash after it, and a real escape is eaten.

Simulated over the actual catalogs, using the conversion #1407 will make: 29 escapes lost in Japanese, 7 in Chinese-Simplified, 5 in Chinese-BIG5, each one a literal `\n` reaching a dialog. Decoding first and unescaping second restores all three byte for byte identical to what they produce today.

Harmless until the catalogs actually convert, because the validity gate leaves legacy bytes alone, so this can land on either side of the engine change.

CI cannot see the defect or the fix. The runner is cp1252, where `IsDBCSLeadByteEx` is always false, so the pairing never happens and every escape survives either way. The evidence is the simulation, not a green leg, and verifying it for real needs a Japanese or Chinese system locale.

One aside for whoever writes #1407's converter: `Chinese-BIG5.txt` contains `0xf9d8`, in the BIG5 ETen extension area. `iconv` and Windows cp950 accept it; a strict BIG5 decoder rejects it and the file will not convert.
