### PR TITLE
The GUI vcpkg manifest still says version 3.49

### DIFF
--- a/WinHTTrack/vcpkg.json
+++ b/WinHTTrack/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "winhttrack",
-  "version-string": "3.49",
+  "version-string": "3.50",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "dependencies": [
     "openssl",


### PR DESCRIPTION
The GUI and the engine are both on 3.50, but this manifest still declared 3.49. vcpkg uses it for the manifest's own identity rather than for resolution, so nothing in this repo's build reads it.

It conflicts with #163, which changes the adjacent line. This one merges first, and I will update #163 and resolve it there.
