### PR TITLE
The dependency watch lost the first drift it found

### DIFF
--- a/.github/workflows/native-dep-watch.yml
+++ b/.github/workflows/native-dep-watch.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Check the pinned OpenSSL against the advisory feed
         id: cve
         continue-on-error: true
-        run: python3 tools/check-native-deps.py --openssl-version "$OPENSSL" --min-severity moderate
+        env:
+          ACCEPTED: ${{ vars.SECURITY_ACCEPTED_CVES }}
+        run: |
+          python3 tools/check-native-deps.py --openssl-version "$OPENSSL" \
+            --min-severity moderate --accept "$ACCEPTED"
 
       - name: Open or update the tracking issue
         if: steps.drift.outputs.drift == 'yes' || steps.cve.outcome == 'failure'
@@ -50,6 +54,7 @@ jobs:
         run: |
           set -euo pipefail
           title="Native dependency drift"
+          gh label create security --color d93f0b --description "Advisory or dependency exposure" --force
           existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file drift.txt

--- a/.github/workflows/native-dep-watch.yml
+++ b/.github/workflows/native-dep-watch.yml
@@ -58,7 +58,7 @@ jobs:
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file drift.txt
           else
-            # Label it after filing, never during: gh drops the whole issue if the label is missing.
+            # gh drops the whole issue when the label is missing, so label after filing.
             url=$(gh issue create --title "$title" --body-file drift.txt)
             gh issue edit "$url" --add-label security || true
           fi

--- a/.github/workflows/native-dep-watch.yml
+++ b/.github/workflows/native-dep-watch.yml
@@ -54,10 +54,11 @@ jobs:
         run: |
           set -euo pipefail
           title="Native dependency drift"
-          gh label create security --color d93f0b --description "Advisory or dependency exposure" --force
           existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number' || true)
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file drift.txt
           else
-            gh issue create --title "$title" --body-file drift.txt --label security
+            # Label it after filing, never during: gh drops the whole issue if the label is missing.
+            url=$(gh issue create --title "$title" --body-file drift.txt)
+            gh issue edit "$url" --add-label security || true
           fi


### PR DESCRIPTION
The weekly watch found real drift on 2026-08-31 and lost it. It filed its tracking issue with `--label security`, and this repo had no `security` label. `gh` drops the whole creation when a label is missing, not just the label. Earlier runs were green because there was nothing to report, so that path had never run.

No label failure can take the report down now. A stubbed `gh` that fails every label call files the report and exits 0, where the old shape exits 1 with nothing filed. The `security` label now exists, created by hand because no workflow here provisions it.

The watch also ignored `SECURITY_ACCEPTED_CVES`, which the build gate honours, so it counted the three moderate OpenSSL advisories already accepted there. Against the pinned 3.6.3 the checker exits 1 without that list and 0 with it.

The genuine finding in the lost report was the drift itself, OpenSSL 3.6.3 here against 3.6.4 upstream.

This workflow runs only on `schedule` and `workflow_dispatch`, so the PR build never exercises it. A dispatch would file the drift issue for real, so I have not run one.