### PR TITLE
The GUI vcpkg pin still names OpenSSL 3.6.3

### DIFF
--- a/WinHTTrack/vcpkg.json
+++ b/WinHTTrack/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "winhttrack",
   "version-string": "3.49",
-  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "openssl",
     "zlib"


### PR DESCRIPTION
The engine moved its baseline to `04a9d8e5` in xroche/httrack#1598, which takes OpenSSL from 3.6.3 to 3.6.4. This repo carries its own `builtin-baseline`, and `native-dep-watch.yml` reads that one rather than the engine's, so the pin here has to follow.

`SECURITY_ACCEPTED_CVES` held CVE-2026-18798, CVE-2026-63072 and CVE-2026-63076. Each is Moderate with an affected range of 3.6.0 up to 3.6.4, so all three stop matching at 3.6.4. The checker fails on an acceptance that no longer matches, so the variable is now deleted. GitHub rejects an empty value with a 422, which is why deleting it is the only way to empty the list.

The build gate did not need this commit. It reads the engine's pin and scans the engine tree first-wins, so it went clean when #1598 landed. The weekly watch reads the pin in this file instead. It would have stayed on 3.6.3 and reported those same three as blocking once nothing accepted them.

I ran the checker three ways. At 3.6.4 with no acceptances it is clean. At 3.6.3 with none it fires all three, and at 3.6.4 with the old list it reports three spent. Mixed pins still build, because the workflow checks `versions/` out at each manifest's own baseline before that manifest builds.

Closes #164, the drift the weekly watch filed for this pin on 2026-09-07.