### PR TITLE
Give a later duplicate its English fallback

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -231,6 +231,11 @@ runs:
         if ("$so" -notmatch 'help URLs ok on 5 checks') {
           throw "selftest did not check the help URLs"
         }
+        # Pinned exactly: the numbering maps the Nth duplicate line to the Nth lang.def entry,
+        # so a check that quietly stops running would hide a string landing on the wrong control.
+        if ("$so" -notmatch 'duplicate key numbering ok on 5 checks') {
+          throw "selftest did not check the duplicate key numbering"
+        }
         # Guards the empty-name terminator (newlang.h); losing it hangs the first-run About
         # box. The only count left loose: it is the size of the engine's lang.def, so pinning
         # it would turn an engine translation into a red build here.

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -420,6 +420,38 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("help URLs ok on %d checks\n", nchecks);
     }
+    /* 27 English texts key more than one entry, and the Nth line resolves through the Nth
+       spelling of that text. Getting the numbering wrong maps a string onto another control. */
+    {
+      static const struct { int n; const char* want; } dupes[] = {
+        { 0, "Exit" }, { 1, "Exit1" }, { 2, "Exit2" }, { 12, "Exit12" }, { -1, NULL }
+      };
+      int nchecks = 0;
+      for(int k=0 ; dupes[k].want != NULL ; k++) {
+        char key[32];
+        strcpybuff(key, "Exit");
+        if (!LANG_DUPKEY(key, strlen("Exit"), dupes[k].n, sizeof(key))
+            || strcmp(key, dupes[k].want) != 0) {
+          fprintf(stderr, "FATAL: duplicate key %d of 'Exit' is '%s', expected '%s'\n",
+                  dupes[k].n, key, dupes[k].want);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* Refused rather than truncated: a truncated suffix collides with another entry's key. */
+      {
+        char tight[6];
+        strcpybuff(tight, "Exit");
+        if (LANG_DUPKEY(tight, strlen("Exit"), 123456, sizeof(tight))) {
+          fprintf(stderr, "FATAL: duplicate key accepted a number it could not spell: '%s'\n", tight);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      printf("duplicate key numbering ok on %d checks\n", nchecks);
+    }
     /* Only reachable by typing into the Experts page, so pin the rule splitter here:
        a rule the engine cannot parse aborts the whole mirror. */
     {

--- a/WinHTTrack/newlang.cpp
+++ b/WinHTTrack/newlang.cpp
@@ -243,6 +243,19 @@ static CString LANG_DATAFILE(const char* relative) {
   return name;
 }
 
+/* Duplicate English texts share one lookup key, so the Nth is spelled "text", "text1", "text2".
+   Returns FALSE when the number does not fit, which must skip the entry rather than truncate it
+   into a neighbour's key. */
+BOOL LANG_DUPKEY(char* base, size_t baselen, int n, size_t size) {
+  if (base == NULL || baselen >= size)
+    return FALSE;
+  if (n <= 0) {
+    base[baselen] = '\0';
+    return TRUE;
+  }
+  return _snprintf_s(base + baselen, size - baselen, _TRUNCATE, "%d", n) >= 0;
+}
+
 /* The engine's UTF-8 converter substitutes U+FFFD rather than refusing, so a catalog
    still in its legacy charset would silently render as '?'. Gate on real UTF-8. */
 static BOOL IsValidUTF8(const char* s, int len) {
@@ -480,20 +493,18 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
         linput_cpp(fp,intkey,8000);
         linput_cpp(fp,key,8000);
         if (strnotempty(intkey) && strnotempty(key)) {
+          const size_t keylen=strlen(key);
           const char* test=LANGINTKEY(key);
+          BOOL ok=TRUE;
+          int dup=0;
 
-          /* Increment for multiple definitions */
-          if (strnotempty(test)) {
-            int increment=0;
-            size_t pos = strlen(key);
-            do {
-              increment++;
-              sprintf(key+pos,"%d",increment);
-              test=LANGINTKEY(key);
-            }  while (strnotempty(test));
+          /* Walk to the first unused slot: the same English text can define several entries. */
+          while (ok && strnotempty(test)) {
+            ok=LANG_DUPKEY(key,keylen,++dup,sizeof(key));
+            test = ok ? LANGINTKEY(key) : "";
           }
 
-          if (!strnotempty(test)) {         // éviter doublons
+          if (ok && !strnotempty(test)) {         // éviter doublons
             // conv_printf(key,key);
             size_t len;
             char* buff;
@@ -600,31 +611,23 @@ void LANG_LOAD(char* limit_to, size_t limit_size) {
             intkey=LANGINTKEY(extkey);
             
             if (strnotempty(intkey)) {
-              
-              /* Increment for multiple definitions */
-              {
-                const char* test=LANGSEL(intkey);
-                if (strnotempty(test)) {
-                  if (loops == 0) {
-                    int increment=0;
-                    size_t pos=strlen(extkey);
-                    do {
-                      increment++;
-                      sprintf(extkey+pos,"%d",increment);
-                      intkey=LANGINTKEY(extkey);
-                      if (strnotempty(intkey))
-                        test=LANGSEL(intkey);
-                      else
-                        test="";
-                    }  while (strnotempty(test));
-                  } else
-                    intkey="";
-                } else {
-                  if (loops > 0) {
-                    err_msg += intkey;
-                    err_msg += " ";
-                  }
-                }
+              const size_t extlen=strlen(extkey);
+              const char* test=LANGSEL(intkey);
+              BOOL ok=TRUE;
+              int dup=0;
+
+              /* Nothing filled it yet, so on the English pass only English defines it. */
+              if (loops > 0 && !strnotempty(test)) {
+                err_msg += intkey;
+                err_msg += " ";
+              }
+
+              /* Walk to the first unfilled slot. The English pass has to walk too: stopping at a
+                 filled first slot leaves every later duplicate without its English fallback. */
+              while (ok && strnotempty(test)) {
+                ok=LANG_DUPKEY(extkey,extlen,++dup,sizeof(extkey));
+                intkey = ok ? LANGINTKEY(extkey) : "";
+                test = strnotempty(intkey) ? LANGSEL(intkey) : "";
               }
               
               /* Add key */

--- a/WinHTTrack/newlang.h
+++ b/WinHTTrack/newlang.h
@@ -37,6 +37,9 @@ void LANG_INIT();
 int LANG_INDEX_OF(const char* tag);
 int LANG_T(int);
 int QLANG_T(int l);
+/* Spell the Nth lookup key for an English text that keys several entries: n=0 leaves it
+   alone, n=1 appends "1". Writes into base at baselen; FALSE means it did not fit. */
+BOOL LANG_DUPKEY(char* base, size_t baselen, int n, size_t size);
 //char* LANGSEL(char* lang0,...);
 /* Set by --selftest (WinHTTrack.cpp): report fatals on stderr and exit non-zero
    instead of raising a message box nobody can click. */


### PR DESCRIPTION
Two catalog lines can share one English text. The loader tells them apart by position: the Nth line resolves through the Nth spelling of that text, `Exit`, then `Exit1`, then `Exit2`.

The English backfill pass did not walk that chain. Where the selected language had already filled the first slot, the pass blanked the key and skipped the line. A later duplicate that the selected catalog was missing therefore never received its English value, and rendered as an empty string.

Nothing reaches it today. All 30 catalogs carry the same 525 key lines, so no catalog is missing an occurrence that English has. It bites the first time one diverges.

Both loops now share `LANG_DUPKEY()`, which spells the Nth key. It refuses a number it cannot fit, rather than truncating it into a neighbouring entry's key. The `sprintf()` it replaces had no such bound.

The new `--selftest` block covers the numbering and the refusal, pinned at 5 checks in the smoke test. CI is the only build here, so I have not run it.

The skipped-fallback path itself gets no CI test, because no fixture can reach it while the shipped catalogs stay parallel. I simulated the loader over the real `lang.def` and all 30 catalogs instead. 510 symbolic keys resolve, and none is left empty.
