### PR TITLE
Set the GUI version to 3.50-2

### DIFF
--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -38,7 +38,7 @@ Please visit our Website: http://www.httrack.com
    the installer and CI all read this file, and the release tag must match it. */
 #define WINHTTRACK_VERSION "3.50-2"
 
-/* Dotted, for Inno and the FileVersion field. The betas sat below this, at 3.49.99.N. */
+/* Dotted, for Inno and the FileVersion field. The betas sat below 3.50.0.0, at 3.49.99.N. */
 #define WINHTTRACK_VERSIONID "3.50.2.0"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */

--- a/WinHTTrack/version.h
+++ b/WinHTTrack/version.h
@@ -36,12 +36,12 @@ Please visit our Website: http://www.httrack.com
 
 /* The GUI versions itself, independently of the engine. Bump it here only: the .rc,
    the installer and CI all read this file, and the release tag must match it. */
-#define WINHTTRACK_VERSION "3.50"
+#define WINHTTRACK_VERSION "3.50-2"
 
 /* Dotted, for Inno and the FileVersion field. The betas sat below this, at 3.49.99.N. */
-#define WINHTTRACK_VERSIONID "3.50.0.0"
+#define WINHTTRACK_VERSIONID "3.50.2.0"
 
 /* WINHTTRACK_VERSIONID in the resource compiler's comma form. */
-#define WINHTTRACK_VERSION_NUM 3, 50, 0, 0
+#define WINHTTRACK_VERSION_NUM 3, 50, 2, 0
 
 #endif


### PR DESCRIPTION
Engine 3.50.2 is published, so the GUI takes its own 3.50-2. `version.h` is the only file that moves, because the `.rc`, the installer and CI all read it.

`HTTRACK_ENGINE_REF` is set to aea04f0b39d7675c8d4504c73b48f25257ea4d2e. That is the commit the 3.50.2 tag derefs to, so the pin matches the tested build.
