### PR TITLE
Keep a portable copy out of the registry

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -204,6 +204,11 @@ runs:
         if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
         # The counts below are exact, not lower bounds: adding a case must move the number
         # here too, since a deleted one otherwise hides behind a still-positive total.
+        # The installer leaves no WinHTTrack.ini, so this is the control for the staged
+        # tree's portable run: a mode wired to a constant fails one of the two.
+        if ("$so" -notmatch 'settings store ok on 4 checks \(registry, associates\)') {
+          throw "an installed copy did not keep its settings in the registry"
+        }
         # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into
         # a dialog. --selftest exercises it; assert it actually RAN, or the check silently
         # skips (its ANSI-codepage guard) and proves nothing.

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -204,9 +204,9 @@ runs:
         if ("$so" -notmatch 'startup ok') { throw "selftest did not report startup ok" }
         # The counts below are exact, not lower bounds: adding a case must move the number
         # here too, since a deleted one otherwise hides behind a still-positive total.
-        # The installer leaves no WinHTTrack.ini, so this is the control for the staged
-        # tree's portable run: a mode wired to a constant fails one of the two.
-        if ("$so" -notmatch 'settings store ok on 4 checks \(registry, associates\)') {
+        # The installer never writes WinHTTrack.ini, so this leg is the control for the
+        # staged tree's portable run: a constant mode fails one of the two.
+        if ("$so" -notmatch 'settings store ok on 2 checks \(registry, associates\)') {
           throw "an installed copy did not keep its settings in the registry"
         }
         # The MBCS->UTF-8 conversion the engine depends on is only reachable by typing into

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -127,9 +127,6 @@ jobs:
                  else { $found | Where-Object { $_.Directory.Name -like '*x64*' } | Select-Object -First 1 }
           # An arch pair without x64 stops here rather than shooting an arbitrary one.
           if (-not $exe) { throw "artifact $env:ARTIFACT holds $($found.Count) WinHTTrack.exe, none in an x64 directory" }
-          # The artifact ships WinHTTrack.ini, which would put the shots in portable mode:
-          # a settings path and a default mirror folder no installed user ever sees.
-          Remove-Item (Join-Path $exe.Directory.FullName 'WinHTTrack.ini') -ErrorAction SilentlyContinue
           Write-Host "walking $($exe.FullName)"
           "exe=$($exe.FullName)" | Out-File -Append $env:GITHUB_OUTPUT
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -127,6 +127,9 @@ jobs:
                  else { $found | Where-Object { $_.Directory.Name -like '*x64*' } | Select-Object -First 1 }
           # An arch pair without x64 stops here rather than shooting an arbitrary one.
           if (-not $exe) { throw "artifact $env:ARTIFACT holds $($found.Count) WinHTTrack.exe, none in an x64 directory" }
+          # The artifact ships WinHTTrack.ini, which would put the shots in portable mode:
+          # a settings path and a default mirror folder no installed user ever sees.
+          Remove-Item (Join-Path $exe.Directory.FullName 'WinHTTrack.ini') -ErrorAction SilentlyContinue
           Write-Host "walking $($exe.FullName)"
           "exe=$($exe.FullName)" | Out-File -Append $env:GITHUB_OUTPUT
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -59,6 +59,32 @@ jobs:
           print('signature check starts before the first-run About')
           EOF
 
+      # File > Open used to reach MFC's own dialog, which takes no flags of ours, so a
+      # portable run left a shortcut in %AppData% (#159). --selftest cannot open a dialog,
+      # so a sixth one added without the flag is only catchable here.
+      - name: File dialogs suppress the Recent folder
+        run: |
+          python3 - <<'EOF'
+          import glob, re, sys
+          made = re.compile(r'\bCFileDialog\s+\w+\s*\(([^;]*?)\)\s*;'
+                            r'|\bnew\s+CFileDialog\s*\(([^;]*?)\)\s*;', re.S)
+          bad, n = [], 0
+          for path in sorted(glob.glob('WinHTTrack/*.cpp')):
+              src = open(path, encoding='utf-8').read()
+              for m in made.finditer(src):
+                  n += 1
+                  if 'WhttOfnFlags()' not in (m.group(1) or m.group(2)):
+                      bad.append('%s: %s' % (path, ' '.join(m.group(0).split())[:88]))
+          # The floor is the control: a regex that matched nothing would report every
+          # dialog clean.
+          if n < 6:
+              sys.exit('matched only %d file dialogs: this check would prove nothing' % n)
+          if bad:
+              sys.exit('a file dialog built without WhttOfnFlags() writes to the Recent '
+                       'folder:\n' + '\n'.join(bad))
+          print('%d file dialogs pass WhttOfnFlags()' % n)
+          EOF
+
       # The install-over-previous smoke test re-runs ONE installer, which only stands in for
       # an upgrade while the installer's identity carries no version. Assert that here, or the
       # day someone templates a version into AppName the smoke test keeps passing and real
@@ -731,9 +757,8 @@ jobs:
           Delete it to get the usual per-user settings instead.
           '@
 
-          # Presence is the switch: this is the copy people unzip onto a stick, so it keeps
-          # its settings and its mirrors here instead of in HKCU. The installer excludes it.
-          # Not a here-string: a section header indented by one space stops being one.
+          # Set-Content, not a here-string: a section header indented by one space stops
+          # being one. The installer excludes this file.
           Set-Content (Join-Path $bin 'WinHTTrack.ini') @(
             '; WinHTTrack settings. This file being here is what makes this copy portable:'
             '; nothing goes to the registry and no file type is associated. Delete it to'
@@ -764,10 +789,9 @@ jobs:
             throw "--selftest exited $($p.ExitCode) from the staged tree"
           }
           $so = Get-Content "$PWD\crash-st.txt" -Raw -ErrorAction SilentlyContinue
-          # The pair that matters: this tree ships WinHTTrack.ini, the installed one does not,
-          # and the smoke test asserts the opposite answer. Either alone would pass with the
-          # mode wired to a constant.
-          if ("$so" -notmatch 'settings store ok on 5 checks \(portable ini, no association\)') {
+          # This tree ships WinHTTrack.ini and the installed one does not; the smoke test
+          # asserts the opposite answer, so a constant mode reds one leg.
+          if ("$so" -notmatch 'settings store ok on 4 checks \(portable ini, no association\)') {
             Write-Host "--- selftest stdout ---`n$so"
             throw 'the staged tree did not run portable: it would write settings to HKCU'
           }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -725,7 +725,21 @@ jobs:
           only Windows Update can supply.
 
           httrack.exe is the command-line version, against the same libhttrack.dll.
+
+          WinHTTrack.ini makes this copy portable: settings and mirrors stay in this
+          folder, nothing is written to the registry, and .whtt is not associated.
+          Delete it to get the usual per-user settings instead.
           '@
+
+          # Presence is the switch: this is the copy people unzip onto a stick, so it keeps
+          # its settings and its mirrors here instead of in HKCU. The installer excludes it.
+          # Not a here-string: a section header indented by one space stops being one.
+          Set-Content (Join-Path $bin 'WinHTTrack.ini') @(
+            '; WinHTTrack settings. This file being here is what makes this copy portable:'
+            '; nothing goes to the registry and no file type is associated. Delete it to'
+            '; go back to per-user settings under HKCU.'
+            '[Interface]'
+          )
           Write-Host "--- package contents ---"
           Get-ChildItem $bin | ForEach-Object { Write-Host "  $($_.Name)" }
 
@@ -748,6 +762,14 @@ jobs:
             Write-Host "--- selftest stdout ---`n$(Get-Content "$PWD\crash-st.txt" -Raw -ErrorAction SilentlyContinue)"
             Write-Host "--- selftest stderr ---`n$(Get-Content "$PWD\crash-st.err" -Raw -ErrorAction SilentlyContinue)"
             throw "--selftest exited $($p.ExitCode) from the staged tree"
+          }
+          $so = Get-Content "$PWD\crash-st.txt" -Raw -ErrorAction SilentlyContinue
+          # The pair that matters: this tree ships WinHTTrack.ini, the installed one does not,
+          # and the smoke test asserts the opposite answer. Either alone would pass with the
+          # mode wired to a constant.
+          if ("$so" -notmatch 'settings store ok on 5 checks \(portable ini, no association\)') {
+            Write-Host "--- selftest stdout ---`n$so"
+            throw 'the staged tree did not run portable: it would write settings to HKCU'
           }
           if (-not (Test-Path $report)) { throw 'no crash report written: the first-chance hook never ran' }
           $trace = Get-Content $report -Raw

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -59,21 +59,21 @@ jobs:
           print('signature check starts before the first-run About')
           EOF
 
-      # File > Open used to reach MFC's own dialog, which takes no flags of ours, so a
-      # portable run left a shortcut in %AppData% (#159). --selftest cannot open a dialog,
-      # so a sixth one added without the flag is only catchable here.
+      # A file dialog missing WhttOfnFlags() leaks a shortcut into %AppData%, and
+      # --selftest cannot open one. Six today, so this catches the seventh.
       - name: File dialogs suppress the Recent folder
         run: |
           python3 - <<'EOF'
           import glob, re, sys
-          made = re.compile(r'\bCFileDialog\s+\w+\s*\(([^;]*?)\)\s*;'
-                            r'|\bnew\s+CFileDialog\s*\(([^;]*?)\)\s*;', re.S)
+          # Two forms in the tree: CFileDialog dial(...) and new CFileDialog(...).
+          built = re.compile(r'\bCFileDialog\s+\w+\s*\(([^;]*?)\)\s*;'
+                             r'|\bnew\s+CFileDialog\s*\(([^;]*?)\)\s*;', re.S)
           bad, n = [], 0
           for path in sorted(glob.glob('WinHTTrack/*.cpp')):
               src = open(path, encoding='utf-8').read()
-              for m in made.finditer(src):
+              for m in built.finditer(src):
                   n += 1
-                  if 'WhttOfnFlags()' not in (m.group(1) or m.group(2)):
+                  if 'WhttOfnFlags()' not in (m.group(1) or m.group(2) or ''):
                       bad.append('%s: %s' % (path, ' '.join(m.group(0).split())[:88]))
           # The floor is the control: a regex that matched nothing would report every
           # dialog clean.

--- a/InnoSetup/httrack.iss
+++ b/InnoSetup/httrack.iss
@@ -86,7 +86,8 @@ Name: "quicklaunchicon"; Description: "Create a &quick launch icon"; GroupDescri
 ; and lang/ and templates/. This is the same staged directory CI publishes, so what gets tested is
 ; what gets shipped. PDBs are built but not shipped, so a user crash report names no
 ; line; source.txt carries the GPL offer the src/ tree used to meet.
-Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.pdb,*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt,runtime-vendored.txt"; Flags: recursesubdirs ignoreversion
+; WinHTTrack.ini is excluded too: shipping it would make an installed copy portable.
+Source: "{#PayloadDir}\*"; DestDir: "{app}"; Excludes: "*.pdb,*.iobj,*.ipdb,*.exp,*.lib,README-artifact.txt,runtime-vendored.txt,WinHTTrack.ini"; Flags: recursesubdirs ignoreversion
 
 ; Documentation that actually exists. The old script also listed readme, copying and
 ; file_id.diz, none of which are in the tree any more.

--- a/WinHTTrack/NewProj.cpp
+++ b/WinHTTrack/NewProj.cpp
@@ -287,7 +287,7 @@ BOOL CNewProj::OnInitDialog()
     if (st != "")
       SetDlgItemTextCP(this, IDC_projpath,st);    
     else
-      SetDlgItemTextCP(this, IDC_projpath,LANG(LANG_S20));    
+      SetDlgItemTextCP(this, IDC_projpath,WhttDefaultBasePath());    
   }
 
   return TRUE;

--- a/WinHTTrack/OptionTab8.cpp
+++ b/WinHTTrack/OptionTab8.cpp
@@ -120,7 +120,7 @@ void COptionTab8::OnCookiesFileBrowse()
 {
   // writable buffer: CFileDialog rewrites the '|' separators in place
   char szFilter[] = "Cookies file (cookies.txt, *.txt)|*.txt|All files (*.*)|*.*||";
-  CFileDialog dial(TRUE, "txt", NULL, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST, szFilter);
+  CFileDialog dial(TRUE, "txt", NULL, OFN_HIDEREADONLY | WhttOfnFlags() | OFN_FILEMUSTEXIST, szFilter);
   if (dial.DoModal() == IDOK)
     SetDlgItemTextCP(this, IDC_cookiesfile, dial.GetPathName());
 }

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2563,6 +2563,69 @@ CString profile_decode(const char* from) {
 }
 //
 // Ecriture/Lecture profiles
+/* Beside the exe, with a trailing backslash; empty if the path cannot be had. */
+static CString WhttAppDir() {
+  TCHAR path[MAX_PATH + 1];
+  path[0] = '\0';
+  if (GetModuleFileName(NULL, path, sizeof(path)/sizeof(TCHAR) - 1) == 0)
+    return "";
+  CString dir = path;
+  const int pos = dir.ReverseFind('\\');
+  if (pos < 0)
+    return "";
+  return dir.Left(pos + 1);
+}
+
+/* Resolved on the first call, which InitInstance makes before touching the profile. */
+static TCHAR WhttPortableIniPath[MAX_PATH + 16] = { 0 };
+static int WhttPortableState = -1;   /* -1 undecided, 0 no, 1 yes */
+
+BOOL WhttPortable() {
+  if (WhttPortableState < 0) {
+    const CString dir = WhttAppDir();
+    const CString ini = dir + "WinHTTrack.ini";
+    /* The file has to exist: creating it on demand would make every unpacked copy
+       portable, including one unpacked over an installation. */
+    WhttPortableState = (dir.GetLength() != 0
+                         && (size_t) ini.GetLength() < _countof(WhttPortableIniPath)
+                         && GetFileAttributes(ini) != INVALID_FILE_ATTRIBUTES) ? 1 : 0;
+    if (WhttPortableState)
+      _tcscpy_s(WhttPortableIniPath, _countof(WhttPortableIniPath), ini);
+  }
+  return WhttPortableState != 0;
+}
+
+CString WhttPortableIni() {
+  WhttPortable();
+  return WhttPortableIniPath;
+}
+
+BOOL WhttPortableIniReadOnly() {
+  if (!WhttPortable())
+    return FALSE;
+  /* A write-protected stick, or a copy unpacked under Program Files, fails at the
+     handle rather than in the attributes. */
+  const HANDLE h = CreateFile(WhttPortableIniPath, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (h == INVALID_HANDLE_VALUE)
+    return TRUE;
+  CloseHandle(h);
+  return FALSE;
+}
+
+CString WhttDefaultBasePath() {
+  if (WhttPortable()) {
+    const CString dir = WhttAppDir();
+    if (dir.GetLength() != 0)
+      return dir + "Websites";
+  }
+  return LANG(LANG_S20);
+}
+
+DWORD WhttOfnFlags() {
+  return WhttPortable() ? OFN_DONTADDTORECENT : 0;
+}
+
 int MyWriteProfileInt(CString path,CString dummy,CString name,int value) {
   if (path.IsEmpty()) {
     CWinApp* pApp = AfxGetApp();

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2576,7 +2576,8 @@ static CString WhttAppDir() {
   return dir.Left(pos + 1);
 }
 
-/* Resolved on the first call, which InitInstance makes before touching the profile. */
+/* Resolved on the first call, which InitInstance makes before touching the profile.
+   GetModuleFileName caps the directory at MAX_PATH, so the leaf always fits. */
 static TCHAR WhttPortableIniPath[MAX_PATH + 16] = { 0 };
 static int WhttPortableState = -1;   /* -1 undecided, 0 no, 1 yes */
 
@@ -2587,7 +2588,6 @@ BOOL WhttPortable() {
     /* The file has to exist: creating it on demand would make every unpacked copy
        portable, including one unpacked over an installation. */
     WhttPortableState = (dir.GetLength() != 0
-                         && (size_t) ini.GetLength() < _countof(WhttPortableIniPath)
                          && GetFileAttributes(ini) != INVALID_FILE_ATTRIBUTES) ? 1 : 0;
     if (WhttPortableState)
       _tcscpy_s(WhttPortableIniPath, _countof(WhttPortableIniPath), ini);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -227,6 +227,25 @@ WhttMirrorStop SessionEndStop(BOOL bEnding);
 // profile
 int Save_current_profile(int ask);
 //
+/* A run is portable when WinHTTrack.ini sits next to the exe: settings go to that file
+   instead of HKCU, and nothing is registered machine-side. Decided before the first read. */
+BOOL WhttPortable();
+
+/* The full path of that file, empty when this run is not portable. */
+CString WhttPortableIni();
+
+/* TRUE when the settings file cannot be written, so nothing the user changes will
+   survive the run. Only meaningful in portable mode. */
+BOOL WhttPortableIniReadOnly();
+
+/* Where the New Project page points when no BasePath was ever saved. A portable run
+   keeps mirrors beside the exe, under a name kept ASCII so it survives the trip. */
+CString WhttDefaultBasePath();
+
+/* OFN_DONTADDTORECENT in portable mode, else 0: every file dialog leaves a shortcut
+   in %AppData%\Microsoft\Windows\Recent otherwise. */
+DWORD WhttOfnFlags();
+
 int MyGetProfileInt(CString path,CString dummy,CString name,int value);
 int MyGetProfileIntFile(FILE* fp,CString dummy,CString name,int value);
 int MyWriteProfileString(CString path,CString dummy,CString name,CString value);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -239,11 +239,11 @@ CString WhttPortableIni();
 BOOL WhttPortableIniReadOnly();
 
 /* Where the New Project page points when no BasePath was ever saved. A portable run
-   keeps mirrors beside the exe, under a name kept ASCII so it survives the trip. */
+   keeps mirrors beside the exe, under a fixed name that no catalog translates. */
 CString WhttDefaultBasePath();
 
-/* OFN_DONTADDTORECENT in portable mode, else 0: every file dialog leaves a shortcut
-   in %AppData%\Microsoft\Windows\Recent otherwise. */
+/* OFN_DONTADDTORECENT in portable mode. Without it a file dialog leaves a shortcut in
+   %AppData%\Microsoft\Windows\Recent. Every dialog we build must pass it. */
 DWORD WhttOfnFlags();
 
 int MyGetProfileInt(CString path,CString dummy,CString name,int value);

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -243,7 +243,7 @@ BOOL WhttPortableIniReadOnly();
 CString WhttDefaultBasePath();
 
 /* OFN_DONTADDTORECENT in portable mode. Without it a file dialog leaves a shortcut in
-   %AppData%\Microsoft\Windows\Recent. Every dialog we build must pass it. */
+   %AppData%\Microsoft\Windows\Recent. */
 DWORD WhttOfnFlags();
 
 int MyGetProfileInt(CString path,CString dummy,CString name,int value);

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -723,7 +723,7 @@ BOOL Wid1::OnHelpInfo(HELPINFO* dummy)
 void Wid1::OnLoadprofile() {
   static char BASED_CODE szFilter[256];
   strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","Réglages de WinHTTrack (*.opt)|*.opt||"*/));
-  CFileDialog* dial = new CFileDialog(true,"opt",NULL,OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,szFilter);
+  CFileDialog* dial = new CFileDialog(true,"opt",NULL,OFN_HIDEREADONLY | WhttOfnFlags() | OFN_OVERWRITEPROMPT,szFilter);
   if (dial->DoModal() == IDOK) {
     CString st=dial->GetPathName();
     char s[256];
@@ -739,7 +739,7 @@ void Wid1::OnLoadprofile() {
 void Wid1::OnSaveprofile() {
   static char BASED_CODE szFilter[256];
   strcpybuff(szFilter,LANG(LANG_G25 /*"WinHTTrack preferences (*.opt)|*.opt||","Réglages de WinHTTrack (*.opt)|*.opt||"*/));
-  CFileDialog* dial = new CFileDialog(false,"opt",NULL,OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT,szFilter);
+  CFileDialog* dial = new CFileDialog(false,"opt",NULL,OFN_HIDEREADONLY | WhttOfnFlags() | OFN_OVERWRITEPROMPT,szFilter);
   if (dial->DoModal() == IDOK) {
     CString st=dial->GetPathName();
     Write_profile(st,1);
@@ -872,7 +872,7 @@ void Wid1::Onbr()
 {
   static char BASED_CODE szFilter[256];
   strcpybuff(szFilter,LANG(LANG_G25b));
-  CFileDialog* dial = new CFileDialog(true,"txt",NULL,OFN_HIDEREADONLY,szFilter);
+  CFileDialog* dial = new CFileDialog(true,"txt",NULL,OFN_HIDEREADONLY | WhttOfnFlags(),szFilter);
   if (dial->DoModal() == IDOK) {
     if (fexist((char*)LPCSTR(dial->GetPathName()))) {
       SetDlgItemTextCP(this, IDC_filelist,dial->GetPathName());

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1332,15 +1332,13 @@ BOOL CWinHTTrackApp::InitInstance()
         } else
           nchecks++;
       }
-      /* Portable only, on both counts: it is where an unreachable store is plausible (a
-         write-protected medium answers every check above and still keeps nothing), and
-         where the probe leaves no registry section behind. */
+      /* Portable only: an unreachable store would still pass every check above, and the
+         probe would otherwise leave a registry section behind. */
       if (portable) {
         static const char *const section = "SelfTest";
         WriteProfileString(section, "store", "kept");
         const CString got = GetProfileString(section, "store");
-        /* Deleted last: a read would put the section straight back. */
-        WriteProfileString(section, NULL, NULL);
+        WriteProfileString(section, NULL, NULL);   /* the probe must not stay behind */
         if (got != "kept") {
           fprintf(stderr, "FATAL: the settings store kept '%s', not 'kept'\n", (LPCSTR) got);
           fflush(stderr);
@@ -1358,6 +1356,7 @@ BOOL CWinHTTrackApp::InitInstance()
         } else
           nchecks++;
       }
+      /* Straight-line, so this fires on a deleted check rather than on any input. */
       const int want = portable ? 4 : 2;
       if (nchecks != want) {
         fprintf(stderr, "FATAL: settings store ran %d checks, expected %d\n", nchecks, want);
@@ -1760,14 +1759,15 @@ afx_msg void CWinHTTrackApp::OnFileNew( ) {
 }
 
 afx_msg void CWinHTTrackApp::OnFileOpen( ) {
-  /* Not CWinApp::OnFileOpen(): the dialog MFC builds for it takes no flags of ours, so a
-     portable run still left a shortcut in the Recent folder. */
+  /* Not CWinApp::OnFileOpen(): its dialog ignores WhttOfnFlags(), which portable mode
+     needs to skip the Recent folder. The rest is what MFC did, down to opening through
+     AfxGetApp() so that the same overload is picked. */
   static char szFilter[256];
   strcpybuff(szFilter,"WinHTTrack Website Copier Project (*.whtt)|*.whtt|All files (*.*)|*.*||");
   CFileDialog dial(TRUE,"whtt",NULL,
                    OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | WhttOfnFlags(),szFilter);
   if (dial.DoModal() == IDOK)
-    OpenDocumentFile(dial.GetPathName());
+    AfxGetApp()->OpenDocumentFile(dial.GetPathName());
 }
 
 void CWinHTTrackApp::OnFileSave() {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -263,6 +263,16 @@ static CString UpdateUrl() {
   return st;
 }
 
+/* Whether this run registers .whtt with the shell. A portable copy never does, an
+   unpacked one does so that opening a project works, and an installed one obeys the
+   setup's file-types task. */
+static BOOL WhttShouldAssociate() {
+  CWinApp *const pApp = AfxGetApp();
+  return !WhttPortable()
+    && (pApp->GetProfileInt("Interface","SetupRun",0) != 1
+        || pApp->GetProfileInt("Interface","SetupHasRegistered",0) == 1);
+}
+
 BOOL CWinHTTrackApp::InitInstance()
 {
   /* Answer --version without bringing up the UI, so a smoke test can prove the
@@ -333,10 +343,16 @@ BOOL CWinHTTrackApp::InitInstance()
 
   WhttMutex = CreateMutex(NULL,FALSE,NULL);
 
-  // Change the registry key under which our settings are stored.
-  // TODO: You should modify this string to be something appropriate
-  // such as the name of your company or organization.
-  SetRegistryKey("WinHTTrack Website Copier");
+  /* Where the whole MFC profile lands; anything not portable keeps the HKCU key older
+     versions and the setup use. _tcsdup, not freet(): ~CWinApp free()s this pointer. */
+  if (WhttPortable()) {
+    free((void*) m_pszProfileName);
+    m_pszProfileName = _tcsdup(WhttPortableIni());
+  } else
+    SetRegistryKey("WinHTTrack Website Copier");
+  /* Silence here would look like the settings never took: nothing survives the run. */
+  if (WhttPortableIniReadOnly() && !WhttSelfTest)
+    AfxMessageBox("Settings cannot be saved: " + WhttPortableIni() + " is not writable.");
   LANG_INIT();    // petite init langue
 
   /* --selftest: everything that depends on the installed data files has now run
@@ -1294,6 +1310,65 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("session end ok on %d checks\n", nchecks);
     }
+    /* Which store this run writes to is the whole of portable mode, and it is decided by
+       a file, so the suffix names the mode and the two CI legs assert opposite answers. */
+    {
+      int nchecks = 0;
+      const BOOL portable = WhttPortable();
+      if ((m_pszRegistryKey != NULL) == (portable != FALSE)) {
+        fprintf(stderr, "FATAL: portable=%d yet the registry key is %s\n",
+                (int) portable, m_pszRegistryKey != NULL ? "set" : "unset");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+      /* Counted only where it asserts, so the registry leg cannot borrow its number. */
+      if (portable) {
+        if (m_pszProfileName == NULL || WhttPortableIni() != m_pszProfileName) {
+          fprintf(stderr, "FATAL: settings go to '%s', not '%s'\n",
+                  m_pszProfileName != NULL ? m_pszProfileName : "(null)", (LPCSTR) WhttPortableIni());
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* The round trip is what proves the store is reachable: a portable copy on a
+         write-protected medium answers every check above and still keeps nothing. */
+      {
+        static const char *const section = "SelfTest";
+        WriteProfileString(section, "store", "kept");
+        const CString got = GetProfileString(section, "store");
+        /* Last: reading a deleted section would recreate its registry key. */
+        WriteProfileString(section, NULL, NULL);
+        if (got != "kept") {
+          fprintf(stderr, "FATAL: the settings store kept '%s', not 'kept'\n", (LPCSTR) got);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      if (WhttOfnFlags() != (portable ? OFN_DONTADDTORECENT : 0)) {
+        fprintf(stderr, "FATAL: file dialogs would still write to the Recent folder\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+      {
+        const CString base = WhttDefaultBasePath();
+        const BOOL beside = (base.Right(9) == "\\Websites");
+        if (portable ? !beside : (base != LANG(LANG_S20))) {
+          fprintf(stderr, "FATAL: new projects would default to '%s'\n", (LPCSTR) base);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* The association block runs long after --selftest has exited, so its decision is
+         reported rather than asserted; the two CI legs pin opposite answers. */
+      printf("settings store ok on %d checks (%s, %s)\n", nchecks,
+             portable ? "portable ini" : "registry",
+             WhttShouldAssociate() ? "associates" : "no association");
+    }
     /* Exercise the crash reporter for real: a Release PDB built without line info, or a
        first-chance hook that never registered, both still produce a plausible-looking
        report that names nothing. Only throwing proves the chain resolves. */
@@ -1428,9 +1503,7 @@ BOOL CWinHTTrackApp::InitInstance()
 
     CWinApp* pApp = AfxGetApp();
 
-    // Portable runs always associate; an installed one obeys the setup's file-types task.
-    if (pApp->GetProfileInt("Interface","SetupRun",0) != 1
-      || pApp->GetProfileInt("Interface","SetupHasRegistered",0) == 1) {
+    if (WhttShouldAssociate()) {
         HKEY phkResult;
         DWORD creResult;
 
@@ -1702,7 +1775,7 @@ void CWinHTTrackApp::OnFileDelete()
 {
   static char szFilter[256];
   strcpybuff(szFilter,"WinHTTrack Website Copier Project (*.whtt)|*.whtt||");
-  CFileDialog* dial = new CFileDialog(true,"whtt",NULL,OFN_HIDEREADONLY,szFilter);
+  CFileDialog* dial = new CFileDialog(true,"whtt",NULL,OFN_HIDEREADONLY | WhttOfnFlags(),szFilter);
   if (dial->DoModal() == IDOK) {
     CString st=dial->GetPathName();
     if (fexist((char*) LPCTSTR(st))) {
@@ -1892,6 +1965,14 @@ void CWinHTTrackApp::FwOnViewTransfers() {
     inprogress->OnViewTransfers();
   else
     AfxMessageBox(LANG_ACTIONNYP,MB_OK);
+}
+
+/* MFC's list writes a shortcut to %AppData% and the jump list, and its entries name
+   drive letters that a stick does not keep. Portable runs get no recent files. */
+void CWinHTTrackApp::AddToRecentFileList(LPCTSTR lpszPathName)
+{
+  if (!WhttPortable())
+    CWinApp::AddToRecentFileList(lpszPathName);
 }
 
 CDocument* CWinHTTrackApp::OpenDocumentFile( LPCTSTR lpszFileName)

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -263,9 +263,8 @@ static CString UpdateUrl() {
   return st;
 }
 
-/* Whether this run registers .whtt with the shell. A portable copy never does, an
-   unpacked one does so that opening a project works, and an installed one obeys the
-   setup's file-types task. */
+/* A portable copy never registers .whtt, an unpacked one does so that opening a project
+   works, and an installed one obeys the setup's file-types task. */
 static BOOL WhttShouldAssociate() {
   CWinApp *const pApp = AfxGetApp();
   return !WhttPortable()
@@ -343,14 +342,15 @@ BOOL CWinHTTrackApp::InitInstance()
 
   WhttMutex = CreateMutex(NULL,FALSE,NULL);
 
-  /* Where the whole MFC profile lands; anything not portable keeps the HKCU key older
-     versions and the setup use. _tcsdup, not freet(): ~CWinApp free()s this pointer. */
+  /* Where the whole MFC profile lands; anything not portable keeps the HKCU key that older
+     versions and the installer use. _tcsdup, not freet(): ~CWinApp free()s this pointer. */
   if (WhttPortable()) {
     free((void*) m_pszProfileName);
     m_pszProfileName = _tcsdup(WhttPortableIni());
   } else
     SetRegistryKey("WinHTTrack Website Copier");
-  /* Silence here would look like the settings never took: nothing survives the run. */
+  /* Silence would look like the settings were never saved. Not under --selftest, which
+     has no one to dismiss a modal. */
   if (WhttPortableIniReadOnly() && !WhttSelfTest)
     AfxMessageBox("Settings cannot be saved: " + WhttPortableIni() + " is not writable.");
   LANG_INIT();    // petite init langue
@@ -1310,8 +1310,8 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("session end ok on %d checks\n", nchecks);
     }
-    /* Which store this run writes to is the whole of portable mode, and it is decided by
-       a file, so the suffix names the mode and the two CI legs assert opposite answers. */
+    /* Portable mode decides which store this run writes to. The two CI legs assert
+       opposite suffixes, so a mode wired to a constant reds one of them. */
     {
       int nchecks = 0;
       const BOOL portable = WhttPortable();
@@ -1332,13 +1332,14 @@ BOOL CWinHTTrackApp::InitInstance()
         } else
           nchecks++;
       }
-      /* The round trip is what proves the store is reachable: a portable copy on a
-         write-protected medium answers every check above and still keeps nothing. */
-      {
+      /* Portable only, on both counts: it is where an unreachable store is plausible (a
+         write-protected medium answers every check above and still keeps nothing), and
+         where the probe leaves no registry section behind. */
+      if (portable) {
         static const char *const section = "SelfTest";
         WriteProfileString(section, "store", "kept");
         const CString got = GetProfileString(section, "store");
-        /* Last: reading a deleted section would recreate its registry key. */
+        /* Deleted last: a read would put the section straight back. */
         WriteProfileString(section, NULL, NULL);
         if (got != "kept") {
           fprintf(stderr, "FATAL: the settings store kept '%s', not 'kept'\n", (LPCSTR) got);
@@ -1347,12 +1348,6 @@ BOOL CWinHTTrackApp::InitInstance()
         } else
           nchecks++;
       }
-      if (WhttOfnFlags() != (portable ? OFN_DONTADDTORECENT : 0)) {
-        fprintf(stderr, "FATAL: file dialogs would still write to the Recent folder\n");
-        fflush(stderr);
-        ExitProcess(3);
-      } else
-        nchecks++;
       {
         const CString base = WhttDefaultBasePath();
         const BOOL beside = (base.Right(9) == "\\Websites");
@@ -1362,6 +1357,12 @@ BOOL CWinHTTrackApp::InitInstance()
           ExitProcess(3);
         } else
           nchecks++;
+      }
+      const int want = portable ? 4 : 2;
+      if (nchecks != want) {
+        fprintf(stderr, "FATAL: settings store ran %d checks, expected %d\n", nchecks, want);
+        fflush(stderr);
+        ExitProcess(3);
       }
       /* The association block runs long after --selftest has exited, so its decision is
          reported rather than asserted; the two CI legs pin opposite answers. */
@@ -1759,7 +1760,14 @@ afx_msg void CWinHTTrackApp::OnFileNew( ) {
 }
 
 afx_msg void CWinHTTrackApp::OnFileOpen( ) {
-  this->CWinApp::OnFileOpen();
+  /* Not CWinApp::OnFileOpen(): the dialog MFC builds for it takes no flags of ours, so a
+     portable run still left a shortcut in the Recent folder. */
+  static char szFilter[256];
+  strcpybuff(szFilter,"WinHTTrack Website Copier Project (*.whtt)|*.whtt|All files (*.*)|*.*||");
+  CFileDialog dial(TRUE,"whtt",NULL,
+                   OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | WhttOfnFlags(),szFilter);
+  if (dial.DoModal() == IDOK)
+    OpenDocumentFile(dial.GetPathName());
 }
 
 void CWinHTTrackApp::OnFileSave() {
@@ -1967,8 +1975,8 @@ void CWinHTTrackApp::FwOnViewTransfers() {
     AfxMessageBox(LANG_ACTIONNYP,MB_OK);
 }
 
-/* MFC's list writes a shortcut to %AppData% and the jump list, and its entries name
-   drive letters that a stick does not keep. Portable runs get no recent files. */
+/* MFC's list writes a shortcut to %AppData% and the jump list, naming a drive letter a
+   stick does not keep. Portable runs get no recent files. */
 void CWinHTTrackApp::AddToRecentFileList(LPCTSTR lpszPathName)
 {
   if (!WhttPortable())

--- a/WinHTTrack/WinHTTrack.h
+++ b/WinHTTrack/WinHTTrack.h
@@ -133,6 +133,8 @@ private:
   afx_msg void OnEndMirror();
   //
   virtual CDocument* OpenDocumentFile( LPCTSTR lpszFileName);
+  // Suppressed in portable mode: see Shell.h.
+  virtual void AddToRecentFileList(LPCTSTR lpszPathName);
   DECLARE_MESSAGE_MAP()
 };
 


### PR DESCRIPTION
A copy unzipped onto a USB key wrote the whole MFC settings profile to HKCU on every launch. It also re-registered the `.whtt` association each time, whenever it decided it was not an installed build. Reported as xroche/httrack#1461.

`WinHTTrack.ini` beside the exe is now the switch, and the same file is the store. Its presence keeps settings there instead of `HKCU\Software\WinHTTrack Website Copier`, skips the association, stops the file dialogs and the recent-files list from writing to `%AppData%\Microsoft\Windows\Recent`, and points new projects beside the exe rather than at `C:\My Web Sites`. An installed copy is unchanged, and so is one merely unpacked, which still associates so that opening a project works.

CI writes the file into the build artifact, which is the "without installer (eg: USB key)" download, and the installer excludes it. `--selftest` therefore runs portable from the staged tree and registry-backed from the installed one, and the two legs assert opposite strings.

Three limits worth knowing. `File > Open` had to stop delegating to MFC, whose own dialog takes no flags of ours; a source guard now catches a sixth dialog added without the flag, because `--selftest` cannot open one. `comdlg32` still writes its own `OpenSavePidlMRU` under HKCU whatever we pass it. And `GetPrivateProfileString` trims outer whitespace and one surrounding quote pair where the registry did not, so a setting typed with wrapping quotes loses them in portable mode; the escaping that would fix it is `winprofile.ini`'s cross-front-end contract, so it wants its own change.

The two `AppEvents` keys the reporter listed come from the installer, never from the portable exe.
