### PR TITLE
Guard the catalog decode/unescape order with a check that can fail

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -215,7 +215,7 @@ runs:
         }
         # Swapping decode and unescape is invisible on this cp1252 runner, so this drives CP932.
         # The first assertion is the control that the hazard fires at all.
-        if ("$so" -notmatch 'unescaping order ok on 4 checks') {
+        if ("$so" -notmatch 'unescaping order ok on 5 checks') {
           throw 'selftest did not prove the catalog is decoded before it is unescaped'
         }
         # Every help button hands one of these to the browser: an unescaped space truncates

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -213,9 +213,9 @@ runs:
         if ("$so" -notmatch 'catalog decoding ok on 3 checks') {
           throw 'selftest did not report catalog decoding: a legacy catalog may be silently mangled'
         }
-        # Swapping the decode and the unescape is invisible on this cp1252 runner, so the
-        # check drives CP932 itself; its first assertion is the control that the hazard fires.
-        if ("$so" -notmatch 'unescaping order ok on 3 checks') {
+        # Swapping decode and unescape is invisible on this cp1252 runner, so this drives CP932.
+        # The first assertion is the control that the hazard fires at all.
+        if ("$so" -notmatch 'unescaping order ok on 4 checks') {
           throw 'selftest did not prove the catalog is decoded before it is unescaped'
         }
         # Every help button hands one of these to the browser: an unescaped space truncates

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -215,7 +215,7 @@ runs:
         }
         # Swapping decode and unescape is invisible on this cp1252 runner, so this drives CP932.
         # The first assertion is the control that the hazard fires at all.
-        if ("$so" -notmatch 'unescaping order ok on 5 checks') {
+        if ("$so" -notmatch 'unescaping order ok on 7 checks(?! \(utf-8)') {
           throw 'selftest did not prove the catalog is decoded before it is unescaped'
         }
         # Every help button hands one of these to the browser: an unescaped space truncates

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -213,6 +213,11 @@ runs:
         if ("$so" -notmatch 'catalog decoding ok on 3 checks') {
           throw 'selftest did not report catalog decoding: a legacy catalog may be silently mangled'
         }
+        # Swapping the decode and the unescape is invisible on this cp1252 runner, so the
+        # check drives CP932 itself; its first assertion is the control that the hazard fires.
+        if ("$so" -notmatch 'unescaping order ok on 3 checks') {
+          throw 'selftest did not prove the catalog is decoded before it is unescaped'
+        }
         # Every help button hands one of these to the browser: an unescaped space truncates
         # the path, an unescaped '#' names a file, since NTFS allows one in a filename.
         if ("$so" -notmatch 'help URLs ok on 5 checks') {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -379,6 +379,7 @@ BOOL CWinHTTrackApp::InitInstance()
       }
     }
     LANG_SELFTEST_DECODE();
+    LANG_SELFTEST_ESCAPE_ORDER();
     /* An unescaped space truncates the path, and an unescaped '#' names a file rather
        than a section, since NTFS allows one in a filename. */
     {

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -275,23 +275,27 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
   static const char utf8_escape[] = "\xe3\x81\x82" "\\n";      /* U+3042, then a \n escape */
   static const char legacy[] = "Crit" "\xe8" "re" "\\n";         /* not UTF-8: must pass through */
   static const char lead_escape[] = "\x82" "\\n";                 /* leads on CP932, plain on CP1252 */
+  static const char no_escape[] = "Crit" "\xe8" "re";            /* nothing to shrink: sizes the buffer */
   int nchecks = 0;
   char hazard[32];
   char* cooked;
 
-  if (!IsValidCodePage(932)) {   /* a runner-image change, not a regression */
-    printf("unescaping order skipped: codepage 932 unavailable\n");
-    return;
+  /* Both of these leave the hazard unreachable, so say so rather than blaming the order. */
+  if (!IsValidCodePage(932)) {
+    fprintf(stderr, "FATAL: codepage 932 is unavailable, so this check cannot run\n");
+    fflush(stderr);
+    ExitProcess(3);
   }
-  if (GetACP() == CP_UTF8) {   /* decoding is then identity, so check 2 would accuse the fix */
-    printf("unescaping order skipped: the ANSI codepage is UTF-8\n");
-    return;
+  if (GetACP() == CP_UTF8) {
+    fprintf(stderr, "FATAL: the ANSI codepage is UTF-8, so decoding cannot model the hazard\n");
+    fflush(stderr);
+    ExitProcess(3);
   }
 
-  /* Negative control: the hazard must really exist, or the check below proves nothing. */
+  /* Negative control: the hazard must really exist, or the checks below prove nothing. */
   conv_printf(utf8_escape,hazard,932);
   if (strchr(hazard,'\n') != NULL) {
-    fprintf(stderr, "FATAL: unescaping UTF-8 on CP932 kept the escape; the check is vacuous\n");
+    fprintf(stderr, "FATAL: unescaping UTF-8 on CP932 kept the escape; the checks below prove nothing\n");
     fflush(stderr);
     ExitProcess(3);
   }
@@ -299,7 +303,7 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
 
   cooked = ConvertCatalogValue(utf8_escape,932);
   if (cooked == NULL || strchr(cooked,'\n') == NULL) {
-    fprintf(stderr, "FATAL: the escape was eaten: the catalog is unescaped before it is decoded\n");
+    fprintf(stderr, "FATAL: the escape was eaten: the helper unescapes before it decodes\n");
     fflush(stderr);
     ExitProcess(3);
   }
@@ -327,6 +331,16 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
   cooked = ConvertCatalogValue(lead_escape,1252);
   if (cooked == NULL || strchr(cooked,'\n') == NULL) {
     fprintf(stderr, "FATAL: a lead byte on one codepage ate an escape on another\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  free(cooked);
+  nchecks++;
+
+  /* Every case above shrinks by at least the escape, so none of them sizes buff exactly. */
+  cooked = ConvertCatalogValue(no_escape,CP_ACP);
+  if (cooked == NULL || strcmp(cooked,no_escape) != 0) {
+    fprintf(stderr, "FATAL: an entry with no escape did not survive unchanged\n");
     fflush(stderr);
     ExitProcess(3);
   }

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -265,89 +265,99 @@ static char* ConvertCatalogValue(const char* value, UINT cp) {
   len = (int) strlen(decoded);
   buff = (char*)malloc(len+2);
   if (buff)
-    conv_printf(decoded,buff,cp);   /* unescaping only ever shrinks */
+    conv_printf(decoded,buff,cp);   /* never grows: len+1 is the exact bound */
   return buff;
 }
 
 /* --selftest: swapping the two steps is invisible on a Latin codepage, so this drives CP932.
    There, unescaping first reads 0x82 as a lead byte and eats the escape. */
 void LANG_SELFTEST_ESCAPE_ORDER(void) {
-  static const char utf8_escape[] = "\xe3\x81\x82" "\\n";      /* U+3042, then a \n escape */
-  static const char legacy[] = "Crit" "\xe8" "re" "\\n";         /* not UTF-8: must pass through */
-  static const char lead_escape[] = "\x82" "\\n";                 /* leads on CP932, plain on CP1252 */
-  static const char no_escape[] = "Crit" "\xe8" "re";            /* nothing to shrink: sizes the buffer */
+  static const char utf8_escape[] = "\xe3\x81\x82" "\\n";   /* U+3042, then a \n escape */
+  static const char legacy[] = "Crit" "\xe8" "re" "\\n";    /* not UTF-8: must pass through */
+  static const char lead_escape[] = "\x82" "\\n";           /* leads on CP932, plain on CP1252 */
+  static const char lead_tail[] = "AB" "\x82";              /* no trail byte: what i+1<len guards */
+  static const char no_escape[] = "Crit" "\xe8" "re";       /* nothing to drop: sizes buff exactly */
+  /* A UTF-8 ANSI codepage decodes U+3042 losslessly, so only that one case cannot run. */
+  const BOOL utf8_acp = (GetACP() == CP_UTF8);
   int nchecks = 0;
   char hazard[32];
   char* cooked;
 
-  /* Both of these leave the hazard unreachable, so say so rather than blaming the order. */
   if (!IsValidCodePage(932)) {
     fprintf(stderr, "FATAL: codepage 932 is unavailable, so this check cannot run\n");
     fflush(stderr);
     ExitProcess(3);
   }
-  if (GetACP() == CP_UTF8) {
-    fprintf(stderr, "FATAL: the ANSI codepage is UTF-8, so decoding cannot model the hazard\n");
-    fflush(stderr);
-    ExitProcess(3);
-  }
 
-  /* Negative control: the hazard must really exist, or the checks below prove nothing. */
+  /* Control: the hazard must really exist, or the checks below prove nothing. */
   conv_printf(utf8_escape,hazard,932);
   if (strchr(hazard,'\n') != NULL) {
     fprintf(stderr, "FATAL: unescaping UTF-8 on CP932 kept the escape; the checks below prove nothing\n");
     fflush(stderr);
     ExitProcess(3);
-  }
-  nchecks++;
+  } else
+    nchecks++;
 
-  cooked = ConvertCatalogValue(utf8_escape,932);
-  if (cooked == NULL || strchr(cooked,'\n') == NULL) {
-    fprintf(stderr, "FATAL: the escape was eaten: the helper unescapes before it decodes\n");
-    fflush(stderr);
-    ExitProcess(3);
+  if (!utf8_acp) {
+    cooked = ConvertCatalogValue(utf8_escape,932);
+    if (cooked == NULL || strchr(cooked,'\n') == NULL) {
+      fprintf(stderr, "FATAL: the escape was eaten: the helper unescapes before it decodes\n");
+      fflush(stderr);
+      ExitProcess(3);
+    } else
+      nchecks++;
+    free(cooked);
   }
-  free(cooked);
-  nchecks++;
 
   cooked = ConvertCatalogValue(legacy,CP_ACP);
-  if (cooked == NULL || strchr(cooked,'\n') == NULL || strstr(cooked,"Crit\xe8" "re") == NULL) {
+  if (cooked == NULL || strcmp(cooked,"Crit" "\xe8" "re" "\n") != 0) {
     fprintf(stderr, "FATAL: a legacy-charset entry lost its accent or its escape\n");
     fflush(stderr);
     ExitProcess(3);
-  }
+  } else
+    nchecks++;
   free(cooked);
-  nchecks++;
 
-  /* 0x82 leads on CP932 and is an ordinary byte on CP1252, so the same entry must unescape
-     differently under each: that is what proves cp reaches conv_printf at all. */
+  /* 0x82 leads on CP932 and is ordinary on CP1252, so the same entry must come back
+     differently under each. Only these two catch the helper forcing CP_ACP, so they
+     count separately: sharing one increment would hide the deletion of either. */
   cooked = ConvertCatalogValue(lead_escape,932);
-  if (cooked == NULL || strchr(cooked,'\n') != NULL) {
-    fprintf(stderr, "FATAL: the codepage never reached the unescaper\n");
+  if (cooked == NULL || strcmp(cooked,"\x82" "\\n") != 0) {
+    fprintf(stderr, "FATAL: CP932 did not pair the lead byte with the backslash\n");
     fflush(stderr);
     ExitProcess(3);
-  }
+  } else
+    nchecks++;
   free(cooked);
-  cooked = ConvertCatalogValue(lead_escape,1252);
-  if (cooked == NULL || strchr(cooked,'\n') == NULL) {
-    fprintf(stderr, "FATAL: a lead byte on one codepage ate an escape on another\n");
-    fflush(stderr);
-    ExitProcess(3);
-  }
-  free(cooked);
-  nchecks++;
 
-  /* Every case above shrinks by at least the escape, so none of them sizes buff exactly. */
+  cooked = ConvertCatalogValue(lead_escape,1252);
+  if (cooked == NULL || strcmp(cooked,"\x82" "\n") != 0) {
+    fprintf(stderr, "FATAL: CP1252 treated the lead byte as one, so cp never reached the unescaper\n");
+    fflush(stderr);
+    ExitProcess(3);
+  } else
+    nchecks++;
+  free(cooked);
+
+  cooked = ConvertCatalogValue(lead_tail,932);
+  if (cooked == NULL || strcmp(cooked,"AB" "\x82") != 0) {
+    fprintf(stderr, "FATAL: a trailing lead byte was paired with the terminator\n");
+    fflush(stderr);
+    ExitProcess(3);
+  } else
+    nchecks++;
+  free(cooked);
+
   cooked = ConvertCatalogValue(no_escape,CP_ACP);
   if (cooked == NULL || strcmp(cooked,no_escape) != 0) {
     fprintf(stderr, "FATAL: an entry with no escape did not survive unchanged\n");
     fflush(stderr);
     ExitProcess(3);
-  }
+  } else
+    nchecks++;
   free(cooked);
-  nchecks++;
 
-  printf("unescaping order ok on %d checks\n", nchecks);
+  printf("unescaping order ok on %d checks%s\n", nchecks, utf8_acp ? " (utf-8 acp)" : "");
 }
 
 /* --selftest: the catalogs are the only non-ASCII data the GUI loads, and the

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -250,6 +250,68 @@ static BOOL IsValidUTF8(const char* s, int len) {
       || MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, len, NULL, 0) > 0;
 }
 
+/* One catalog entry: decode, then unescape — the only point covering the LANG_* sites that
+   bypass SetDlgItemTextCP(). Codepage explicit so --selftest drives a DBCS one; caller frees. */
+static char* lang_cook_value(const char* value, UINT cp) {
+  char decoded[8192];
+  int len;
+  char* buff;
+
+  if (IsValidUTF8(value,(int) strlen(value)))
+    CopyTextUTF8ToCP(decoded,sizeof(decoded),value);
+  else
+    lstrcpynA(decoded,value,sizeof(decoded));   /* legacy catalog: leave it alone */
+  len = (int) strlen(decoded);
+  buff = (char*)malloc(len+2);
+  if (buff)
+    conv_printf(decoded,buff,cp);   /* unescaping only ever shrinks */
+  return buff;
+}
+
+/* --selftest: swapping the two steps above is invisible on a Latin codepage, so drive
+   CP932, where unescaping first reads 0x82 as a lead byte and eats the escape. */
+void LANG_SELFTEST_ESCAPE_ORDER(void) {
+  static const char utf8_escape[] = "\xe3\x81\x82" "\\n";      /* U+3042, then a \n escape */
+  static const char legacy[] = "Crit" "\xe8" "re" "\\n";         /* not UTF-8: must pass through */
+  int nchecks = 0;
+  char hazard[32];
+  char* cooked;
+
+  if (!IsValidCodePage(932)) {   /* a runner-image change, not a regression */
+    printf("unescaping order skipped: codepage 932 unavailable\n");
+    return;
+  }
+
+  /* Negative control: the hazard must really exist, or the check below proves nothing. */
+  conv_printf((char*)utf8_escape,hazard,932);
+  if (strchr(hazard,'\n') != NULL) {
+    fprintf(stderr, "FATAL: unescaping UTF-8 on CP932 kept the escape; the check is vacuous\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  nchecks++;
+
+  cooked = lang_cook_value(utf8_escape,932);
+  if (cooked == NULL || strchr(cooked,'\n') == NULL) {
+    fprintf(stderr, "FATAL: the escape was eaten: the catalog is unescaped before it is decoded\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  free(cooked);
+  nchecks++;
+
+  cooked = lang_cook_value(legacy,CP_ACP);
+  if (cooked == NULL || strchr(cooked,'\n') == NULL || strstr(cooked,"Crit\xe8" "re") == NULL) {
+    fprintf(stderr, "FATAL: a legacy-charset entry lost its accent or its escape\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  free(cooked);
+  nchecks++;
+
+  printf("unescaping order ok on %d checks\n", nchecks);
+}
+
 /* --selftest: the catalogs are the only non-ASCII data the GUI loads, and the
    English-only smoke walk cannot see a decoding regression. */
 void LANG_SELFTEST_DECODE(void) {
@@ -444,7 +506,6 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
           */
 
           if (strnotempty(extkey) && strnotempty(value)) {
-            int len;
             char* buff;
             const char* intkey;
             
@@ -480,20 +541,9 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
               
               /* Add key */
               if (strnotempty(intkey)) {
-                /* Convert once here: most LANG_* sites bypass the SetDlgItemTextCP()
-                   wrappers, so converting at display time would miss them. Decode first:
-                   conv_printf()'s DBCS pairing reads CP_ACP and must not see UTF-8 bytes. */
-                char decoded[8192];
-                if (IsValidUTF8(value,(int) strlen(value)))
-                  CopyTextUTF8ToCP(decoded,sizeof(decoded),value);
-                else
-                  lstrcpynA(decoded,value,sizeof(decoded));   /* legacy catalog: leave it alone */
-                len = (int) strlen(decoded);
-                buff = (char*)malloc(len+2);
-                if (buff) {
-                  conv_printf(decoded,buff);
+                buff = lang_cook_value(value,CP_ACP);
+                if (buff)
                   coucal_add(NewLangStr,intkey,(intptr_t)buff);
-                }
               }
               
             }
@@ -525,12 +575,12 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
     limit_to[0]='\0';
 }
 
-void conv_printf(char* from,char* to) {
+void conv_printf(char* from,char* to,UINT cp) {
   int i=0,j=0,len;
   len = (int) strlen(from);
   while(i<len) {
     /* A DBCS trail byte can be 0x5C; copy the pair before it is mistaken for an escape. */
-    if (IsDBCSLeadByteEx(CP_ACP,(unsigned char)from[i]) && i+1<len) {
+    if (IsDBCSLeadByteEx(cp,(unsigned char)from[i]) && i+1<len) {
       to[j++]=from[i++];
       to[j++]=from[i++];
       continue;

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -250,9 +250,10 @@ static BOOL IsValidUTF8(const char* s, int len) {
       || MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, len, NULL, 0) > 0;
 }
 
-/* One catalog entry: decode, then unescape — the only point covering the LANG_* sites that
-   bypass SetDlgItemTextCP(). Codepage explicit so --selftest drives a DBCS one; caller frees. */
-static char* lang_cook_value(const char* value, UINT cp) {
+/* One catalog entry: decode, then unescape. The only point covering the LANG_* sites that
+   bypass SetDlgItemTextCP(). cp drives the unescape alone, the decode always targets the ANSI
+   codepage. Returns a malloc'd string the caller frees, or NULL if the allocation failed. */
+static char* ConvertCatalogValue(const char* value, UINT cp) {
   char decoded[8192];
   int len;
   char* buff;
@@ -268,11 +269,12 @@ static char* lang_cook_value(const char* value, UINT cp) {
   return buff;
 }
 
-/* --selftest: swapping the two steps above is invisible on a Latin codepage, so drive
-   CP932, where unescaping first reads 0x82 as a lead byte and eats the escape. */
+/* --selftest: swapping the two steps is invisible on a Latin codepage, so this drives CP932.
+   There, unescaping first reads 0x82 as a lead byte and eats the escape. */
 void LANG_SELFTEST_ESCAPE_ORDER(void) {
   static const char utf8_escape[] = "\xe3\x81\x82" "\\n";      /* U+3042, then a \n escape */
   static const char legacy[] = "Crit" "\xe8" "re" "\\n";         /* not UTF-8: must pass through */
+  static const char lead_escape[] = "\x82" "\\n";                 /* leads on CP932, plain on CP1252 */
   int nchecks = 0;
   char hazard[32];
   char* cooked;
@@ -281,9 +283,13 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
     printf("unescaping order skipped: codepage 932 unavailable\n");
     return;
   }
+  if (GetACP() == CP_UTF8) {   /* decoding is then identity, so check 2 would accuse the fix */
+    printf("unescaping order skipped: the ANSI codepage is UTF-8\n");
+    return;
+  }
 
   /* Negative control: the hazard must really exist, or the check below proves nothing. */
-  conv_printf((char*)utf8_escape,hazard,932);
+  conv_printf(utf8_escape,hazard,932);
   if (strchr(hazard,'\n') != NULL) {
     fprintf(stderr, "FATAL: unescaping UTF-8 on CP932 kept the escape; the check is vacuous\n");
     fflush(stderr);
@@ -291,7 +297,7 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
   }
   nchecks++;
 
-  cooked = lang_cook_value(utf8_escape,932);
+  cooked = ConvertCatalogValue(utf8_escape,932);
   if (cooked == NULL || strchr(cooked,'\n') == NULL) {
     fprintf(stderr, "FATAL: the escape was eaten: the catalog is unescaped before it is decoded\n");
     fflush(stderr);
@@ -300,9 +306,27 @@ void LANG_SELFTEST_ESCAPE_ORDER(void) {
   free(cooked);
   nchecks++;
 
-  cooked = lang_cook_value(legacy,CP_ACP);
+  cooked = ConvertCatalogValue(legacy,CP_ACP);
   if (cooked == NULL || strchr(cooked,'\n') == NULL || strstr(cooked,"Crit\xe8" "re") == NULL) {
     fprintf(stderr, "FATAL: a legacy-charset entry lost its accent or its escape\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  free(cooked);
+  nchecks++;
+
+  /* 0x82 leads on CP932 and is an ordinary byte on CP1252, so the same entry must unescape
+     differently under each: that is what proves cp reaches conv_printf at all. */
+  cooked = ConvertCatalogValue(lead_escape,932);
+  if (cooked == NULL || strchr(cooked,'\n') != NULL) {
+    fprintf(stderr, "FATAL: the codepage never reached the unescaper\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  free(cooked);
+  cooked = ConvertCatalogValue(lead_escape,1252);
+  if (cooked == NULL || strchr(cooked,'\n') == NULL) {
+    fprintf(stderr, "FATAL: a lead byte on one codepage ate an escape on another\n");
     fflush(stderr);
     ExitProcess(3);
   }
@@ -541,7 +565,7 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
               
               /* Add key */
               if (strnotempty(intkey)) {
-                buff = lang_cook_value(value,CP_ACP);
+                buff = ConvertCatalogValue(value,CP_ACP);
                 if (buff)
                   coucal_add(NewLangStr,intkey,(intptr_t)buff);
               }
@@ -575,7 +599,7 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
     limit_to[0]='\0';
 }
 
-void conv_printf(char* from,char* to,UINT cp) {
+void conv_printf(const char* from,char* to,UINT cp) {
   int i=0,j=0,len;
   len = (int) strlen(from);
   while(i<len) {

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -46,9 +46,9 @@ void WhttEnsureConsole(void);
 const char* LANGSEL(const char* name);
 const char* LANGINTKEY(const char* name);
 void LANG_DELETE();
-/* Unescape against an explicit codepage: its DBCS pairing must match the encoding the
-   text is already in, or a lead byte swallows the backslash after it. */
-void conv_printf(char* from,char* to,UINT cp);
+/* Unescape against an explicit codepage. Its DBCS pairing must match the actual encoding,
+   or a lead byte swallows the following backslash. */
+void conv_printf(const char* from,char* to,UINT cp);
 #define LANG(A) A
 
 BOOL SetDlgItemTextCP(HWND hDlg, int nIDDlgItem, LPCSTR lpString);
@@ -58,6 +58,7 @@ BOOL SetDlgItemTextCP(CWnd* wnd, int nIDDlgItem, LPCSTR lpString);
 BOOL SetDlgItemTextLang(CWnd* wnd, int nIDDlgItem, LPCSTR lpString);
 // --selftest: prove catalog text decodes, and that a legacy catalog is left alone.
 void LANG_SELFTEST_DECODE(void);
+// --selftest: prove the catalog is decoded before it is unescaped.
 void LANG_SELFTEST_ESCAPE_ORDER(void);
 
 BOOL SetDlgItemTextUTF8(HWND hDlg, int nIDDlgItem, LPCSTR lpString);

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -46,7 +46,9 @@ void WhttEnsureConsole(void);
 const char* LANGSEL(const char* name);
 const char* LANGINTKEY(const char* name);
 void LANG_DELETE();
-void conv_printf(char* from,char* to);
+/* Unescape against an explicit codepage: its DBCS pairing must match the encoding the
+   text is already in, or a lead byte swallows the backslash after it. */
+void conv_printf(char* from,char* to,UINT cp);
 #define LANG(A) A
 
 BOOL SetDlgItemTextCP(HWND hDlg, int nIDDlgItem, LPCSTR lpString);
@@ -56,6 +58,7 @@ BOOL SetDlgItemTextCP(CWnd* wnd, int nIDDlgItem, LPCSTR lpString);
 BOOL SetDlgItemTextLang(CWnd* wnd, int nIDDlgItem, LPCSTR lpString);
 // --selftest: prove catalog text decodes, and that a legacy catalog is left alone.
 void LANG_SELFTEST_DECODE(void);
+void LANG_SELFTEST_ESCAPE_ORDER(void);
 
 BOOL SetDlgItemTextUTF8(HWND hDlg, int nIDDlgItem, LPCSTR lpString);
 BOOL SetDlgItemTextUTF8(CWnd* wnd, int nIDDlgItem, LPCSTR lpString);


### PR DESCRIPTION
#146 fixed the decode/unescape order but nothing holds it there: the runner is cp1252, where `IsDBCSLeadByteEx()` always returns false, so both orders behave identically and a test written against them passes either way. This extracts the step into `ConvertCatalogValue(value, cp)`, so reordering the halves changes what the function returns, and gives `conv_printf()` the codepage for its DBCS pairing instead of a hardcoded `CP_ACP`. `--selftest` drives CP932 through that path: decoding first reduces U+3042 to `?` and the escape survives, unescaping first reads `0x82` as a lead byte and eats it.

Five checks, pinned by count. Three things they do not cover. `cp` reaches only the unescape, because the decode always targets the ANSI codepage, so check 2 pairs a cp1252 decode with a 932 unescape, which production never does; it still discriminates the reorder, which is what the check is for. Nothing proves `LANG_LOAD` passes `CP_ACP`, visible only on a DBCS ANSI codepage. Check 5 exercises the exact-size allocation, but Release CI has no sanitizer, so a one-byte short malloc goes unnoticed there.