### PR TITLE
Set the GUI version to 3.50-beta-8

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI ships ahead of the 3.49 engine as the 3.50 beta, so it carries its own
    version. Bump it here only: the .rc, the installer and CI all read this file. */
-#define WINHTTRACK_VERSION "3.50-beta-7"
+#define WINHTTRACK_VERSION "3.50-beta-8"
 
 /* Dotted, for Inno and the FileVersion field. Below 3.50.0.0 so 3.50 outranks its betas. */
-#define WINHTTRACK_VERSIONID "3.49.99.7"
+#define WINHTTRACK_VERSIONID "3.49.99.8"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7
+#define WINHTTRACK_VERSION_NUM 3, 49, 99, 8
 
 #endif


### PR DESCRIPTION
Opens the beta-8 round. The engine is pinned to `26f24acb` (3.49-24), which is what master's build 32974900101 tested, so the tag names the tree it was built from.

Only `version.h` moves. `Test-TagVersion.ps1` names 3.50-beta-7 too, but that is a temp-file fixture for the parser rather than a reference to the shipping version. Leaving it behind is deliberate: a fixture that matches the real version cannot catch `Get-GuiVersion` reading the wrong file.
