### PR TITLE
Nothing tests the two guards from #166

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -43,11 +43,10 @@ jobs:
       # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
       - name: Advisory accept/stale cases
         run: python3 tools/test-check-native-deps.py
-      # Both guards are config, so nothing else runs them: the arm gate needs a dependabot
-      # event, and the CVE gate's severity only shows on a push.
+      # Both guards are config, so nothing else runs them. The arm gate needs a
+      # dependabot event, and the CVE gate needs a push.
       - name: Auto-merge and CVE gate cases
         run: python3 tools/test-automerge-gate.py
-
       # Cheap companion to the walk's runtime check: started after that dialog, the check can
       # never give it a verdict (#152), and nothing in the build can see that.
       - name: The signature check starts before the first-run About

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -43,6 +43,11 @@ jobs:
       # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
       - name: Advisory accept/stale cases
         run: python3 tools/test-check-native-deps.py
+      # Both guards are config, so nothing else runs them: the arm gate needs a dependabot
+      # event, and the CVE gate's severity only shows on a push.
+      - name: Auto-merge and CVE gate cases
+        run: python3 tools/test-automerge-gate.py
+
       # Cheap companion to the walk's runtime check: started after that dialog, the check can
       # never give it a verdict (#152), and nothing in the build can see that.
       - name: The signature check starts before the first-run About

--- a/tools/test-automerge-gate.py
+++ b/tools/test-automerge-gate.py
@@ -3,6 +3,10 @@
 
 Both are config, so nothing else exercises them. The arm gate only runs on a
 dependabot event, and the CVE gate's severity only shows on a push.
+
+This reads the workflows as text, so it catches a careless edit rather than a
+crafted one. An edit that keeps every string below while changing what the
+shell means will pass, so review still owns these two files.
 """
 import sys
 from pathlib import Path
@@ -15,7 +19,10 @@ ARM = ROOT / ".github/workflows/dependabot-automerge.yml"
 BUILD = ROOT / ".github/workflows/windows-build.yml"
 
 # Reached only after both refusals, so it is what every edit must not expose.
-ARM_CMD = "gh pr merge --auto --squash"
+# Any merge method, because a second arm spelled --rebase arms just as hard.
+ARM_CMD = "gh pr merge --auto"
+# Each refusal must disarm and then leave, or it falls through to the arm.
+REFUSAL = 'gh pr merge --disable-auto "$PR_URL" || true exit 0'
 HELD_GUARD = 'if [ -n "$held" ]; then'
 FILES_GUARD = 'if [ "$files" != "WinHTTrack/vcpkg.json" ]; then'
 
@@ -42,7 +49,7 @@ def arm_problems(text):
     for clause in CLAUSES:
         if clause not in gate:
             bad.append(f"the gate is missing: {clause}")
-    # Pins the clause count, so a fifth has to come past a reader.
+    # This pins the clause count, so a fifth clause has to pass a reader.
     if gate.count("&&") != len(CLAUSES) - 1:
         bad.append(f"the gate joins with {gate.count('&&')} '&&', expected {len(CLAUSES) - 1}")
 
@@ -50,6 +57,8 @@ def arm_problems(text):
     if len(steps) != 1:
         return bad + [f"{len(steps)} steps, expected exactly 1"]
     run = steps[0].get("run", "")
+    # Whitespace-collapsed, so indentation changes do not read as damage.
+    flat = " ".join(run.split())
 
     # A failed lookup must not fall through to arming.
     if "set -euo pipefail" not in run:
@@ -58,19 +67,17 @@ def arm_problems(text):
     for var in ("files=", "held="):
         if run.count(var) != 1:
             bad.append(f"{run.count(var)} assignments to {var}, expected 1")
-    # Polarity, not presence. Swapping -n for -z arms on a held human PR.
+    # This checks polarity, so swapping -n for -z would arm on a held human PR.
     if HELD_GUARD not in run:
         bad.append("the held branch does not refuse on a non-empty result")
     if FILES_GUARD not in run:
         bad.append("the files branch does not refuse on a mismatch")
-    # Both refusals must leave, or one falls through to the arm below it.
-    if run.count("exit 0") != 2:
-        bad.append(f"{run.count('exit 0')} refusal exits, expected 2")
-    if run.count("--disable-auto") != 2:
-        bad.append(f"{run.count('--disable-auto')} disarm calls, expected 2")
+    # Pairs, not totals. A comment holding the words would restore a bare count.
+    if flat.count(REFUSAL) != 2:
+        bad.append(f"{flat.count(REFUSAL)} refusals that disarm and leave, expected 2")
 
-    # Scoped to the lookup: the files branch names the manifest too, so searching
-    # the whole step would satisfy this even with the lookup filtering nothing.
+    # The files branch names the manifest too, so an unscoped search would pass
+    # even with a lookup that filters nothing.
     lookup = run[run.find("held=$("):run.find(HELD_GUARD)]
     if ".author.is_bot" not in lookup:
         bad.append("the lookup does not match a bot on is_bot")
@@ -78,10 +85,15 @@ def arm_problems(text):
         bad.append("the lookup does not exclude the current PR")
     if "WinHTTrack/vcpkg.json" not in lookup:
         bad.append("the lookup does not name the manifest")
+    # Narrowing either would empty the result while every name above survives.
+    if "--state open" not in lookup:
+        bad.append("the lookup does not read open pull requests")
+    if ".files[].path" not in lookup:
+        bad.append("the lookup does not read every changed path")
 
-    if run.count(ARM_CMD) != 1:
-        bad.append(f"{run.count(ARM_CMD)} arm calls, expected 1")
-    elif run.index(ARM_CMD) < run.rfind("exit 0"):
+    if flat.count(ARM_CMD) != 1:
+        bad.append(f"{flat.count(ARM_CMD)} arm calls, expected 1")
+    elif flat.index(ARM_CMD) < flat.rfind(REFUSAL):
         bad.append("the arm runs before a refusal branch")
     return bad
 
@@ -89,22 +101,32 @@ def arm_problems(text):
 def cve_problems(text):
     """Everything wrong with the CVE gate's severity. Empty means sound."""
     want = "${{ github.event_name == 'pull_request' }}"
-    # Every match, not the first: a later advisory copy would go unread.
-    found = [str(s.get("continue-on-error", ""))
-             for job in (yaml.safe_load(text).get("jobs") or {}).values()
+    # A later advisory copy of the step would otherwise go unread.
+    steps = [s for job in (yaml.safe_load(text).get("jobs") or {}).values()
              for s in job.get("steps") or []
              if "native dependencies" in s.get("name", "")]
-    if not found:
+    if not steps:
         return ["no native-dependency step found"]
-    return [f"continue-on-error is {got!r}, want {want!r}" for got in found if got != want]
+    bad = []
+    for step in steps:
+        got = str(step.get("continue-on-error", ""))
+        if got != want:
+            bad.append(f"continue-on-error is {got!r}, want {want!r}")
+        # A skipped step reports nothing at all, which beats being advisory.
+        if "if" in step:
+            bad.append(f"the step is conditional on {step['if']!r}")
+        if "check-native-deps.py" not in step.get("run", ""):
+            bad.append("the step does not run the checker")
+    return bad
 
 
 ARM_TEXT, BUILD_TEXT = ARM.read_text(), BUILD.read_text()
-CVE_STEP = "      - name: Check shipped native dependencies for advisories\n"
+CVE_STEP_NAME = "      - name: Check shipped native dependencies for advisories\n"
+NEXT_STEP = "      - name: Build the installer\n"
 CVE_LINE = "continue-on-error: ${{ github.event_name == 'pull_request' }}"
 
-# Grepping their text would miss && flipped to ||, which arms every pull request
-# in the repo, so each row damages a guard and the checker must catch it.
+# A grep-based check would miss && flipped to ||, which arms every pull request.
+# The committed rows run first, so a broken guard reports the guard, not a stale row.
 # (name, check, text, (old, new) edit or None, must be caught)
 CASES = [
     ("arm gate as committed", arm_problems, ARM_TEXT, None, False),
@@ -140,8 +162,16 @@ CASES = [
      (CVE_LINE, "continue-on-error: true"), True),
     ("CVE gate advisory off a tag", cve_problems, BUILD_TEXT,
      (CVE_LINE, "continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}"), True),
-    ("advisory copy of the CVE step", cve_problems, BUILD_TEXT,
-     (CVE_STEP, CVE_STEP + "        continue-on-error: true\n" + CVE_STEP), True),
+    ("files result overwritten", arm_problems, ARM_TEXT,
+     (FILES_GUARD, 'files="WinHTTrack/vcpkg.json"\n          ' + FILES_GUARD), True),
+    ("CVE step made conditional", cve_problems, BUILD_TEXT,
+     (CVE_LINE, CVE_LINE + "\n        if: false"), True),
+    ("CVE step stops running the checker", cve_problems, BUILD_TEXT,
+     ("python httrack-windows/tools/check-native-deps.py", "echo skipped #"), True),
+    ("advisory copy after the sound step", cve_problems, BUILD_TEXT,
+     (NEXT_STEP, CVE_STEP_NAME + "        continue-on-error: true\n"
+      "        run: python httrack-windows/tools/check-native-deps.py --help\n" + NEXT_STEP),
+     True),
 ]
 
 failed = 0
@@ -166,8 +196,8 @@ for name, check, text, edit, must_catch in CASES:
         print(f"ok   {name}")
 
 # Pin the count, or deleting a row leaves this green.
-if len(CASES) != 18:
-    print(f"FAIL expected 18 cases, table has {len(CASES)}")
+if len(CASES) != 21:
+    print(f"FAIL expected 21 cases, table has {len(CASES)}")
     failed += 1
 
 print(f"{len(CASES)} cases, {failed} failed")

--- a/tools/test-automerge-gate.py
+++ b/tools/test-automerge-gate.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Mutation test for the two CI guards from #166.
+
+Both are config, so nothing else exercises them: the arm gate only runs on a
+dependabot event, and the CVE gate's severity only shows on a push. A test that
+grepped for their text would pass with `&&` flipped to `||`, which arms every PR
+in the repo, so each guard is parsed and each mutation below must be caught.
+
+yaml is preinstalled on the runner image; a missing import fails this loudly.
+"""
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+ARM = ROOT / ".github/workflows/dependabot-automerge.yml"
+BUILD = ROOT / ".github/workflows/windows-build.yml"
+
+# Reached only after both refusals, so it is the thing every mutation must not expose.
+ARM_CMD = "gh pr merge --auto --squash"
+
+CLAUSES = (
+    "github.repository == 'xroche/httrack-windows'",
+    "github.event.pull_request.user.login == 'dependabot[bot]'",
+    "github.event.pull_request.head.repo.full_name == github.repository",
+    "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')",
+)
+
+
+def arm_problems(text):
+    """Everything wrong with the auto-merge gate. Empty means sound."""
+    bad = []
+    jobs = yaml.safe_load(text).get("jobs") or {}
+    # A second job could arm without any of this.
+    if list(jobs) != ["automerge"]:
+        return [f"jobs are {list(jobs)}, expected exactly ['automerge']"]
+    job = jobs["automerge"]
+
+    gate = " ".join(str(job.get("if", "")).split())
+    # A disjunction anywhere makes the whole gate satisfiable by one clause.
+    if "||" in gate:
+        bad.append("the gate contains a disjunction")
+    for clause in ("github.repository == 'xroche/httrack-windows'",
+                   "github.event.pull_request.user.login == 'dependabot[bot]'",
+                   "github.event.pull_request.head.repo.full_name == github.repository",
+                   "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')"):
+        if clause not in gate:
+            bad.append(f"the gate is missing: {clause}")
+    if gate.count("&&") != 3:
+        bad.append(f"the gate joins with {gate.count('&&')} '&&', expected 3")
+
+    steps = job.get("steps") or []
+    if len(steps) != 1:
+        return bad + [f"{len(steps)} steps, expected exactly 1"]
+    run = steps[0].get("run", "")
+
+    # gh exports this author as app/dependabot, so a login match here matches nothing
+    # and the guard holds on every dependabot PR, itself included.
+    if ".author.is_bot" not in run:
+        bad.append("the held lookup does not match a bot on is_bot")
+    if "env.PR_NUMBER" not in run:
+        bad.append("the held lookup does not exclude the current PR")
+    if "WinHTTrack/vcpkg.json" not in run:
+        bad.append("the held lookup does not name the manifest")
+    # Polarity, not presence: -z for -n arms exactly when a human PR is held.
+    if 'if [ -n "$held" ]; then' not in run:
+        bad.append("the held branch does not refuse on a non-empty result")
+    if 'if [ "$files" != "WinHTTrack/vcpkg.json" ]; then' not in run:
+        bad.append("the files branch does not refuse on a mismatch")
+    if run.count("--disable-auto") != 2:
+        bad.append(f"{run.count('--disable-auto')} disarm calls, expected 2")
+    if run.count(ARM_CMD) != 1:
+        bad.append(f"{run.count(ARM_CMD)} arm calls, expected 1")
+    elif run.index(ARM_CMD) < run.rfind("exit 0"):
+        bad.append("the arm runs before a refusal branch")
+    return bad
+
+
+def cve_problems(text):
+    """Everything wrong with the CVE gate's severity. Empty means sound."""
+    want = "${{ github.event_name == 'pull_request' }}"
+    for job in (yaml.safe_load(text).get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if "native dependencies" in step.get("name", ""):
+                got = str(step.get("continue-on-error", ""))
+                # Advisory anywhere but a pull request is how a red master hides.
+                return [] if got == want else [f"continue-on-error is {got!r}, want {want!r}"]
+    return ["no native-dependency step found"]
+
+
+ARM_TEXT, BUILD_TEXT = ARM.read_text(), BUILD.read_text()
+CVE_LINE = "continue-on-error: ${{ github.event_name == 'pull_request' }}"
+
+# Each row is the file as committed, or one edit to it that must be caught. The
+# committed rows run first, so breaking a guard reports the guard, not a stale edit.
+CASES = [
+    ("arm gate as committed", arm_problems, ARM_TEXT, None, False),
+    ("CVE gate as committed", cve_problems, BUILD_TEXT, None, False),
+    ("&& flipped to ||", arm_problems, ARM_TEXT,
+     ("&& " + CLAUSES[3], "|| " + CLAUSES[3]), True),
+    ("author clause dropped", arm_problems, ARM_TEXT,
+     ("&& " + CLAUSES[1] + "\n", ""), True),
+    ("head-repo clause dropped", arm_problems, ARM_TEXT,
+     ("&& " + CLAUSES[2] + "\n", ""), True),
+    ("vcpkg branch clause dropped", arm_problems, ARM_TEXT,
+     ("&& " + CLAUSES[3] + "\n", ""), True),
+    ("bot matched by login again", arm_problems, ARM_TEXT,
+     ("select(.author.is_bot | not)", 'select(.author.login != "dependabot[bot]")'), True),
+    ("self-exclusion dropped", arm_problems, ARM_TEXT,
+     ("| select(.number != (env.PR_NUMBER | tonumber))\n", ""), True),
+    ("held guard disarmed", arm_problems, ARM_TEXT,
+     ('if [ -n "$held" ]; then', 'if [ -z "$held" ]; then'), True),
+    ("files guard inverted", arm_problems, ARM_TEXT,
+     ('if [ "$files" != "WinHTTrack/vcpkg.json" ]; then',
+      'if [ "$files" = "WinHTTrack/vcpkg.json" ]; then'), True),
+    ("CVE gate advisory everywhere", cve_problems, BUILD_TEXT,
+     (CVE_LINE, "continue-on-error: true"), True),
+    ("CVE gate advisory off a tag", cve_problems, BUILD_TEXT,
+     (CVE_LINE, "continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}"), True),
+]
+
+bad = 0
+for name, check, text, mutation, want_problem in CASES:
+    if mutation:
+        old, new = mutation
+        # An edit that no longer applies proves nothing, so say which it is.
+        if old not in text:
+            bad += 1
+            print(f"FAIL {name}: the workflow no longer contains {old!r}, so this case "
+                  f"tests nothing. Update it if the guard legitimately changed shape.")
+            continue
+        text = text.replace(old, new, 1)
+    found = check(text)
+    if want_problem and not found:
+        bad += 1
+        print(f"FAIL {name}: the edit went unnoticed")
+    elif not want_problem and found:
+        bad += 1
+        print(f"FAIL {name}: {'; '.join(found)}")
+    else:
+        print(f"ok   {name}")
+
+# Pin the count, or deleting a row leaves this green.
+if len(CASES) != 12:
+    print(f"FAIL expected 12 cases, table has {len(CASES)}")
+    bad += 1
+
+print(f"{len(CASES)} cases, {bad} failed")
+sys.exit(1 if bad else 0)

--- a/tools/test-automerge-gate.py
+++ b/tools/test-automerge-gate.py
@@ -1,31 +1,29 @@
 #!/usr/bin/env python3
 """Mutation test for the two CI guards from #166.
 
-Both are config, so nothing else exercises them: the arm gate only runs on a
-dependabot event, and the CVE gate's severity only shows on a push. A test that
-grepped for their text would pass with `&&` flipped to `||`, which arms every PR
-in the repo, so each guard is parsed and each mutation below must be caught.
-
-yaml is preinstalled on the runner image; a missing import fails this loudly.
+Both are config, so nothing else exercises them. The arm gate only runs on a
+dependabot event, and the CVE gate's severity only shows on a push.
 """
 import sys
 from pathlib import Path
 
+# yaml ships on the runner image, so a missing import fails this loudly.
 import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 ARM = ROOT / ".github/workflows/dependabot-automerge.yml"
 BUILD = ROOT / ".github/workflows/windows-build.yml"
 
-# Reached only after both refusals, so it is the thing every mutation must not expose.
+# Reached only after both refusals, so it is what every edit must not expose.
 ARM_CMD = "gh pr merge --auto --squash"
+HELD_GUARD = 'if [ -n "$held" ]; then'
+FILES_GUARD = 'if [ "$files" != "WinHTTrack/vcpkg.json" ]; then'
 
-CLAUSES = (
-    "github.repository == 'xroche/httrack-windows'",
-    "github.event.pull_request.user.login == 'dependabot[bot]'",
-    "github.event.pull_request.head.repo.full_name == github.repository",
-    "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')",
-)
+REPO_CLAUSE = "github.repository == 'xroche/httrack-windows'"
+AUTHOR_CLAUSE = "github.event.pull_request.user.login == 'dependabot[bot]'"
+HEAD_REPO_CLAUSE = "github.event.pull_request.head.repo.full_name == github.repository"
+VCPKG_CLAUSE = "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')"
+CLAUSES = (REPO_CLAUSE, AUTHOR_CLAUSE, HEAD_REPO_CLAUSE, VCPKG_CLAUSE)
 
 
 def arm_problems(text):
@@ -41,35 +39,46 @@ def arm_problems(text):
     # A disjunction anywhere makes the whole gate satisfiable by one clause.
     if "||" in gate:
         bad.append("the gate contains a disjunction")
-    for clause in ("github.repository == 'xroche/httrack-windows'",
-                   "github.event.pull_request.user.login == 'dependabot[bot]'",
-                   "github.event.pull_request.head.repo.full_name == github.repository",
-                   "startsWith(github.event.pull_request.head.ref, 'dependabot/vcpkg/')"):
+    for clause in CLAUSES:
         if clause not in gate:
             bad.append(f"the gate is missing: {clause}")
-    if gate.count("&&") != 3:
-        bad.append(f"the gate joins with {gate.count('&&')} '&&', expected 3")
+    # Pins the clause count, so a fifth has to come past a reader.
+    if gate.count("&&") != len(CLAUSES) - 1:
+        bad.append(f"the gate joins with {gate.count('&&')} '&&', expected {len(CLAUSES) - 1}")
 
     steps = job.get("steps") or []
     if len(steps) != 1:
         return bad + [f"{len(steps)} steps, expected exactly 1"]
     run = steps[0].get("run", "")
 
-    # gh exports this author as app/dependabot, so a login match here matches nothing
-    # and the guard holds on every dependabot PR, itself included.
-    if ".author.is_bot" not in run:
-        bad.append("the held lookup does not match a bot on is_bot")
-    if "env.PR_NUMBER" not in run:
-        bad.append("the held lookup does not exclude the current PR")
-    if "WinHTTrack/vcpkg.json" not in run:
-        bad.append("the held lookup does not name the manifest")
-    # Polarity, not presence: -z for -n arms exactly when a human PR is held.
-    if 'if [ -n "$held" ]; then' not in run:
+    # A failed lookup must not fall through to arming.
+    if "set -euo pipefail" not in run:
+        bad.append("the step does not fail closed")
+    # A second assignment to either would leave its refusal vacuous.
+    for var in ("files=", "held="):
+        if run.count(var) != 1:
+            bad.append(f"{run.count(var)} assignments to {var}, expected 1")
+    # Polarity, not presence. Swapping -n for -z arms on a held human PR.
+    if HELD_GUARD not in run:
         bad.append("the held branch does not refuse on a non-empty result")
-    if 'if [ "$files" != "WinHTTrack/vcpkg.json" ]; then' not in run:
+    if FILES_GUARD not in run:
         bad.append("the files branch does not refuse on a mismatch")
+    # Both refusals must leave, or one falls through to the arm below it.
+    if run.count("exit 0") != 2:
+        bad.append(f"{run.count('exit 0')} refusal exits, expected 2")
     if run.count("--disable-auto") != 2:
         bad.append(f"{run.count('--disable-auto')} disarm calls, expected 2")
+
+    # Scoped to the lookup: the files branch names the manifest too, so searching
+    # the whole step would satisfy this even with the lookup filtering nothing.
+    lookup = run[run.find("held=$("):run.find(HELD_GUARD)]
+    if ".author.is_bot" not in lookup:
+        bad.append("the lookup does not match a bot on is_bot")
+    if "env.PR_NUMBER" not in lookup:
+        bad.append("the lookup does not exclude the current PR")
+    if "WinHTTrack/vcpkg.json" not in lookup:
+        bad.append("the lookup does not name the manifest")
+
     if run.count(ARM_CMD) != 1:
         bad.append(f"{run.count(ARM_CMD)} arm calls, expected 1")
     elif run.index(ARM_CMD) < run.rfind("exit 0"):
@@ -80,71 +89,86 @@ def arm_problems(text):
 def cve_problems(text):
     """Everything wrong with the CVE gate's severity. Empty means sound."""
     want = "${{ github.event_name == 'pull_request' }}"
-    for job in (yaml.safe_load(text).get("jobs") or {}).values():
-        for step in job.get("steps") or []:
-            if "native dependencies" in step.get("name", ""):
-                got = str(step.get("continue-on-error", ""))
-                # Advisory anywhere but a pull request is how a red master hides.
-                return [] if got == want else [f"continue-on-error is {got!r}, want {want!r}"]
-    return ["no native-dependency step found"]
+    # Every match, not the first: a later advisory copy would go unread.
+    found = [str(s.get("continue-on-error", ""))
+             for job in (yaml.safe_load(text).get("jobs") or {}).values()
+             for s in job.get("steps") or []
+             if "native dependencies" in s.get("name", "")]
+    if not found:
+        return ["no native-dependency step found"]
+    return [f"continue-on-error is {got!r}, want {want!r}" for got in found if got != want]
 
 
 ARM_TEXT, BUILD_TEXT = ARM.read_text(), BUILD.read_text()
+CVE_STEP = "      - name: Check shipped native dependencies for advisories\n"
 CVE_LINE = "continue-on-error: ${{ github.event_name == 'pull_request' }}"
 
-# Each row is the file as committed, or one edit to it that must be caught. The
-# committed rows run first, so breaking a guard reports the guard, not a stale edit.
+# Grepping their text would miss && flipped to ||, which arms every pull request
+# in the repo, so each row damages a guard and the checker must catch it.
+# (name, check, text, (old, new) edit or None, must be caught)
 CASES = [
     ("arm gate as committed", arm_problems, ARM_TEXT, None, False),
     ("CVE gate as committed", cve_problems, BUILD_TEXT, None, False),
     ("&& flipped to ||", arm_problems, ARM_TEXT,
-     ("&& " + CLAUSES[3], "|| " + CLAUSES[3]), True),
+     ("&& " + VCPKG_CLAUSE, "|| " + VCPKG_CLAUSE), True),
     ("author clause dropped", arm_problems, ARM_TEXT,
-     ("&& " + CLAUSES[1] + "\n", ""), True),
+     ("&& " + AUTHOR_CLAUSE + "\n", ""), True),
     ("head-repo clause dropped", arm_problems, ARM_TEXT,
-     ("&& " + CLAUSES[2] + "\n", ""), True),
+     ("&& " + HEAD_REPO_CLAUSE + "\n", ""), True),
     ("vcpkg branch clause dropped", arm_problems, ARM_TEXT,
-     ("&& " + CLAUSES[3] + "\n", ""), True),
+     ("&& " + VCPKG_CLAUSE + "\n", ""), True),
+    ("fifth clause bolted on", arm_problems, ARM_TEXT,
+     ("&& " + VCPKG_CLAUSE, "&& true\n      && " + VCPKG_CLAUSE), True),
+    ("fail-closed dropped", arm_problems, ARM_TEXT,
+     ("          set -euo pipefail\n", ""), True),
+    ("lookup result overwritten", arm_problems, ARM_TEXT,
+     (HELD_GUARD, 'held=""\n          ' + HELD_GUARD), True),
+    ("refusal falls through", arm_problems, ARM_TEXT,
+     ("            gh pr merge --disable-auto \"$PR_URL\" || true\n            exit 0\n",
+      "            gh pr merge --disable-auto \"$PR_URL\" || true\n"), True),
     ("bot matched by login again", arm_problems, ARM_TEXT,
      ("select(.author.is_bot | not)", 'select(.author.login != "dependabot[bot]")'), True),
     ("self-exclusion dropped", arm_problems, ARM_TEXT,
      ("| select(.number != (env.PR_NUMBER | tonumber))\n", ""), True),
+    ("lookup stops naming the manifest", arm_problems, ARM_TEXT,
+     ('select(any(.files[].path; . == "WinHTTrack/vcpkg.json"))', "select(true)"), True),
     ("held guard disarmed", arm_problems, ARM_TEXT,
-     ('if [ -n "$held" ]; then', 'if [ -z "$held" ]; then'), True),
+     (HELD_GUARD, 'if [ -z "$held" ]; then'), True),
     ("files guard inverted", arm_problems, ARM_TEXT,
-     ('if [ "$files" != "WinHTTrack/vcpkg.json" ]; then',
-      'if [ "$files" = "WinHTTrack/vcpkg.json" ]; then'), True),
+     (FILES_GUARD, 'if [ "$files" = "WinHTTrack/vcpkg.json" ]; then'), True),
     ("CVE gate advisory everywhere", cve_problems, BUILD_TEXT,
      (CVE_LINE, "continue-on-error: true"), True),
     ("CVE gate advisory off a tag", cve_problems, BUILD_TEXT,
      (CVE_LINE, "continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}"), True),
+    ("advisory copy of the CVE step", cve_problems, BUILD_TEXT,
+     (CVE_STEP, CVE_STEP + "        continue-on-error: true\n" + CVE_STEP), True),
 ]
 
-bad = 0
-for name, check, text, mutation, want_problem in CASES:
-    if mutation:
-        old, new = mutation
+failed = 0
+for name, check, text, edit, must_catch in CASES:
+    if edit:
+        old, new = edit
         # An edit that no longer applies proves nothing, so say which it is.
         if old not in text:
-            bad += 1
+            failed += 1
             print(f"FAIL {name}: the workflow no longer contains {old!r}, so this case "
                   f"tests nothing. Update it if the guard legitimately changed shape.")
             continue
         text = text.replace(old, new, 1)
     found = check(text)
-    if want_problem and not found:
-        bad += 1
+    if must_catch and not found:
+        failed += 1
         print(f"FAIL {name}: the edit went unnoticed")
-    elif not want_problem and found:
-        bad += 1
+    elif not must_catch and found:
+        failed += 1
         print(f"FAIL {name}: {'; '.join(found)}")
     else:
         print(f"ok   {name}")
 
 # Pin the count, or deleting a row leaves this green.
-if len(CASES) != 12:
-    print(f"FAIL expected 12 cases, table has {len(CASES)}")
-    bad += 1
+if len(CASES) != 18:
+    print(f"FAIL expected 18 cases, table has {len(CASES)}")
+    failed += 1
 
-print(f"{len(CASES)} cases, {bad} failed")
-sys.exit(1 if bad else 0)
+print(f"{len(CASES)} cases, {failed} failed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
Both guards from #166 are config, so nothing exercised them. The arm gate only runs on a dependabot event, and the CVE gate's severity only shows on a push.

A test that greps a workflow for a clause cannot see `&&` flipped to `||`. Every grepped byte survives, and the gate then arms auto-merge for every pull request in the repo. So each guard is parsed, and each row damages it in a way the checker must catch.

Twenty-one rows. Two read the files as committed, and nineteen damage them. They cover the three regressions already seen or nearly shipped here. Those are the disjunction, the CVE gate going advisory on master again, and a bot matched by the `dependabot[bot]` login that `gh pr list` does not use.

Review chose the rows rather than guesswork. Damaging each guard by hand found five weakenings the first version missed and six more that survived every string the checker looked for. Two were scoping bugs in the checker itself. The manifest check had searched the whole step, so it now searches only the lookup. The CVE check had read only the first matching step, and now reads every one.

The docstring states what it does not catch. This reads the workflows as text, so an edit that keeps every asserted string while changing what the shell means will pass. A clause negated by a folded `== false`, a second assignment through `read`, and a neutered step body all still get through. Review owns these two files either way, since they are signing-privileged.

A row whose edit no longer applies fails and says so, rather than passing while testing nothing. The committed rows run first, so a broken guard reports the guard instead of a stale row. Reordering or rewrapping the gate breaks the rows that edit raw text. The message names the row to update, so the cost is maintenance rather than a wrong verdict.

The test imports yaml. It ships on the runner image and the step passes there. So I did not add the install step `screenshots.yml` uses for packages the image lacks. black would reformat the existing `tools/*.py`, so it is not this tree's style and I matched the neighbours. flake8 is clean, as it is for the siblings.