### PR TITLE
The end-of-mirror panel says the mirror is finished after a user Stop

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -306,6 +306,9 @@ runs:
         if ("$so" -notmatch 'session end ok on 8 checks') {
           throw "selftest did not check the session-end stop"
         }
+        if ("$so" -notmatch 'end-of-mirror panel ok on 7 checks') {
+          throw "selftest did not check the end-of-mirror panel"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -306,8 +306,9 @@ runs:
         if ("$so" -notmatch 'session end ok on 8 checks') {
           throw "selftest did not check the session-end stop"
         }
-        if ("$so" -notmatch 'end-of-mirror panel ok on 4 checks') {
-          throw "selftest did not check the end-of-mirror panel"
+        # No mirror runs under --selftest, so this count is the only proof the verdict maps right.
+        if ("$so" -notmatch 'end-of-mirror verdict ok on 4 checks') {
+          throw "selftest did not check the end-of-mirror verdict"
         }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -306,7 +306,7 @@ runs:
         if ("$so" -notmatch 'session end ok on 8 checks') {
           throw "selftest did not check the session-end stop"
         }
-        if ("$so" -notmatch 'end-of-mirror panel ok on 7 checks') {
+        if ("$so" -notmatch 'end-of-mirror panel ok on 4 checks') {
           throw "selftest did not check the end-of-mirror panel"
         }
 

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2429,7 +2429,7 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
-    } else if (global_opt != NULL   /* no opt means no mirror ran */
+    } else if (global_opt != NULL   /* nothing joins this thread, so the UI can clear it (#173) */
                && isMirrorCutShort(hts_mirror_completed(global_opt))) {
       strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
     } else {

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2011,6 +2011,14 @@ BOOL isSingleFileMaxArgument(const CString &value) {
 }
 
 // see Shell.h
+WhttEndMirrorPanel EndMirrorPanelFor(int result, hts_tristate completed) {
+  if (result)
+    return WHTT_END_ERROR;
+  /* HTS_DEFAULT is -1, so only an explicit HTS_FALSE means the mirror was cut short. */
+  return completed == HTS_FALSE ? WHTT_END_STOPPED : WHTT_END_FINISHED;
+}
+
+// see Shell.h
 BOOL isBuildStringArgument(const CString &value) {
   return isEngineArgument(value, BUILDSTRING_MAXSIZE);
 }
@@ -2407,7 +2415,10 @@ void lance(void) {
     }
     //
     /* New pannel */
-    if (result) {      // erreur?
+    /* No opt means no mirror ran, which is what HTS_DEFAULT says. */
+    const WhttEndMirrorPanel panel = EndMirrorPanelFor(result,
+        global_opt != NULL ? hts_mirror_completed(global_opt) : HTS_DEFAULT);
+    if (panel == WHTT_END_ERROR) {      // erreur?
       strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
       if (result != -100) {
@@ -2423,6 +2434,8 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
+    } else if (panel == WHTT_END_STOPPED) {
+      strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
     } else {
       strcpybuff(end_mirror_msg,LANG(LANG_F22 /*"The mirror is finished.\nClick OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!","Le miroir est terminé\nCliquez sur OK pour quitter WinHTTrack\nVoir au besoin les fichiers d'audit pour vérifier que tout s'est bien passé\n\nMerci d'utiliser WinHTTrack!"*/));
       //AfxMessageBox("The mirror is finished.\nClic OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!",MB_OK+MB_ICONINFORMATION);

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2011,11 +2011,9 @@ BOOL isSingleFileMaxArgument(const CString &value) {
 }
 
 // see Shell.h
-WhttEndMirrorPanel EndMirrorPanelFor(int result, hts_tristate completed) {
-  if (result)
-    return WHTT_END_ERROR;
+BOOL isMirrorCutShort(hts_tristate completed) {
   /* HTS_DEFAULT is -1, so only an explicit HTS_FALSE means the mirror was cut short. */
-  return completed == HTS_FALSE ? WHTT_END_STOPPED : WHTT_END_FINISHED;
+  return completed == HTS_FALSE;
 }
 
 // see Shell.h
@@ -2415,10 +2413,7 @@ void lance(void) {
     }
     //
     /* New pannel */
-    /* No opt means no mirror ran, which is what HTS_DEFAULT says. */
-    const WhttEndMirrorPanel panel = EndMirrorPanelFor(result,
-        global_opt != NULL ? hts_mirror_completed(global_opt) : HTS_DEFAULT);
-    if (panel == WHTT_END_ERROR) {      // erreur?
+    if (result) {      // erreur?
       strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
       if (result != -100) {
@@ -2434,7 +2429,8 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
-    } else if (panel == WHTT_END_STOPPED) {
+    } else if (global_opt != NULL   /* no opt means no mirror ran */
+               && isMirrorCutShort(hts_mirror_completed(global_opt))) {
       strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
     } else {
       strcpybuff(end_mirror_msg,LANG(LANG_F22 /*"The mirror is finished.\nClick OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!","Le miroir est terminé\nCliquez sur OK pour quitter WinHTTrack\nVoir au besoin les fichiers d'audit pour vérifier que tout s'est bien passé\n\nMerci d'utiliser WinHTTrack!"*/));

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -274,12 +274,9 @@ BOOL isHostAliasArgument(const CString &rule);
    enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
 BOOL isSingleFileMaxArgument(const CString &value);
 
-/* Which end-of-mirror panel a run earned. */
-enum WhttEndMirrorPanel { WHTT_END_ERROR, WHTT_END_STOPPED, WHTT_END_FINISHED };
-
-/* RESULT is hts_main2()'s return and COMPLETED the engine's verdict on the same opt.
-   The verdict decides only when the run reported no error. Exposed for --selftest. */
-WhttEndMirrorPanel EndMirrorPanelFor(int result, hts_tristate completed);
+/* TRUE if the engine's verdict says the mirror was cut short. HTS_DEFAULT means no
+   mirror ran, so it is not a stop. Exposed for --selftest. */
+BOOL isMirrorCutShort(hts_tristate completed);
 
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its
    htscoremain.c, which exports no macro for this one, so the two can drift apart. */

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -274,6 +274,13 @@ BOOL isHostAliasArgument(const CString &rule);
    enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
 BOOL isSingleFileMaxArgument(const CString &value);
 
+/* Which end-of-mirror panel a run earned. */
+enum WhttEndMirrorPanel { WHTT_END_ERROR, WHTT_END_STOPPED, WHTT_END_FINISHED };
+
+/* RESULT is hts_main2()'s return and COMPLETED the engine's verdict on the same opt.
+   The verdict decides only when the run reported no error. Exposed for --selftest. */
+WhttEndMirrorPanel EndMirrorPanelFor(int result, hts_tristate completed);
+
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its
    htscoremain.c, which exports no macro for this one, so the two can drift apart. */
 #define BUILDSTRING_MAXSIZE 127

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -274,8 +274,9 @@ BOOL isHostAliasArgument(const CString &rule);
    enough for argv. A cap the engine refuses aborts the mirror. Exposed for --selftest. */
 BOOL isSingleFileMaxArgument(const CString &value);
 
-/* TRUE if the engine's verdict says the mirror was cut short. HTS_DEFAULT means no
-   mirror ran, so it is not a stop. Exposed for --selftest. */
+/* TRUE if the engine's verdict says the mirror was cut short. Valid only once the
+   mirror has ended, because HTS_FALSE also means still running. HTS_DEFAULT means
+   no mirror ran, so it is not a stop. Exposed for --selftest. */
 BOOL isMirrorCutShort(hts_tristate completed);
 
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1320,34 +1320,33 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("session end ok on %d checks\n", nchecks);
     }
-    /* No mirror runs under --selftest, so the panel decision is pinned here. */
+    /* No mirror runs under --selftest, so the verdict mapping is pinned here. */
     {
-      static const struct { int result; hts_tristate completed; WhttEndMirrorPanel want; } panels[] = {
-        { 0, HTS_TRUE, WHTT_END_FINISHED },
-        { 0, HTS_FALSE, WHTT_END_STOPPED },
-        /* No mirror ran, so nothing was stopped. */
-        { 0, HTS_DEFAULT, WHTT_END_FINISHED },
-        /* A non-zero return outranks the verdict. */
-        { 1, HTS_TRUE, WHTT_END_ERROR },
-        { 1, HTS_FALSE, WHTT_END_ERROR },
-        { 1, HTS_DEFAULT, WHTT_END_ERROR },
-        { -100, HTS_FALSE, WHTT_END_ERROR },   /* the SEH filter's own code */
-        { 0, (hts_tristate) 0, (WhttEndMirrorPanel) -1 }
+      static const struct { hts_tristate completed; BOOL want; } verdicts[] = {
+        { HTS_TRUE, FALSE },
+        { HTS_FALSE, TRUE },
+        { HTS_DEFAULT, FALSE }   /* no mirror ran, so nothing was cut short */
       };
       int nchecks = 0;
-      for(int k=0 ; panels[k].want != (WhttEndMirrorPanel) -1 ; k++) {
-        const WhttEndMirrorPanel got = EndMirrorPanelFor(panels[k].result, panels[k].completed);
-        if (got != panels[k].want) {
-          fprintf(stderr, "FATAL: result %d verdict %d chose panel %d, expected %d\n",
-                  panels[k].result, (int) panels[k].completed, (int) got, (int) panels[k].want);
+      for(size_t k=0 ; k<_countof(verdicts) ; k++) {
+        if (isMirrorCutShort(verdicts[k].completed) != verdicts[k].want) {
+          fprintf(stderr, "FATAL: verdict %d judged %s\n", (int) verdicts[k].completed,
+                  verdicts[k].want ? "finished, expected cut short" : "cut short, expected finished");
           fflush(stderr);
           ExitProcess(3);
         } else
           nchecks++;
       }
+      /* A key no catalog carries reads empty, so the panel would be blank with CI green. */
+      if (LANGSEL("LANG_F22s")[0] == '\0') {
+        fprintf(stderr, "FATAL: LANG_F22s is missing from the language files\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else
+        nchecks++;
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
-      if (nchecks != 7) {
-        fprintf(stderr, "FATAL: end-of-mirror panel ran %d checks, expected 7\n", nchecks);
+      if (nchecks != 4) {
+        fprintf(stderr, "FATAL: end-of-mirror panel ran %d checks, expected 4\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1320,6 +1320,39 @@ BOOL CWinHTTrackApp::InitInstance()
       }
       printf("session end ok on %d checks\n", nchecks);
     }
+    /* No mirror runs under --selftest, so the panel decision is pinned here. */
+    {
+      static const struct { int result; hts_tristate completed; WhttEndMirrorPanel want; } panels[] = {
+        { 0, HTS_TRUE, WHTT_END_FINISHED },
+        { 0, HTS_FALSE, WHTT_END_STOPPED },
+        /* No mirror ran, so nothing was stopped. */
+        { 0, HTS_DEFAULT, WHTT_END_FINISHED },
+        /* A non-zero return outranks the verdict. */
+        { 1, HTS_TRUE, WHTT_END_ERROR },
+        { 1, HTS_FALSE, WHTT_END_ERROR },
+        { 1, HTS_DEFAULT, WHTT_END_ERROR },
+        { -100, HTS_FALSE, WHTT_END_ERROR },   /* the SEH filter's own code */
+        { 0, (hts_tristate) 0, (WhttEndMirrorPanel) -1 }
+      };
+      int nchecks = 0;
+      for(int k=0 ; panels[k].want != (WhttEndMirrorPanel) -1 ; k++) {
+        const WhttEndMirrorPanel got = EndMirrorPanelFor(panels[k].result, panels[k].completed);
+        if (got != panels[k].want) {
+          fprintf(stderr, "FATAL: result %d verdict %d chose panel %d, expected %d\n",
+                  panels[k].result, (int) panels[k].completed, (int) got, (int) panels[k].want);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
+      if (nchecks != 7) {
+        fprintf(stderr, "FATAL: end-of-mirror panel ran %d checks, expected 7\n", nchecks);
+        fflush(stderr);
+        ExitProcess(3);
+      }
+      printf("end-of-mirror panel ok on %d checks\n", nchecks);
+    }
     /* Portable mode decides which store this run writes to. The two CI legs assert
        opposite suffixes, so a mode wired to a constant reds one of them. */
     {

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1337,8 +1337,8 @@ BOOL CWinHTTrackApp::InitInstance()
         } else
           nchecks++;
       }
-      /* A key no catalog carries reads empty, so the panel would be blank with CI green. */
-      if (LANGSEL("LANG_F22s")[0] == '\0') {
+      /* A missing key reads empty, so the panel would be blank with CI green. */
+      if (LANG_F22s[0] == '\0') {
         fprintf(stderr, "FATAL: LANG_F22s is missing from the language files\n");
         fflush(stderr);
         ExitProcess(3);
@@ -1346,11 +1346,11 @@ BOOL CWinHTTrackApp::InitInstance()
         nchecks++;
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
       if (nchecks != 4) {
-        fprintf(stderr, "FATAL: end-of-mirror panel ran %d checks, expected 4\n", nchecks);
+        fprintf(stderr, "FATAL: end-of-mirror verdict ran %d checks, expected 4\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }
-      printf("end-of-mirror panel ok on %d checks\n", nchecks);
+      printf("end-of-mirror verdict ok on %d checks\n", nchecks);
     }
     /* Portable mode decides which store this run writes to. The two CI legs assert
        opposite suffixes, so a mode wired to a constant reds one of them. */

--- a/WinHTTrack/cpp_lang.h
+++ b/WinHTTrack/cpp_lang.h
@@ -132,6 +132,7 @@ Please visit our Website: http://www.httrack.com
 #define LANG_F21 LANGSEL("LANG_F21")
 #define LANG_F22 LANGSEL("LANG_F22")
 #define LANG_F22c LANGSEL("LANG_F22c")
+#define LANG_F22s LANGSEL("LANG_F22s")
 #define LANG_F23 LANGSEL("LANG_F23")
 #define LANG_G1 LANGSEL("LANG_G1")
 #define LANG_G2 LANGSEL("LANG_G2")


### PR DESCRIPTION
The end-of-mirror panel picked its text from `hts_main2()`'s return. A user Stop returns 0, so a stopped mirror got "The mirror is finished."

`hts_mirror_completed()` and the `LANG_F22s` text land in xroche/httrack#1660, and xroche/httrack#1662 fixes a race that had the GUI reading the verdict before the engine stored it. So this needs an engine at aa62dbd9 or later. `--selftest` asserts the key resolves, because a key no catalog carries reads empty and would ship a blank panel with CI green.

`isMirrorCutShort()` keeps the mapping in one place so `--selftest` can reach it, since no mirror runs there. I mutated it to check the table catches a regression. Reading the verdict as `!= HTS_TRUE` fails the `HTS_DEFAULT` row, which is the inverse bug of claiming a stop when no mirror ran.

The panel reads the verdict on a wakeup that can precede the engine finishing. The engine half of that race is fixed upstream, and the GUI half is #173.

Closes #169
