### PR TITLE
Arm auto-merge for vcpkg bumps only

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,39 +1,48 @@
-# CI already validates every bump dependabot opens here, so auto-merge only saves the manual click.
+# CI already validates every bump dependabot opens here, so auto-merge only saves the click.
 name: Dependabot auto-merge
 
-# pull_request_target, because a dependabot pull_request gets a read-only token.
-# Nothing from the PR is checked out or run, so the writable token stays safe.
+# Runs on pull_request_target because a dependabot pull_request gets a read-only token.
+# Nothing from the PR is checked out or run.
 on: pull_request_target
 
-# Keyed on the PR, not on github.ref: a pull_request_target run reports the base
-# branch, so one group per branch lets a second dependabot PR cancel the first's
-# arming job and leave it silently unarmed.
+# Keyed on the PR, because github.ref is the base branch here and one group per
+# branch lets a second PR cancel the first's arming run.
 concurrency:
   group: dependabot-automerge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
-  # Both writes are what enabling auto-merge costs: the API call needs the pull
-  # request scope, and the merge it queues needs the contents one.
+  # Auto-merge needs pull-requests to arm it and contents for the merge it queues.
   contents: write
   pull-requests: write
 
 jobs:
   automerge:
     name: Arm auto-merge
-    # vcpkg only. The github_actions ecosystem exists here to rewrite the SHA pins in
-    # windows-build.yml, and three of those actions run inside the sign job with the
-    # Certum seed in scope, so merging one unread gives back what pinning buys. Master
-    # requires no approving review, so nothing else would read it either.
+    # Author, not github.actor, which is whoever sent the event: dependabot pushing to a
+    # fork's branch makes the actor dependabot on somebody else's pull request. The head
+    # repo must be ours too, because dependabot branches here are never forks.
+    #
+    # vcpkg only, because github_actions bumps rewrite windows-build.yml, whose sign job
+    # runs those actions with the Certum seed in scope.
     if: >-
       github.repository == 'xroche/httrack-windows'
-      && github.actor == 'dependabot[bot]'
-      && startsWith(github.head_ref, 'dependabot/vcpkg/')
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')
     runs-on: ubuntu-24.04
     steps:
-      # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.
+      # The branch name says which ecosystem, this says which files, so a vcpkg PR that
+      # reaches outside its manifest waits for a human.
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
+        run: |
+          files=$(gh pr view "$PR_URL" --json files --jq '.files[].path')
+          if [ "$files" != "WinHTTrack/vcpkg.json" ]; then
+            echo "Not arming, because the PR touches more than the vcpkg manifest:"
+            printf '%s\n' "$files"
+            exit 0
+          fi
+          gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,41 @@
+# CI already validates every bump dependabot opens here, so auto-merge only saves the manual click.
+name: Dependabot auto-merge
+
+# pull_request_target, because a dependabot pull_request gets a read-only token.
+# Nothing from the PR is checked out or run, so the writable token stays safe.
+on: pull_request_target
+
+# Keyed on the PR, not on github.ref: a pull_request_target run reports the base
+# branch, so one group per branch lets a second dependabot PR cancel the first's
+# arming job and leave it silently unarmed.
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  # Both writes are what enabling auto-merge costs: the API call needs the pull
+  # request scope, and the merge it queues needs the contents one.
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Arm auto-merge
+    # vcpkg only. The github_actions ecosystem exists here to rewrite the SHA pins in
+    # windows-build.yml, and three of those actions run inside the sign job with the
+    # Certum seed in scope, so merging one unread gives back what pinning buys. Master
+    # requires no approving review, so nothing else would read it either.
+    if: >-
+      github.repository == 'xroche/httrack-windows'
+      && github.actor == 'dependabot[bot]'
+      && startsWith(github.head_ref, 'dependabot/vcpkg/')
+    runs-on: ubuntu-24.04
+    steps:
+      # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -32,14 +32,15 @@ jobs:
       && startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')
     runs-on: ubuntu-24.04
     steps:
-      # The branch name says which ecosystem, this says which files, so a vcpkg PR that
-      # reaches outside its manifest waits for a human.
+      # The branch name says which ecosystem, this says which files. A PR that reaches
+      # outside the manifest waits for a human, and gives back any arm it already had.
       - name: Enable auto-merge
         run: |
           files=$(gh pr view "$PR_URL" --json files --jq '.files[].path')
           if [ "$files" != "WinHTTrack/vcpkg.json" ]; then
             echo "Not arming, because the PR touches more than the vcpkg manifest:"
             printf '%s\n' "$files"
+            gh pr merge --disable-auto "$PR_URL" || true
             exit 0
           fi
           gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"


### PR DESCRIPTION
Dependabot's monthly PRs still need a merge click. This arms auto-merge for the vcpkg baseline bump, which touches nothing but `WinHTTrack/vcpkg.json`.

The `github_actions` ecosystem stays manual. It is here to rewrite the SHA pins in `windows-build.yml`. Three of the pinned actions run inside the `sign` job with `CERTUM_OTP_URI` in scope: `actions/checkout`, `actions/download-artifact` and `actions/upload-artifact`. Dependabot resolves each new SHA from the upstream tag, so it would pin a hijacked tag just as faithfully. That PR would go green, because the payload need not fire on a PR. Master requires no approving review, so nobody would read it first. SHA pinning exists to stop exactly that, and auto-merging the pin updates hands it back.

Three gates decide whether a PR arms. The author must be `dependabot[bot]`, read from `pull_request.user.login` rather than `github.actor`. The actor is whoever sent the event, so Dependabot pushing to a fork's branch makes the actor Dependabot on somebody else's PR. The head repository must be ours, which no fork satisfies. The branch must start with `dependabot/vcpkg/`.

The branch name is not the last word, though, because nothing in it constrains the diff. The step arms only when the changed-file list is `WinHTTrack/vcpkg.json` alone, and takes back an existing arm when a later push breaks that. Both historical vcpkg PRs, #84 and #42, changed exactly that file.

One deviation from the copy in `xroche/httrack`: the concurrency group keys on the PR number rather than `github.ref`. A `pull_request_target` run reports the base branch there. One group per branch therefore lets a second dependabot PR cancel the first's arming job and leave it unarmed. With two ecosystems on one monthly schedule, that is the ordinary case.

This does not check content. A baseline bump repoints vcpkg at an unreviewed upstream commit, and CI compiles that rather than reading it.
