### PR TITLE
Show the publisher line on the first-run About

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,9 +40,8 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
-      # The first-run About names the publisher, and the verdict comes off a thread. Started
-      # after that dialog it can never arrive in time, which is how #152 shipped: the row was
-      # blank in every screenshot and nothing failed.
+      # Cheap companion to the walk's runtime check: started after that dialog, the check can
+      # never give it a verdict (#152), and nothing in the build can see that.
       - name: The signature check starts before the first-run About
         run: |
           python3 - <<'EOF'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,6 +40,23 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
+      # The first-run About names the publisher, and the verdict comes off a thread. Started
+      # after that dialog it can never arrive in time, which is how #152 shipped: the row was
+      # blank in every screenshot and nothing failed.
+      - name: The signature check starts before the first-run About
+        run: |
+          python3 - <<'EOF'
+          import sys
+          src = open('WinHTTrack/WinHTTrack.cpp', encoding='utf-8').read()
+          start, first_run = src.find('WhttSigCheckStart('), src.find('"FirstRun"')
+          if start < 0 or first_run < 0:
+              sys.exit('anchors moved: WhttSigCheckStart=%d FirstRun=%d' % (start, first_run))
+          if start > first_run:
+              sys.exit('WhttSigCheckStart runs after the first-run About, so that About can '
+                       'never show a verdict (httrack-windows#152)')
+          print('signature check starts before the first-run About')
+          EOF
+
       # The install-over-previous smoke test re-runs ONE installer, which only stands in for
       # an upgrade while the installer's identity carries no version. Assert that here, or the
       # day someone templates a version into AppName the smoke test keeps passing and real

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1400,9 +1400,8 @@ BOOL CWinHTTrackApp::InitInstance()
   // Init Winsock
   WSockInit();
 
-  /* On a thread of its own: none of it may delay startup. OnIdle() collects the answer.
-     Before the first-run About below, which names the publisher: at the end of InitInstance
-     it could never have a verdict to name (#152). Cabout fills the row late for the rest. */
+  /* On a thread of its own: none of it may delay startup, and OnIdle() collects the answer.
+     Must precede the first-run About below, which otherwise has no verdict to show (#152). */
   WhttSigCheckStart(m_pMainWnd != NULL ? m_pMainWnd->GetSafeHwnd() : NULL);
 
 	// The one and only window has been initialized, so show and update it.

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1400,6 +1400,11 @@ BOOL CWinHTTrackApp::InitInstance()
   // Init Winsock
   WSockInit();
 
+  /* On a thread of its own: none of it may delay startup. OnIdle() collects the answer.
+     Before the first-run About below, which names the publisher: at the end of InitInstance
+     it could never have a verdict to name (#152). Cabout fills the row late for the rest. */
+  WhttSigCheckStart(m_pMainWnd != NULL ? m_pMainWnd->GetSafeHwnd() : NULL);
+
 	// The one and only window has been initialized, so show and update it.
 	//m_pMainWnd->ShowWindow(SW_SHOW);
 	//m_pMainWnd->UpdateWindow();
@@ -1498,10 +1503,6 @@ BOOL CWinHTTrackApp::InitInstance()
   AfxMessageBox("--WARNING--\r\n"HTTRACK_AFF_WARNING);
 #endif
 #endif
-
-  /* Last, and on a thread of its own: none of it may delay startup. OnIdle() collects
-     the answer. */
-  WhttSigCheckStart(m_pMainWnd != NULL ? m_pMainWnd->GetSafeHwnd() : NULL);
 
   return TRUE;
 }

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -56,10 +56,9 @@ extern "C" {
   #include "httrack-library.h"
 }
 
-/* The verdict lands on a background thread. Polling for it beats handing the checker a
-   window handle, since the dialog may well close first. */
-#define WHTT_SIG_POLL_TIMER 1
-#define WHTT_SIG_POLL_MS 250
+/* Verdict lands on a background thread; poll rather than assume the dialog outlives it. */
+static const UINT_PTR WHTT_SIG_POLL_TIMER = 1;
+static const UINT WHTT_SIG_POLL_MS = 250;
 
 /////////////////////////////////////////////////////////////////////////////
 // Cabout dialog
@@ -144,7 +143,6 @@ BOOL Cabout::OnInitDialog()
 
   EnableToolTips(true);     // TOOL TIPS
   setlang();
-  /* The first-run About opens before the check can have finished, and a new user sees it. */
   if (WhttSigSummary()[0] == '\0') {
     SetTimer(WHTT_SIG_POLL_TIMER, WHTT_SIG_POLL_MS, NULL);
   }

--- a/WinHTTrack/about.cpp
+++ b/WinHTTrack/about.cpp
@@ -56,6 +56,11 @@ extern "C" {
   #include "httrack-library.h"
 }
 
+/* The verdict lands on a background thread. Polling for it beats handing the checker a
+   window handle, since the dialog may well close first. */
+#define WHTT_SIG_POLL_TIMER 1
+#define WHTT_SIG_POLL_MS 250
+
 /////////////////////////////////////////////////////////////////////////////
 // Cabout dialog
 
@@ -91,6 +96,7 @@ BEGIN_MESSAGE_MAP(Cabout, CDialog)
 	ON_WM_CTLCOLOR()
 	//}}AFX_MSG_MAP
   ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnToolTipNotify )
+  ON_WM_TIMER()
   ON_COMMAND(ID_HELP_FINDER,OnHelpInfo2)
   ON_COMMAND(ID_HELP,OnHelpInfo2)
 	ON_COMMAND(ID_DEFAULT_HELP,OnHelpInfo2)
@@ -138,6 +144,10 @@ BOOL Cabout::OnInitDialog()
 
   EnableToolTips(true);     // TOOL TIPS
   setlang();
+  /* The first-run About opens before the check can have finished, and a new user sees it. */
+  if (WhttSigSummary()[0] == '\0') {
+    SetTimer(WHTT_SIG_POLL_TIMER, WHTT_SIG_POLL_MS, NULL);
+  }
   SetIcon(httrack_icon,false);
   SetIcon(httrack_icon,true);  
 
@@ -169,6 +179,20 @@ void Cabout::setlang() {
   /* Who signed this copy, in every case and not only the bad ones: naming the
      publisher is what turns a support thread into a diagnosis. */
   SetDlgItemTextCP(this, IDC_SIGSTATUS, WhttSigSummary());
+}
+
+void Cabout::OnTimer(UINT_PTR nIDEvent)
+{
+  if (nIDEvent == WHTT_SIG_POLL_TIMER) {
+    const char *const summary = WhttSigSummary();
+
+    if (summary[0] != '\0') {
+      KillTimer(WHTT_SIG_POLL_TIMER);
+      /* Setting the text repaints it, so OnCtlColor picks the verdict's colour up. */
+      SetDlgItemTextCP(this, IDC_SIGSTATUS, summary);
+    }
+  }
+  CDialog::OnTimer(nIDEvent);
 }
 
 HBRUSH Cabout::OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor)

--- a/WinHTTrack/about.h
+++ b/WinHTTrack/about.h
@@ -76,9 +76,9 @@ protected:
 	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
 	afx_msg HBRUSH OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor);
+	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
-  afx_msg void OnTimer(UINT_PTR nIDEvent);
 	DECLARE_MESSAGE_MAP()
 };
 

--- a/WinHTTrack/about.h
+++ b/WinHTTrack/about.h
@@ -78,6 +78,7 @@ protected:
 	afx_msg HBRUSH OnCtlColor(CDC* pDC, CWnd* pWnd, UINT nCtlColor);
 	//}}AFX_MSG
   afx_msg BOOL OnToolTipNotify( UINT id, NMHDR * pNMHDR, LRESULT * pResult );
+  afx_msg void OnTimer(UINT_PTR nIDEvent);
 	DECLARE_MESSAGE_MAP()
 };
 

--- a/tools/screenshot-walk.py
+++ b/tools/screenshot-walk.py
@@ -33,8 +33,8 @@ PSM_SETCURSEL = 0x0465
 TCM_GETITEMCOUNT = 0x1304
 
 PROJECT = "Demo Project"
-NEEDED = ("IDC_lang", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath", "IDC_URL",
-          "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend", "IDC_i6",
+NEEDED = ("IDC_lang", "IDC_SIGSTATUS", "IDC_STATIC_welcome", "IDC_projname", "IDC_projpath",
+          "IDC_URL", "ID_setopt", "IDC_select_start", "IDC_inforun", "IDC_infoend", "IDC_i6",
           "IDC_connexion", "IDC_maxrate")
 
 
@@ -366,6 +366,14 @@ def run(pid, ids, shots, url, base_path, language):
     # failing on it.
     try:
         lang = wait(lambda: window_titled(pid, "About WinHTTrack"), "the language dialog", 25)
+        # Filled from a background verdict, so it lags the dialog: a blank row is #152 again.
+        sig = find(lang, control_id=ids["IDC_SIGSTATUS"])
+        try:
+            line = wait(lambda: win32gui.GetWindowText(sig), "the signature row to fill", 15)
+        except Timeout:
+            # Not a Timeout: the handler below reads one as "not a first run" and passes.
+            raise RuntimeError("the About signature row stayed empty (httrack-windows#152)")
+        print(f"  signature: {line!r}")
         shots.take(lang, "00_language_preference")
         combo = ComboBoxWrapper(find(lang, control_id=ids["IDC_lang"]))
         names = combo.item_texts()


### PR DESCRIPTION
The signature verdict is computed on a background thread, and the check only started at the end of `InitInstance`, after the first-run About had already opened and closed. So that dialog could never name a publisher, on a signed build or an unsigned one. It is the one a new user sees, and it is also `00_language_preference` in the documentation set, which is how it surfaced.

Both halves are needed. Start the check once the main window exists, and have `Cabout` fill the row when the verdict lands rather than only at open. Moving the start alone would leave the row blank whenever chain building outruns the dialog.

The screenshot walk opens that exact About, so it now asserts `IDC_SIGSTATUS` is non-empty before shooting it: on CI the build is unsigned, so the row reads "Not signed: built from source, not an official release." Reverting either half fails it. A source-order guard in the `encoding` job is the cheap companion, and I checked that it fails on the pre-fix source rather than assuming it would.

Closes #152