### PR TITLE
Report an accepted CVE that no longer matches anything

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
+      # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
+      - name: Advisory accept/stale cases
+        run: python3 tools/test-check-native-deps.py
       # Cheap companion to the walk's runtime check: started after that dialog, the check can
       # never give it a verdict (#152), and nothing in the build can see that.
       - name: The signature check starts before the first-run About

--- a/tools/check-native-deps.py
+++ b/tools/check-native-deps.py
@@ -207,7 +207,7 @@ def main():
     for cve, sev in sorted(blocking):
         print(f"::error::openssl {ossl} affected by {cve} ({sev})")
 
-    # An ID that stops matching would otherwise just vanish, leaving the acceptance set.
+    # An ID that stops matching vanishes from the output; nothing marks the acceptance spent.
     stale = sorted(accepted - matched)
     for cve in stale:
         print(f"::error::{cve} is accepted but no longer applies to openssl {ossl}; "

--- a/tools/check-native-deps.py
+++ b/tools/check-native-deps.py
@@ -184,6 +184,7 @@ def main():
     ver_branch = (ver[0], ver[1])
 
     accepted = {c.strip().upper() for c in args.accept.split(",") if c.strip()}
+    matched = set()
     floor = RANK[args.min_severity]
     blocking, noted = [], []
     for doc in advisories():
@@ -192,6 +193,7 @@ def main():
             continue
         cve, sev = h
         if cve.upper() in accepted:
+            matched.add(cve.upper())
             print(f"::warning::{cve} ({sev}) accepted by policy")
         # sev is None only when a matched record lacks severity where OpenSSL always
         # puts it -- an unexpected shape, so block rather than silently downgrade.
@@ -205,10 +207,21 @@ def main():
     for cve, sev in sorted(blocking):
         print(f"::error::openssl {ossl} affected by {cve} ({sev})")
 
-    if blocking:
-        sys.exit(f"{len(blocking)} advisory(ies) at or above {args.min_severity}")
+    # An ID that stops matching would otherwise just vanish, leaving the acceptance set.
+    stale = sorted(accepted - matched)
+    for cve in stale:
+        print(f"::error::{cve} is accepted but no longer applies to openssl {ossl}; "
+              f"drop it from SECURITY_ACCEPTED_CVES")
+
+    if blocking or stale:
+        why = []
+        if blocking:
+            why.append(f"{len(blocking)} advisory(ies) at or above {args.min_severity}")
+        if stale:
+            why.append(f"{len(stale)} spent acceptance(s)")
+        sys.exit(", ".join(why))
     print(f"openssl {ossl}: clean at >= {args.min_severity} "
-          f"({len(noted)} below threshold)")
+          f"({len(noted)} below threshold, {len(matched)} accepted)")
 
 
 if __name__ == "__main__":

--- a/tools/test-check-native-deps.py
+++ b/tools/test-check-native-deps.py
@@ -27,61 +27,85 @@ def advisory(cve, severity, lo, less_than):
     }
 
 
-# HITS matches 3.6.3 and MISSES cannot, so accepting MISSES is a spent acceptance.
+# HITS and LOW both match 3.6.3; MISSES cannot, so accepting MISSES is a spent acceptance.
 HITS = advisory("CVE-2026-11111", "Moderate", "3.6.0", "3.6.4")
 MISSES = advisory("CVE-2026-22222", "Moderate", "3.4.0", "3.4.7")
+LOW = advisory("CVE-2026-33333", "Low", "3.6.0", "3.6.4")
 
 
 def run(feed, accept):
-    """(exit_status, output) of one main() call. Status is None when it returns."""
-    check.advisories = lambda: feed
+    """(exit status, output, stub calls). Status is None when main() returns instead."""
+    calls = []
+
+    def stub():
+        calls.append(1)
+        return feed
+
+    real_advisories, real_argv = check.advisories, sys.argv
     argv = ["check-native-deps.py", "--openssl-version", "3.6.3", "--min-severity", "moderate"]
     if accept:
         argv += ["--accept", accept]
     out, status = io.StringIO(), None
-    with contextlib.redirect_stdout(out):
-        sys.argv = argv
-        try:
-            check.main()
-        except SystemExit as e:
-            status = e.code
-    return status, out.getvalue()
+    try:
+        check.advisories, sys.argv = stub, argv
+        with contextlib.redirect_stdout(out):
+            try:
+                check.main()
+            except SystemExit as e:
+                status = e.code
+    finally:
+        check.advisories, sys.argv = real_advisories, real_argv
+    return status, out.getvalue(), len(calls)
 
 
 CASES = [
-    # (name, feed, accept, want_fail, want_in_output, want_not_in_output)
-    ("spent acceptance fails", [MISSES], "CVE-2026-22222", True,
+    # (name, feed, accept, want_status, want_in_output, want_not_in_output)
+    # want_status is a substring of the exit reason, or None when the run must succeed.
+    ("spent acceptance fails", [MISSES], "CVE-2026-22222", "1 spent acceptance(s)",
      "CVE-2026-22222 is accepted but no longer applies", None),
-    ("live acceptance passes", [HITS], "CVE-2026-11111", False,
+    ("live acceptance passes", [HITS], "CVE-2026-11111", None,
      "accepted by policy", "no longer applies"),
-    ("unaccepted advisory still blocks", [HITS], "", True,
+    ("unaccepted advisory still blocks", [HITS], "", "1 advisory(ies) at or above moderate",
      "affected by CVE-2026-11111", "no longer applies"),
-    ("clean feed passes", [MISSES], "", False, "clean at >=", None),
+    ("clean feed passes", [MISSES], "", None, "clean at >=", None),
     # One live, one spent: the spent half must still fail, and name only itself.
     ("live plus spent fails on the spent one", [HITS, MISSES],
-     "CVE-2026-11111,CVE-2026-22222", True,
+     "CVE-2026-11111,CVE-2026-22222", "1 spent acceptance(s)",
      "CVE-2026-22222 is accepted but no longer applies",
      "CVE-2026-11111 is accepted but no longer applies"),
-    ("case and spacing are normalised", [MISSES], " cve-2026-22222 ", True,
+    ("case and spacing are normalised", [MISSES], " cve-2026-22222 ", "1 spent acceptance(s)",
      "CVE-2026-22222 is accepted but no longer applies", None),
+    # Acceptance is judged before severity, so a live one below the floor is not spent.
+    ("below-threshold acceptance is live", [LOW], "CVE-2026-33333", None,
+     "accepted by policy", "no longer applies"),
+    ("below-threshold advisory only warns", [LOW], "", None, "1 below threshold", "::error::"),
 ]
 
 bad = 0
-for name, feed, accept, want_fail, want_in, want_not in CASES:
-    status, out = run(feed, accept)
-    failed = status not in (None, 0)
+for name, feed, accept, want_status, want_in, want_not in CASES:
+    status, out, calls = run(feed, accept)
     problems = []
-    if failed != want_fail:
-        problems.append(f"expected {'failure' if want_fail else 'success'}, got status {status!r}")
+    if (status not in (None, 0)) != (want_status is not None):
+        problems.append(f"expected {'failure' if want_status else 'success'}, got {status!r}")
+    elif want_status and want_status not in str(status):
+        problems.append(f"exit reason {str(status)!r} lacks {want_status!r}")
     if want_in not in out:
         problems.append(f"missing {want_in!r}")
     if want_not and want_not in out:
         problems.append(f"unexpected {want_not!r}")
+    # A refactor that stops calling advisories() would reach the network and still pass.
+    if calls != 1:
+        problems.append(f"stubbed feed read {calls} times, expected 1")
     if problems:
         bad += 1
         print(f"FAIL {name}: {'; '.join(problems)}\n{out}")
     else:
         print(f"ok   {name}")
+
+# Pin the count, or deleting a row leaves this green.
+if len(CASES) != 8:
+    print(f"FAIL expected 8 cases, table has {len(CASES)}")
+    bad += 1
 
 print(f"{len(CASES)} cases, {bad} failed")
 sys.exit(1 if bad else 0)

--- a/tools/test-check-native-deps.py
+++ b/tools/test-check-native-deps.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Table test for the accept/stale logic in check-native-deps.py.
+
+Stubs the advisory feed, so it needs no network and no vcpkg tree.
+"""
+import contextlib
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+MOD = Path(__file__).with_name("check-native-deps.py")
+spec = importlib.util.spec_from_file_location("check_native_deps", MOD)
+check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check)
+
+
+def advisory(cve, severity, lo, less_than):
+    return {
+        "cveMetadata": {"cveId": cve},
+        "containers": {"cna": {
+            "metrics": [{"other": {"content": {"text": severity}}}],
+            "affected": [{"vendor": "OpenSSL", "product": "OpenSSL",
+                          "versions": [{"status": "affected", "version": lo,
+                                        "lessThan": less_than, "versionType": "semver"}]}],
+        }},
+    }
+
+
+# HITS matches 3.6.3 and MISSES cannot, so accepting MISSES is a spent acceptance.
+HITS = advisory("CVE-2026-11111", "Moderate", "3.6.0", "3.6.4")
+MISSES = advisory("CVE-2026-22222", "Moderate", "3.4.0", "3.4.7")
+
+
+def run(feed, accept):
+    """(exit_status, output) of one main() call. Status is None when it returns."""
+    check.advisories = lambda: feed
+    argv = ["check-native-deps.py", "--openssl-version", "3.6.3", "--min-severity", "moderate"]
+    if accept:
+        argv += ["--accept", accept]
+    out, status = io.StringIO(), None
+    with contextlib.redirect_stdout(out):
+        sys.argv = argv
+        try:
+            check.main()
+        except SystemExit as e:
+            status = e.code
+    return status, out.getvalue()
+
+
+CASES = [
+    # (name, feed, accept, want_fail, want_in_output, want_not_in_output)
+    ("spent acceptance fails", [MISSES], "CVE-2026-22222", True,
+     "CVE-2026-22222 is accepted but no longer applies", None),
+    ("live acceptance passes", [HITS], "CVE-2026-11111", False,
+     "accepted by policy", "no longer applies"),
+    ("unaccepted advisory still blocks", [HITS], "", True,
+     "affected by CVE-2026-11111", "no longer applies"),
+    ("clean feed passes", [MISSES], "", False, "clean at >=", None),
+    # One live, one spent: the spent half must still fail, and name only itself.
+    ("live plus spent fails on the spent one", [HITS, MISSES],
+     "CVE-2026-11111,CVE-2026-22222", True,
+     "CVE-2026-22222 is accepted but no longer applies",
+     "CVE-2026-11111 is accepted but no longer applies"),
+    ("case and spacing are normalised", [MISSES], " cve-2026-22222 ", True,
+     "CVE-2026-22222 is accepted but no longer applies", None),
+]
+
+bad = 0
+for name, feed, accept, want_fail, want_in, want_not in CASES:
+    status, out = run(feed, accept)
+    failed = status not in (None, 0)
+    problems = []
+    if failed != want_fail:
+        problems.append(f"expected {'failure' if want_fail else 'success'}, got status {status!r}")
+    if want_in not in out:
+        problems.append(f"missing {want_in!r}")
+    if want_not and want_not in out:
+        problems.append(f"unexpected {want_not!r}")
+    if problems:
+        bad += 1
+        print(f"FAIL {name}: {'; '.join(problems)}\n{out}")
+    else:
+        print(f"ok   {name}")
+
+print(f"{len(CASES)} cases, {bad} failed")
+sys.exit(1 if bad else 0)


### PR DESCRIPTION
`--accept` was only consulted for advisories that hit the installed OpenSSL. Once the version moved past the affected range, the ID dropped out of the output and `SECURITY_ACCEPTED_CVES` showed no sign it was spent. The checker now tracks which accepted IDs matched and reports the ones that did not. The step is already advisory on branches and fatal on tags, so this needs no new policy.

Three of the test's eight cases fail without the fix, and the rest are controls, so a suite that passed everything would be visibly wrong. It stubs the advisory feed instead of fetching it, which keeps a required check off the network.

Two rows exist because a review built the mutants that beat the first draft. Acceptance is judged before severity, so an accepted CVE below the threshold is still live; an implementation testing acceptance only inside the blocking branch passed all six original cases, and would fail a tagged build the day upstream re-rates one of these Low. The exit reason is asserted for the same reason: counting `accepted` rather than `stale` also survived.

Inferring "spent" from a missing match would be wrong on an empty feed. A fetch failure there would mark every accepted ID stale, turning a network problem into a fatal error on a release tag. `advisories()` already rules that out by exiting FATAL below 200 records, before the stale set is computed, though the two sit far apart in the file.

Note for review: this touches `.github/workflows/windows-build.yml`, which is on the signing-privileged list. The change adds one step to the `encoding` job on ubuntu, running a script tracked in the tree. It adds no secret, no `environment:`, no `pull_request_target`, and no action reference.

Removing a spent entry from `SECURITY_ACCEPTED_CVES` still waits on vcpkg shipping OpenSSL 3.6.4. This check is what will flag that entry when the time comes.

Closes #155