### PR TITLE
Two CI guards pass when they should not

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -45,9 +45,11 @@ jobs:
             gh pr merge --disable-auto "$PR_URL" || true
             exit 0
           fi
-          # An unattended merge hands any open human PR on this file a conflict.
+          # An unattended merge hands any open human PR on this file a conflict. Match on
+          # is_bot, because gh spells this author "app/dependabot", not "dependabot[bot]".
           held=$(gh pr list --state open --limit 100 --json number,author,files --jq '[.[]
-            | select(.author.login != "dependabot[bot]")
+            | select(.number != (env.PR_NUMBER | tonumber))
+            | select(.author.is_bot | not)
             | select(any(.files[].path; . == "WinHTTrack/vcpkg.json"))
             | "#\(.number)"] | join(" ")')
           if [ -n "$held" ]; then

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,6 +36,8 @@ jobs:
       # outside the manifest waits for a human, and gives back any arm it already had.
       - name: Enable auto-merge
         run: |
+          # Fail closed: a failed lookup below must not fall through to arming.
+          set -euo pipefail
           files=$(gh pr view "$PR_URL" --json files --jq '.files[].path')
           if [ "$files" != "WinHTTrack/vcpkg.json" ]; then
             echo "Not arming, because the PR touches more than the vcpkg manifest:"
@@ -43,8 +45,19 @@ jobs:
             gh pr merge --disable-auto "$PR_URL" || true
             exit 0
           fi
+          # An unattended merge hands any open human PR on this file a conflict.
+          held=$(gh pr list --state open --limit 100 --json number,author,files --jq '[.[]
+            | select(.author.login != "dependabot[bot]")
+            | select(any(.files[].path; . == "WinHTTrack/vcpkg.json"))
+            | "#\(.number)"] | join(" ")')
+          if [ -n "$held" ]; then
+            echo "Not arming, because these open PRs touch the same manifest: $held"
+            gh pr merge --disable-auto "$PR_URL" || true
+            exit 0
+          fi
           gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
         env:
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -848,12 +848,12 @@ jobs:
       # vcpkg is invisible to Dependabot alerts, CodeQL and the dependency graph, so
       # this is the only thing between a stale OpenSSL and a signed installer. Advisory
       # on a pull request, fatal on master and on tags. The engine tree is what ships
-      # (the GUI imports neither library); the GUI tree is scanned too and cross-checked
+      # (the GUI imports neither library). The GUI tree is scanned too and cross-checked
       # against its pin.
       - name: Check shipped native dependencies for advisories
         shell: pwsh
         # An author cannot fix an advisory published while their PR is open, but a red
-        # master is seen long before release day. push here is master and tags only.
+        # master is seen long before release day. push fires only for master and tags.
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           ACCEPTED: ${{ vars.SECURITY_ACCEPTED_CVES }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -847,11 +847,14 @@ jobs:
 
       # vcpkg is invisible to Dependabot alerts, CodeQL and the dependency graph, so
       # this is the only thing between a stale OpenSSL and a signed installer. Advisory
-      # on branches, fatal on tags. The engine tree is what ships (the GUI imports
-      # neither library); the GUI tree is scanned too and cross-checked against its pin.
+      # on a pull request, fatal on master and on tags. The engine tree is what ships
+      # (the GUI imports neither library); the GUI tree is scanned too and cross-checked
+      # against its pin.
       - name: Check shipped native dependencies for advisories
         shell: pwsh
-        continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        # An author cannot fix an advisory published while their PR is open, but a red
+        # master is seen long before release day. push here is master and tags only.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           ACCEPTED: ${{ vars.SECURITY_ACCEPTED_CVES }}
         run: |


### PR DESCRIPTION
The arm rule fires on any dependabot PR touching `WinHTTrack/vcpkg.json`, which is where the OpenSSL pin lives. #163 and #165 changed adjacent lines of that file and conflicted, so an unattended dependabot merge would hand an open human PR the same conflict.

The step now holds off while an open non-dependabot PR touches the manifest, and gives back any arm it already had. That is what it already does for a PR reaching outside the manifest. `GH_REPO` is needed because the job checks nothing out, so `gh pr list` has no remote to resolve against.

The guard matches a bot on `is_bot` rather than on a login. `gh pr list` exports the author as `app/dependabot`, while the job condition reads `dependabot[bot]` from the event payload. A first version of this PR filtered on the payload spelling, so it matched nothing. It then held on every dependabot PR, including the one being processed, and would have killed arming permanently. Review caught it. The guard also excludes the current PR by number, so a further change in that export shape cannot deadlock it on itself.

`set -euo pipefail` makes the lookup fail closed. Without it a failed `gh pr list` returns empty and the step arms, which is the wrong direction for this guard.

Two dependabot PRs on the same file still arm each other. Dependabot rebases its own branches, and excluding them would deadlock the pair.

This PR also folds in a second guard. The CVE gate was advisory on every branch. A failing check therefore left master green, and the failure showed up only in the step's own conclusion. A release build was the first place it could be fatal. It is now advisory on a pull request and fatal on master and on tags.

An author cannot fix an advisory published while their PR is open, so a pull request stays advisory. A red master is seen long before release day. The accept list remains the escape hatch for the window where vcpkg has no fixed version yet, and the spent-acceptance check forces the cleanup afterwards.

Master pushes carry `event=push` and pull requests `event=pull_request`, so the expression splits exactly there. It also makes a `workflow_dispatch` signing rehearsal fatal, which previously signed despite a CVE finding. This PR's own run is a pull request, so it cannot exercise the master-fatal path, because that starts at the merge. The weekly watch keeps its own `continue-on-error`, because its outcome is what files the drift issue.

I ran the guard's own jq, extracted from the workflow file, against three cases. A dependabot PR excludes itself, a human PR on the manifest is caught, and today's empty tree lets arming proceed. shellcheck is clean.