### PR TITLE
The Stop button throws away what a resume needs

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -303,7 +303,7 @@ runs:
         }
 
         # No CI can log off, so this count is the only proof the session-end stop ran.
-        if ("$so" -notmatch 'session end ok on 7 checks') {
+        if ("$so" -notmatch 'session end ok on 8 checks') {
           throw "selftest did not check the session-end stop"
         }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -288,7 +288,9 @@ WhttMirrorStop RequestMirrorStop() {
     return WHTT_STOP_ABORTED;
   }
   soft_term_requested=1;
-  hts_request_stop(global_opt, 0);
+  /* keep_resume: a mirror the user stopped is meant to be continued, unlike one
+     that ran out of links. */
+  hts_request_stop(global_opt, 1);
   return WHTT_STOP_ASKED;
 }
 

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -485,11 +485,7 @@ void Wid1::AfterChangepathlog()
             && (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/new.ndx")))
             ) {  // il existe déja un cache précédent.. renommer
             if (modify) {
-              if (
-                (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-in_progress.lock")))
-                &&
-                (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/interrupted.lock")))
-                )
+              if (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-in_progress.lock")))
                 m_ctl_todo.SetCurSel(LAST_ACTION);
               else
                 m_ctl_todo.SetCurSel(LAST_ACTION-1);

--- a/WinHTTrack/Wid1.cpp
+++ b/WinHTTrack/Wid1.cpp
@@ -485,7 +485,11 @@ void Wid1::AfterChangepathlog()
             && (fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/new.ndx")))
             ) {  // il existe déja un cache précédent.. renommer
             if (modify) {
-              if (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-in_progress.lock")))
+              if (
+                (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-in_progress.lock")))
+                &&
+                (!fexist(fconcat(catbuff,sizeof(catbuff),tempo,"hts-cache/interrupted.lock")))
+                )
                 m_ctl_todo.SetCurSel(LAST_ACTION);
               else
                 m_ctl_todo.SetCurSel(LAST_ACTION-1);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1243,9 +1243,10 @@ BOOL CWinHTTrackApp::InitInstance()
         nchecks++;
 
       termine = 0;                 /* and one that is still running */
-      /* state.stop is what hts_request_stop() sets; nothing exported reads it back. */
+      /* state.stop and exit_xh are what hts_request_stop() sets; nothing exported
+         reads either back. */
       if (SessionEndStop(FALSE) != WHTT_STOP_NOT_ENDING || soft_term_requested
-          || global_opt->state.stop) {
+          || global_opt->state.stop || global_opt->state.exit_xh) {
         fprintf(stderr, "FATAL: a FALSE session-end flag asked the mirror to stop\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1256,6 +1257,15 @@ BOOL CWinHTTrackApp::InitInstance()
       if (SessionEndStop(TRUE) != WHTT_STOP_ASKED || !soft_term_requested
           || !global_opt->state.stop || GetTickCount() - t0 > 1000) {
         fprintf(stderr, "FATAL: session end did not ask the running mirror to stop, or waited\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
+
+      /* 1, not merely non-zero: -1 would mean an engine fatal and report MIRROR ABORTED. */
+      if (global_opt->state.exit_xh != 1) {
+        fprintf(stderr, "FATAL: the stop left exit_xh at %d, so the engine erases the resume data\n",
+                global_opt->state.exit_xh);
         fflush(stderr);
         ExitProcess(3);
       } else
@@ -1303,8 +1313,8 @@ BOOL CWinHTTrackApp::InitInstance()
       global_opt = NULL;
       termine = soft_term_requested = 0;
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
-      if (nchecks != 7) {
-        fprintf(stderr, "FATAL: session end ran %d checks, expected 7\n", nchecks);
+      if (nchecks != 8) {
+        fprintf(stderr, "FATAL: session end ran %d checks, expected 8\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }


### PR DESCRIPTION
The Stop button took the engine's erasing path. `hts_request_stop()` left `exit_xh` at 0, so the engine read that as a clean end of mirror. It then deleted `hts-cache/ref`, the per-URL byte ranges a later `--continue` needs. The partial bodies stayed on disk with nothing left to describe them.

Engine `1444db4a` gave that call's second parameter a meaning, so passing 1 asks for the metadata to be kept. The exit code does not move, because only `exit_xh == -1` yields `HTS_EXIT_MIRROR_ABORTED`. A `MIRROR ABORTED` block now appears in `hts-log.txt` after a stop, which is right for a mirror the user ended.

The line lives in `RequestMirrorStop()`, which also serves the Windows session-end path. That path wants the same thing, because neither a logoff nor a Stop click means the mirror finished.

The selftest pins the flag both ways, unset before the stop and exactly 1 after, so the argument cannot revert to 0 unnoticed. 1 rather than non-zero, because -1 would mean an engine fatal.

Two consequences a reviewer should weigh, neither of them new states. A single Stop now leaves the engine where a double Stop already left it. So `hts_is_exiting()` reads 1 at `inprogress.cpp:1153`, and an update project can offer the "restore the old cache?" prompt where one Stop did not before. The prompt defaults to declining it. Nobody has exercised a `--continue` against a restored old cache, so the VM pass should check that the surviving `ref` offsets still read sensibly. The same prompt can now appear during a logoff, where the old single-Stop path could not raise one.

The `hts-cache/interrupted.lock` check in `Wid1::AfterChangepathlog` was meant to come out alongside this, on the grounds that no engine writes that file. It stays, because `Shell.cpp` writes it here on the Stop path. Dropping the reader would reopen a stopped project on "Update existing download" rather than "Continue interrupted download", re-crawling the queue this change preserves.

CI cannot see the behaviour. It needs a VM pass. Mirror a site, press Stop mid-transfer, then reopen the project and continue. The transfer must resume at a non-zero offset instead of restarting.