### PR TITLE
Nothing checks that WINHTTRACK_VERSIONID is the dotted form of WINHTTRACK_VERSION

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
+      # The build holds each version macro to the binary stamped from it and never to
+      # its siblings, so only this sees a bump that edited one macro and not the rest.
+      - name: Version macros agree with each other
+        run: python3 tools/check-version-header.py
+      - name: Version macro cases
+        run: python3 tools/test-check-version-header.py
       # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
       - name: Advisory accept/stale cases
         run: python3 tools/test-check-native-deps.py
@@ -928,7 +934,9 @@ jobs:
   sign:
     # A workflow_dispatch from a tag ref used to reach this whatever `sign` said.
     if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && inputs.sign) }}
-    needs: build
+    # encoding too, not build alone: its guards run on a tag as well, and the version
+    # macros it checks are what the signed installer is named after.
+    needs: [build, encoding]
     runs-on: windows-2022
     environment: signing
     # Two tags pushed at once would fight over the signing session; queue: max holds

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
-      # The build holds each version macro to the binary stamped from it and never to
-      # its siblings, so only this sees a bump that edited one macro and not the rest.
+      # The build already holds WINHTTRACK_VERSIONID against the numeric parts the .rc
+      # stamps from WINHTTRACK_VERSION_NUM. Nothing compares the version string to that
+      # pair, so only this sees a bump that edited one and not the other.
       - name: Version macros agree with each other
         run: python3 tools/check-version-header.py
       - name: Version macro cases

--- a/tools/check-version-header.py
+++ b/tools/check-version-header.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fail if the three version macros in WinHTTrack/version.h disagree.
+
+CI holds each macro to the binary stamped from it and never to its siblings, so
+"3.50-2" beside "3.50.3.0" builds, signs and publishes. The About box and the
+installer name would then read one number where Explorer reads another (#175).
+
+WINHTTRACK_VERSION is the source: the other two are derived from it and compared,
+so a version shape this file does not know is an error rather than a pass.
+"""
+import re
+import sys
+
+HEADER = "WinHTTrack/version.h"
+FIELD_MAX = 0xFFFF  # a PE and an Inno version field are both 16-bit
+
+
+def dotted(version):
+    """The four version fields WINHTTRACK_VERSION implies, or None for an unknown shape.
+
+    A beta sorts below the release it precedes, so 3.50-beta-5 borrows a minor and
+    becomes 3.49.99.5. A patch release takes the third field: 3.50-2 is 3.50.2.0.
+    """
+    m = re.match(r"\A(\d+)\.(\d+)(?:-beta-(\d+)|-(\d+))?\Z", version)
+    if not m:
+        return None
+    major, minor = int(m.group(1)), int(m.group(2))
+    beta, patch = m.group(3), m.group(4)
+    if beta is None:
+        fields = (major, minor, int(patch or 0), 0)
+    elif minor > 0:
+        fields = (major, minor - 1, 99, int(beta))
+    elif major > 0:
+        fields = (major - 1, 99, 99, int(beta))
+    else:
+        return None  # nothing sorts below 0.0
+    return fields if all(0 <= f <= FIELD_MAX for f in fields) else None
+
+
+def macros(text, path=HEADER):
+    """The three version macros, as (version, versionid, version_num tuple)."""
+    def one(name, pattern):
+        m = re.search(r"#define\s+WINHTTRACK_%s\s+%s" % (name, pattern), text)
+        if not m:
+            sys.exit("cannot read WINHTTRACK_%s from %s" % (name, path))
+        return m
+    # \s+ cannot match the _ or I that follow, so VERSIONID and VERSION_NUM never bind here.
+    version = one("VERSION", r'"([^"]*)"').group(1)
+    versionid = one("VERSIONID", r'"([^"]*)"').group(1)
+    num = one("VERSION_NUM", r"(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)")
+    return version, versionid, tuple(int(g) for g in num.groups())
+
+
+def check(text, path=HEADER):
+    """The complaints about this header, empty when the three macros agree."""
+    version, versionid, num = macros(text, path)
+    want = dotted(version)
+    if want is None:
+        return ['WINHTTRACK_VERSION "%s" has a shape with no dotted form. Add it to '
+                "dotted(), and give it a row in the table test" % version]
+    want_str = ".".join(str(f) for f in want)
+    bad = []
+    if versionid != want_str:
+        bad.append('WINHTTRACK_VERSION "%s" means WINHTTRACK_VERSIONID "%s", not "%s"'
+                   % (version, want_str, versionid))
+    if num != want:
+        bad.append("WINHTTRACK_VERSION_NUM is %s, not %s"
+                   % (", ".join(str(n) for n in num), ", ".join(str(f) for f in want)))
+    return bad
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else HEADER
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    bad = check(text, path)
+    if bad:
+        sys.exit("%s disagrees with itself:\n  %s" % (path, "\n  ".join(bad)))
+    version, versionid, _ = macros(text, path)
+    print("%s: %s is %s" % (path, version, versionid))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check-version-header.py
+++ b/tools/check-version-header.py
@@ -45,10 +45,12 @@ def macros(text, path=HEADER):
 
     def one(name, pattern):
         # \s+ cannot match the _ or I that follow, so VERSIONID and VERSION_NUM never bind
-        # to VERSION. Every occurrence, not the first: the preprocessor takes the LAST
-        # definition and ignores the ones inside comments and #if 0, and a regex cannot tell
-        # which is live. Two of anything means a bump left something behind.
-        found = re.findall(rf"#define\s+WINHTTRACK_{name}\s+{pattern}", text)
+        # to VERSION. Every occurrence, not the first: a regex cannot tell which definition
+        # is live, so one inside a comment, an #if 0 or an #ifdef would be read instead. That
+        # refuses a header defining a macro conditionally, which is correct here, because
+        # TagVersion.ps1, build-installer/action.yml and windows-build.yml all regex this same
+        # file and would each silently take the first match.
+        found = re.findall(rf"#\s*define\s+WINHTTRACK_{name}\s+{pattern}", text)
         if not found:
             sys.exit(f"cannot read WINHTTRACK_{name} from {path}")
         if len(found) > 1:
@@ -86,7 +88,8 @@ def main():
         text = f.read()
     bad = check(text, path)
     if bad:
-        sys.exit("{} disagrees with itself:\n  {}".format(path, "\n  ".join(bad)))
+        joined = "\n  ".join(bad)
+        sys.exit(f"{path} disagrees with itself:\n  {joined}")
     version, versionid, _ = macros(text, path)
     print(f"{path}: {version} is {versionid}")
 

--- a/tools/check-version-header.py
+++ b/tools/check-version-header.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Fail if the three version macros in WinHTTrack/version.h disagree.
 
-CI holds each macro to the binary stamped from it and never to its siblings, so
-"3.50-2" beside "3.50.3.0" builds, signs and publishes. The About box and the
-installer name would then read one number where Explorer reads another (#175).
+CI holds WINHTTRACK_VERSION to the ProductVersion of the binary stamped from it, and
+WINHTTRACK_VERSIONID to that binary's numeric parts, which the .rc stamps from
+WINHTTRACK_VERSION_NUM. Nothing compares the version string to the dotted pair, so
+"3.50-2" beside "3.50.3.0" builds, signs and publishes. The About box would then read
+one number where Explorer reads another (#175).
 
 WINHTTRACK_VERSION is the source: the other two are derived from it and compared,
 so a version shape this file does not know is an error rather than a pass.
@@ -21,6 +23,7 @@ def dotted(version):
     A beta sorts below the release it precedes, so 3.50-beta-5 borrows a minor and
     becomes 3.49.99.5. A patch release takes the third field: 3.50-2 is 3.50.2.0.
     """
+    # \A and \Z, not ^ and $: a trailing newline would otherwise pass.
     m = re.match(r"\A(\d+)\.(\d+)(?:-beta-(\d+)|-(\d+))?\Z", version)
     if not m:
         return None
@@ -34,21 +37,29 @@ def dotted(version):
         fields = (major - 1, 99, 99, int(beta))
     else:
         return None  # nothing sorts below 0.0
-    return fields if all(0 <= f <= FIELD_MAX for f in fields) else None
+    return fields if all(f <= FIELD_MAX for f in fields) else None
 
 
 def macros(text, path=HEADER):
     """The three version macros, as (version, versionid, version_num tuple)."""
+
     def one(name, pattern):
-        m = re.search(r"#define\s+WINHTTRACK_%s\s+%s" % (name, pattern), text)
-        if not m:
-            sys.exit("cannot read WINHTTRACK_%s from %s" % (name, path))
-        return m
-    # \s+ cannot match the _ or I that follow, so VERSIONID and VERSION_NUM never bind here.
-    version = one("VERSION", r'"([^"]*)"').group(1)
-    versionid = one("VERSIONID", r'"([^"]*)"').group(1)
+        # \s+ cannot match the _ or I that follow, so VERSIONID and VERSION_NUM never bind
+        # to VERSION. Every occurrence, not the first: the preprocessor takes the LAST
+        # definition and ignores the ones inside comments and #if 0, and a regex cannot tell
+        # which is live. Two of anything means a bump left something behind.
+        found = re.findall(rf"#define\s+WINHTTRACK_{name}\s+{pattern}", text)
+        if not found:
+            sys.exit(f"cannot read WINHTTRACK_{name} from {path}")
+        if len(found) > 1:
+            sys.exit(f"{path} defines WINHTTRACK_{name} {len(found)} times, so which one the "
+                     f"compiler uses cannot be read off the file: {found}")
+        return found[0]
+
+    version = one("VERSION", r'"([^"]*)"')
+    versionid = one("VERSIONID", r'"([^"]*)"')
     num = one("VERSION_NUM", r"(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)")
-    return version, versionid, tuple(int(g) for g in num.groups())
+    return version, versionid, tuple(int(g) for g in num)
 
 
 def check(text, path=HEADER):
@@ -56,16 +67,16 @@ def check(text, path=HEADER):
     version, versionid, num = macros(text, path)
     want = dotted(version)
     if want is None:
-        return ['WINHTTRACK_VERSION "%s" has a shape with no dotted form. Add it to '
-                "dotted(), and give it a row in the table test" % version]
+        return [f'WINHTTRACK_VERSION "{version}" has a shape with no dotted form. Add it to '
+                f"dotted(), and give it a row in the table test"]
     want_str = ".".join(str(f) for f in want)
     bad = []
     if versionid != want_str:
-        bad.append('WINHTTRACK_VERSION "%s" means WINHTTRACK_VERSIONID "%s", not "%s"'
-                   % (version, want_str, versionid))
+        bad.append(f'WINHTTRACK_VERSION "{version}" means WINHTTRACK_VERSIONID "{want_str}", '
+                   f'not "{versionid}"')
     if num != want:
-        bad.append("WINHTTRACK_VERSION_NUM is %s, not %s"
-                   % (", ".join(str(n) for n in num), ", ".join(str(f) for f in want)))
+        nums = ", ".join(str(n) for n in num)
+        bad.append(f"WINHTTRACK_VERSION_NUM is {nums}, not {', '.join(str(f) for f in want)}")
     return bad
 
 
@@ -75,9 +86,9 @@ def main():
         text = f.read()
     bad = check(text, path)
     if bad:
-        sys.exit("%s disagrees with itself:\n  %s" % (path, "\n  ".join(bad)))
+        sys.exit("{} disagrees with itself:\n  {}".format(path, "\n  ".join(bad)))
     version, versionid, _ = macros(text, path)
-    print("%s: %s is %s" % (path, version, versionid))
+    print(f"{path}: {version} is {versionid}")
 
 
 if __name__ == "__main__":

--- a/tools/test-check-version-header.py
+++ b/tools/test-check-version-header.py
@@ -20,14 +20,14 @@ fail = 0
 ran = 0
 
 
-def check(what, got, want):
+def expect(what, got, want):
     global fail, ran
     ran += 1
     if got != want:
-        print("  FAIL %s : got %r, wanted %r" % (what, got, want))
+        print(f"  FAIL {what} : got {got!r}, wanted {want!r}")
         fail += 1
     else:
-        print("  ok   %s" % what)
+        print(f"  ok   {what}")
 
 
 print("--- dotted() over every shape version.h has carried, and the ones it must refuse ---")
@@ -44,20 +44,19 @@ DERIVED = [
     ("3.50.2", None, "already dotted"),
     ("3.50-2-beta-1", None, "a beta of a patch release: teach the rule before shipping one"),
     ("3.50 ", None, "trailing space"),
-    ("3.50\n", None, "trailing newline, which a bare $ would have let through"),
     (" 3.50", None, "leading space"),
+    ("3.50\n", None, "trailing newline, which a bare $ would have let through"),
     ("", None, "empty"),
     ("3.50-70000", None, "a patch number past the 16-bit field"),
     ("3.50-beta-70000", None, "a beta number past the 16-bit field"),
 ]
 for version, want, why in DERIVED:
-    check("%s: %s" % (why, version or "(empty)"), guard.dotted(version), want)
+    expect(f"{why}: {version or '(empty)'}", guard.dotted(version), want)
 
 print("--- the real header agrees with itself ---")
 real = REAL.read_text(encoding="utf-8")
-check("WinHTTrack/version.h", guard.check(real, str(REAL)), [])
+expect("WinHTTrack/version.h", guard.check(real, str(REAL)), [])
 
-print("--- macros() binds to the right macro ---")
 SYNTH = (
     "#ifndef WINHTTRACK_VERSION_H\n"
     "#define WINHTTRACK_VERSION_H\n"
@@ -66,51 +65,81 @@ SYNTH = (
     "#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7\n"
     "#endif\n"
 )
-check("picks VERSION, not VERSIONID/NUM/_H",
-      guard.macros(SYNTH), ("3.50-beta-7", "3.49.99.7", (3, 49, 99, 7)))
-check("a consistent synthetic header passes", guard.check(SYNTH), [])
+print("--- macros() binds to the right macro ---")
+expect("picks VERSION, not VERSIONID/NUM/_H",
+       guard.macros(SYNTH), ("3.50-beta-7", "3.49.99.7", (3, 49, 99, 7)))
+expect("a consistent synthetic header passes", guard.check(SYNTH), [])
 
-print("--- a damaged header is caught ---")
-# Each row edits one macro of SYNTH and names how many complaints that must raise.
+print("--- a damaged header is caught, and says which macro is wrong ---")
+# Each row edits one macro of SYNTH, and names the complaints it must raise, by the macro
+# each one has to name. Counting alone would keep a guard that blames the wrong macro green.
 MUTANTS = [
-    ('"3.49.99.7"', '"3.50.0.7"', 1, "VERSIONID alone is wrong"),
-    ("3, 49, 99, 7", "3, 49, 99, 8", 1, "VERSION_NUM alone is wrong"),
-    ('"3.50-beta-7"', '"3.50-7"', 2, "VERSION bumped out of beta, the other two left behind"),
-    ('"3.50-beta-7"', '"3.50-beta-8"', 2, "the beta number bumped in one place only"),
-    ('"3.49.99.7"', '"3.49.99.70"', 1, "a digit appended to VERSIONID"),
-    ('"3.49.99.7"', '"3.49.99.7 "', 1, "a trailing space in VERSIONID"),
+    ('"3.49.99.7"', '"3.50.0.7"', ["WINHTTRACK_VERSIONID"], "VERSIONID alone is wrong"),
+    ("3, 49, 99, 7", "3, 49, 99, 8", ["WINHTTRACK_VERSION_NUM"], "VERSION_NUM alone is wrong"),
+    ('"3.50-beta-7"', '"3.50-7"', ["WINHTTRACK_VERSIONID", "WINHTTRACK_VERSION_NUM"],
+     "VERSION bumped out of beta, the other two left behind"),
+    ('"3.50-beta-7"', '"3.50-beta-8"', ["WINHTTRACK_VERSIONID", "WINHTTRACK_VERSION_NUM"],
+     "the beta number bumped in one place only"),
+    ('"3.49.99.7"', '"3.49.99.70"', ["WINHTTRACK_VERSIONID"], "a digit appended to VERSIONID"),
+    ('"3.49.99.7"', '"3.49.99.7 "', ["WINHTTRACK_VERSIONID"], "a trailing space in VERSIONID"),
     # Settled, not a defect: a leading zero names the same release, and refusing one
     # would also refuse a two-digit minor like 3.05.
-    ('"3.50-beta-7"', '"3.50-beta-07"', 0, "a leading zero still agrees"),
+    ('"3.50-beta-7"', '"3.50-beta-07"', [], "a leading zero still agrees"),
 ]
 for old, new, want, why in MUTANTS:
     mutant = SYNTH.replace(old, new)
     if mutant == SYNTH:
-        print("  FAIL %s : the edit %r -> %r changed nothing" % (why, old, new))
+        print(f"  FAIL {why} : the edit {old!r} -> {new!r} changed nothing")
         fail += 1
         continue
-    check(why, len(guard.check(mutant)), want)
+    bad = guard.check(mutant)
+    expect(why, [m for m in want if not any(m in line for line in bad)], [])
+    expect(f"{why}, and says nothing else", len(bad), len(want))
+
+print("--- a definition the preprocessor would not use is an error, not a pass ---")
+# The live macros below disagree. A guard reading the FIRST match reads the dead triple
+# above them instead and reports clean, which is the very state #175 exists to catch.
+LIVE = ('#define WINHTTRACK_VERSION "3.50-2"\n'
+        '#define WINHTTRACK_VERSIONID "3.99.9.9"\n'
+        "#define WINHTTRACK_VERSION_NUM 3, 99, 9, 9\n")
+for dead, why in [
+    ("/* was:\n" + SYNTH + "*/\n", "a commented-out triple above the live macros"),
+    ("#if 0\n" + SYNTH + "#endif\n", "an #if 0 triple above the live macros"),
+    ('#define WINHTTRACK_VERSION "3.50-1"\n', "a stale VERSION line left by a bump"),
+]:
+    exited = ""
+    try:
+        guard.check(dead + LIVE)
+    except SystemExit as e:
+        exited = str(e.code)
+    expect(why, "defines WINHTTRACK_VERSION" in exited and "times" in exited, True)
 
 print("--- a header the guard cannot read is an error, not a pass ---")
-for text, why in [
-    (SYNTH.replace('#define WINHTTRACK_VERSION "3.50-beta-7"\n', ""), "VERSION absent"),
-    (SYNTH.replace('#define WINHTTRACK_VERSIONID "3.49.99.7"\n', ""), "VERSIONID absent"),
-    (SYNTH.replace("#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7\n", ""), "VERSION_NUM absent"),
+for text, macro, why in [
+    (SYNTH.replace('#define WINHTTRACK_VERSION "3.50-beta-7"\n', ""), "VERSION", "VERSION absent"),
+    (SYNTH.replace('#define WINHTTRACK_VERSIONID "3.49.99.7"\n', ""), "VERSIONID",
+     "VERSIONID absent"),
+    (SYNTH.replace("#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7\n", ""), "VERSION_NUM",
+     "VERSION_NUM absent"),
 ]:
-    exited = False
+    exited = ""
     try:
         guard.check(text)
-    except SystemExit:
-        exited = True
-    check(why, exited, True)
+    except SystemExit as e:
+        exited = str(e.code)
+    # The message, not just the exit: any raise would satisfy a bare except.
+    expect(why, exited, f"cannot read WINHTTRACK_{macro} from {guard.HEADER}")
 
 print("--- an unknown VERSION shape is an error, not a pass ---")
-check("VERSION shape the rule does not cover",
-      len(guard.check(SYNTH.replace('"3.50-beta-7"', '"3.50rc1"'))), 1)
+expect("VERSION shape the rule does not cover",
+       ["no dotted form" in line for line in guard.check(SYNTH.replace('"3.50-beta-7"',
+                                                                       '"3.50rc1"'))], [True])
 
+# Counted, not written down: a row deleted by hand would otherwise still be claimed. Exact,
+# not a floor, because a floor passes the deletion it exists to catch (#126, #127).
+# 17 derived + 2 per mutant + 10 standalone.
+if ran != 41:
+    sys.exit(f"{ran} cases ran, expected 41: rows have gone missing or been added")
 if fail:
-    sys.exit("%d version-header case(s) failed" % fail)
-# Counted, not written down: a row deleted by hand would otherwise still be claimed.
-if ran < 30:
-    sys.exit("only %d cases ran; rows have gone missing" % ran)
-print("::notice::version-header guard: %d cases pass" % ran)
+    sys.exit(f"{fail} version-header case(s) failed")
+print(f"::notice::version-header guard: {ran} cases pass")

--- a/tools/test-check-version-header.py
+++ b/tools/test-check-version-header.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Table test for check-version-header.py, plus the mutations it must catch.
+
+The guard only ever sees one header, and that header agrees with itself, so a
+guard that returned "no complaints" unconditionally would look just as green.
+The mutation rows are what tell the two apart.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+MOD = Path(__file__).with_name("check-version-header.py")
+spec = importlib.util.spec_from_file_location("check_version_header", MOD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+REAL = Path(__file__).resolve().parent.parent / "WinHTTrack" / "version.h"
+
+fail = 0
+ran = 0
+
+
+def check(what, got, want):
+    global fail, ran
+    ran += 1
+    if got != want:
+        print("  FAIL %s : got %r, wanted %r" % (what, got, want))
+        fail += 1
+    else:
+        print("  ok   %s" % what)
+
+
+print("--- dotted() over every shape version.h has carried, and the ones it must refuse ---")
+DERIVED = [
+    ("3.50", (3, 50, 0, 0), "a bare release"),
+    ("3.50-2", (3, 50, 2, 0), "a patch release takes the third field"),
+    ("3.50-beta-8", (3, 49, 99, 8), "a beta borrows a minor so 3.50 outranks it"),
+    ("3.50-beta-1", (3, 49, 99, 1), "the first beta"),
+    ("4.0-beta-1", (3, 99, 99, 1), "a beta of an x.0 borrows a major"),
+    ("0.0-beta-1", None, "nothing sorts below 0.0"),
+    ("3.50-beta", None, "beta with no number"),
+    ("3.50-beta-x", None, "beta number is not a number"),
+    ("v3.50-2", None, "v-prefix"),
+    ("3.50.2", None, "already dotted"),
+    ("3.50-2-beta-1", None, "a beta of a patch release: teach the rule before shipping one"),
+    ("3.50 ", None, "trailing space"),
+    ("3.50\n", None, "trailing newline, which a bare $ would have let through"),
+    (" 3.50", None, "leading space"),
+    ("", None, "empty"),
+    ("3.50-70000", None, "a patch number past the 16-bit field"),
+    ("3.50-beta-70000", None, "a beta number past the 16-bit field"),
+]
+for version, want, why in DERIVED:
+    check("%s: %s" % (why, version or "(empty)"), guard.dotted(version), want)
+
+print("--- the real header agrees with itself ---")
+real = REAL.read_text(encoding="utf-8")
+check("WinHTTrack/version.h", guard.check(real, str(REAL)), [])
+
+print("--- macros() binds to the right macro ---")
+SYNTH = (
+    "#ifndef WINHTTRACK_VERSION_H\n"
+    "#define WINHTTRACK_VERSION_H\n"
+    '#define WINHTTRACK_VERSION "3.50-beta-7"\n'
+    '#define WINHTTRACK_VERSIONID "3.49.99.7"\n'
+    "#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7\n"
+    "#endif\n"
+)
+check("picks VERSION, not VERSIONID/NUM/_H",
+      guard.macros(SYNTH), ("3.50-beta-7", "3.49.99.7", (3, 49, 99, 7)))
+check("a consistent synthetic header passes", guard.check(SYNTH), [])
+
+print("--- a damaged header is caught ---")
+# Each row edits one macro of SYNTH and names how many complaints that must raise.
+MUTANTS = [
+    ('"3.49.99.7"', '"3.50.0.7"', 1, "VERSIONID alone is wrong"),
+    ("3, 49, 99, 7", "3, 49, 99, 8", 1, "VERSION_NUM alone is wrong"),
+    ('"3.50-beta-7"', '"3.50-7"', 2, "VERSION bumped out of beta, the other two left behind"),
+    ('"3.50-beta-7"', '"3.50-beta-8"', 2, "the beta number bumped in one place only"),
+    ('"3.49.99.7"', '"3.49.99.70"', 1, "a digit appended to VERSIONID"),
+    ('"3.49.99.7"', '"3.49.99.7 "', 1, "a trailing space in VERSIONID"),
+    # Settled, not a defect: a leading zero names the same release, and refusing one
+    # would also refuse a two-digit minor like 3.05.
+    ('"3.50-beta-7"', '"3.50-beta-07"', 0, "a leading zero still agrees"),
+]
+for old, new, want, why in MUTANTS:
+    mutant = SYNTH.replace(old, new)
+    if mutant == SYNTH:
+        print("  FAIL %s : the edit %r -> %r changed nothing" % (why, old, new))
+        fail += 1
+        continue
+    check(why, len(guard.check(mutant)), want)
+
+print("--- a header the guard cannot read is an error, not a pass ---")
+for text, why in [
+    (SYNTH.replace('#define WINHTTRACK_VERSION "3.50-beta-7"\n', ""), "VERSION absent"),
+    (SYNTH.replace('#define WINHTTRACK_VERSIONID "3.49.99.7"\n', ""), "VERSIONID absent"),
+    (SYNTH.replace("#define WINHTTRACK_VERSION_NUM 3, 49, 99, 7\n", ""), "VERSION_NUM absent"),
+]:
+    exited = False
+    try:
+        guard.check(text)
+    except SystemExit:
+        exited = True
+    check(why, exited, True)
+
+print("--- an unknown VERSION shape is an error, not a pass ---")
+check("VERSION shape the rule does not cover",
+      len(guard.check(SYNTH.replace('"3.50-beta-7"', '"3.50rc1"'))), 1)
+
+if fail:
+    sys.exit("%d version-header case(s) failed" % fail)
+# Counted, not written down: a row deleted by hand would otherwise still be claimed.
+if ran < 30:
+    sys.exit("only %d cases ran; rows have gone missing" % ran)
+print("::notice::version-header guard: %d cases pass" % ran)

--- a/tools/test-check-version-header.py
+++ b/tools/test-check-version-header.py
@@ -70,6 +70,7 @@ expect("picks VERSION, not VERSIONID/NUM/_H",
        guard.macros(SYNTH), ("3.50-beta-7", "3.49.99.7", (3, 49, 99, 7)))
 expect("a consistent synthetic header passes", guard.check(SYNTH), [])
 
+MACROS = ["WINHTTRACK_VERSIONID", "WINHTTRACK_VERSION_NUM"]
 print("--- a damaged header is caught, and says which macro is wrong ---")
 # Each row edits one macro of SYNTH, and names the complaints it must raise, by the macro
 # each one has to name. Counting alone would keep a guard that blames the wrong macro green.
@@ -93,7 +94,10 @@ for old, new, want, why in MUTANTS:
         fail += 1
         continue
     bad = guard.check(mutant)
-    expect(why, [m for m in want if not any(m in line for line in bad)], [])
+    # The macros named, not the ones missing: "none missing" is true of any complaint at all,
+    # so the leading-zero row below would have asserted nothing.
+    named = [m for m in MACROS if any(m in line for line in bad)]
+    expect(why, named, want)
     expect(f"{why}, and says nothing else", len(bad), len(want))
 
 print("--- a definition the preprocessor would not use is an error, not a pass ---")
@@ -102,6 +106,8 @@ print("--- a definition the preprocessor would not use is an error, not a pass -
 LIVE = ('#define WINHTTRACK_VERSION "3.50-2"\n'
         '#define WINHTTRACK_VERSIONID "3.99.9.9"\n'
         "#define WINHTTRACK_VERSION_NUM 3, 99, 9, 9\n")
+# The guard counts definitions and never sees /* or #if 0, so the first two rows are one
+# test under two names. Both are kept to record which shapes were meant.
 for dead, why in [
     ("/* was:\n" + SYNTH + "*/\n", "a commented-out triple above the live macros"),
     ("#if 0\n" + SYNTH + "#endif\n", "an #if 0 triple above the live macros"),


### PR DESCRIPTION
`WinHTTrack/version.h` declares the version three ways. CI holds `WINHTTRACK_VERSIONID` against the numeric parts the `.rc` stamps from `WINHTTRACK_VERSION_NUM`, but nothing compares the version string to that pair. So `"3.50-2"` beside `"3.50.3.0"` builds, signs and publishes. The About box would then read one number where Explorer reads another.

`tools/check-version-header.py` derives the dotted form from `WINHTTRACK_VERSION` and holds the other two macros to it. Each shape the file has carried has a rule. `3.50` is `3.50.0.0` and `3.50-2` is `3.50.2.0`. A beta borrows a minor, so `3.50-beta-8` is `3.49.99.8` and sorts below `3.50`. Any other shape is an error, so a new one has to be taught rather than passing unread.

A regex cannot tell which `#define` the preprocessor uses, so the guard refuses a macro defined more than once. Read the first match instead and a dead triple left in a comment, an `#if 0` or an `#ifdef` gets certified while the live macros disagree.

The table test damages a synthetic header one macro at a time, and each row names the macro the complaint must mention. Nine mutants are caught. Among them are a guard that always answers clean, one that blames the wrong macro, one that tolerates the duplicate, and a deleted row.

Found on the way: `sign` needed only `build`, so a red `encoding` job left every guard in it advisory on the one push that signs. It now needs both.

Closes #175