### PR TITLE
The end-of-mirror panel says the mirror finished when it was stopped

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -307,7 +307,7 @@ runs:
           throw "selftest did not check the session-end stop"
         }
         # No mirror runs under --selftest, so this count is the only proof the verdict maps right.
-        if ("$so" -notmatch 'end-of-mirror verdict ok on 4 checks') {
+        if ("$so" -notmatch 'end-of-mirror verdict ok on 14 checks') {
           throw "selftest did not check the end-of-mirror verdict"
         }
 

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -307,7 +307,7 @@ runs:
           throw "selftest did not check the session-end stop"
         }
         # No mirror runs under --selftest, so this count is the only proof the verdict maps right.
-        if ("$so" -notmatch 'end-of-mirror verdict ok on 14 checks') {
+        if ("$so" -notmatch 'end-of-mirror verdict ok on 21 checks') {
           throw "selftest did not check the end-of-mirror verdict"
         }
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Tag/version guard cases
         shell: pwsh
         run: ./tools/Test-TagVersion.ps1
+      # The guard itself runs in the build job, where the engine's catalogs are checked out.
+      - name: Stopped-panel title cases
+        run: python3 tools/test-check-stop-title.py
       # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
       - name: Advisory accept/stale cases
         run: python3 tools/test-check-native-deps.py

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -327,6 +327,12 @@ jobs:
           path: httrack
           submodules: recursive
 
+      # Same reason as the anchors below: the engine is unpinned, so a translator's edit
+      # upstream reaches the title bar here with nothing in between.
+      - name: The stopped panel can title itself in every language
+        shell: pwsh
+        run: python httrack-windows/tools/check-stop-title.py httrack
+
       - name: Help anchors resolve in the engine's guide
         shell: pwsh
         # The GUI deep-links into the engine's guide.html and the engine is unpinned, so a

--- a/WinHTTrack/Infoend.cpp
+++ b/WinHTTrack/Infoend.cpp
@@ -289,7 +289,9 @@ BOOL Cinfoend::OnSetActive( ) {
   }
 
   this_CWizTab->SetWizardButtons(PSWIZB_FINISH);
-  SetWindowTextCP(this_app->GetMainWnd(), LANG_F18b);
+  /* LANG_F18b says the mirror finished, which a stopped one did not (#176). */
+  SetWindowTextCP(this_app->GetMainWnd(),
+                  end_mirror_title[0] != '\0' ? end_mirror_title : LANG_F18b);
   SetDlgItemTextCP(this_CWizTab, IDCANCEL,LANG_QUIT);
   return 1;
 }

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -2017,6 +2017,18 @@ BOOL isMirrorCutShort(hts_tristate completed) {
 }
 
 // see Shell.h
+void firstLineOf(const char *msg, char *dest, size_t size) {
+  size_t n = 0;
+
+  if (size == 0)
+    return;
+  while (n + 1 < size && msg[n] != '\0' && msg[n] != '\n' && msg[n] != '\r')
+    n++;
+  memcpy(dest, msg, n);
+  dest[n] = '\0';
+}
+
+// see Shell.h
 BOOL isBuildStringArgument(const CString &value) {
   return isEngineArgument(value, BUILDSTRING_MAXSIZE);
 }
@@ -2413,6 +2425,8 @@ void lance(void) {
     }
     //
     /* New pannel */
+    /* The panel outlives one mirror, so a stop must not title the next one. */
+    end_mirror_title[0] = '\0';
     if (result) {      // erreur?
       strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
@@ -2432,6 +2446,8 @@ void lance(void) {
     } else if (global_opt != NULL   /* nothing joins this thread, so the UI can clear it (#173) */
                && isMirrorCutShort(hts_mirror_completed(global_opt))) {
       strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
+      /* Its own first line, so the title is translated wherever the body is (#176). */
+      firstLineOf(end_mirror_msg, end_mirror_title, sizeof(end_mirror_title));
     } else {
       strcpybuff(end_mirror_msg,LANG(LANG_F22 /*"The mirror is finished.\nClick OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!","Le miroir est terminé\nCliquez sur OK pour quitter WinHTTrack\nVoir au besoin les fichiers d'audit pour vérifier que tout s'est bien passé\n\nMerci d'utiliser WinHTTrack!"*/));
       //AfxMessageBox("The mirror is finished.\nClic OK to quit WinHTTrack.\nSee log file(s) if necessary to ensure that everything is OK.\n\nThanks for using WinHTTrack!",MB_OK+MB_ICONINFORMATION);
@@ -2440,8 +2456,10 @@ void lance(void) {
 #if USE_RAS
     // erreur ras
     if (connected == -1)
-      if ((int) strlen(connected_err) > 0)
+      if ((int) strlen(connected_err) > 0) {
         strcpybuff(end_mirror_msg,connected_err);
+        end_mirror_title[0] = '\0';   /* this body is no longer the stop message */
+      }
 #endif
       {
         char pathlog[HTS_URLMAXSIZE*2];

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -283,8 +283,8 @@ BOOL isMirrorCutShort(hts_tristate completed);
    Exposed for --selftest. */
 void firstLineOf(const char *msg, char *dest, size_t size);
 
-/* The end-of-mirror panel wears this title, or LANG_F18b when it is empty. lance() picks
-   it as the mirror ends, because the engine's verdict is gone once the panel shows. */
+/* The end-of-mirror panel wears this title, or LANG_F18b when it is empty. lance() picks it
+   as the mirror ends, because the verdict is gone by then. */
 extern char end_mirror_title[256];
 
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -283,8 +283,8 @@ BOOL isMirrorCutShort(hts_tristate completed);
    Exposed for --selftest. */
 void firstLineOf(const char *msg, char *dest, size_t size);
 
-/* Title for the end-of-mirror panel, empty for the usual LANG_F18b. Picked as the mirror
-   ends, because the engine's verdict is gone by the time the panel shows itself. */
+/* The end-of-mirror panel wears this title, or LANG_F18b when it is empty. lance() picks
+   it as the mirror ends, because the engine's verdict is gone once the panel shows. */
 extern char end_mirror_title[256];
 
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -279,6 +279,14 @@ BOOL isSingleFileMaxArgument(const CString &value);
    no mirror ran, so it is not a stop. Exposed for --selftest. */
 BOOL isMirrorCutShort(hts_tristate completed);
 
+/* DEST takes MSG up to its first line break, NUL-terminated and truncated to SIZE.
+   Exposed for --selftest. */
+void firstLineOf(const char *msg, char *dest, size_t size);
+
+/* Title for the end-of-mirror panel, empty for the usual LANG_F18b. Picked as the mirror
+   ends, because the engine's verdict is gone by the time the panel shows itself. */
+extern char end_mirror_title[256];
+
 /* -N's format cap in the engine, exclusive. A hand copy of a bare 127 in its
    htscoremain.c, which exports no macro for this one, so the two can drift apart. */
 #define BUILDSTRING_MAXSIZE 127

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1327,6 +1327,15 @@ BOOL CWinHTTrackApp::InitInstance()
         { HTS_FALSE, TRUE },
         { HTS_DEFAULT, FALSE }   /* no mirror ran, so nothing was cut short */
       };
+      static const struct { const char *msg; size_t size; const char *want; } lines[] = {
+        { "one\ntwo", 64, "one" },
+        { "one\r\ntwo", 64, "one" },
+        { "no break at all", 64, "no break at all" },
+        { "", 64, "" },
+        { "\nsecond", 64, "" },
+        { "abcdef", 4, "abc" },
+        { "abcdef", 1, "" }
+      };
       int nchecks = 0;
       for(size_t k=0 ; k<_countof(verdicts) ; k++) {
         if (isMirrorCutShort(verdicts[k].completed) != verdicts[k].want) {
@@ -1345,66 +1354,69 @@ BOOL CWinHTTrackApp::InitInstance()
       } else
         nchecks++;
       /* The stopped panel titles itself from its own first line, so pin the cut. */
-      {
-        static const struct { const char *msg; size_t size; const char *want; } lines[] = {
-          { "one\ntwo", 64, "one" },
-          { "one\r\ntwo", 64, "one" },
-          { "no break at all", 64, "no break at all" },
-          { "", 64, "" },
-          { "\nsecond", 64, "" },
-          { "abcdef", 4, "abc" },
-          { "abcdef", 1, "" }
-        };
-        for(size_t k=0 ; k<_countof(lines) ; k++) {
-          char got[64];
-          memset(got, 'x', sizeof(got));
-          firstLineOf(lines[k].msg, got, lines[k].size);
-          if (strcmp(got, lines[k].want) != 0) {
-            fprintf(stderr, "FATAL: first line of '%s' in %d bytes is '%s', expected '%s'\n",
-                    lines[k].msg, (int) lines[k].size, got, lines[k].want);
-            fflush(stderr);
-            ExitProcess(3);
-          } else
-            nchecks++;
-        }
-        /* size 0 has nowhere to put the NUL, so it must write nothing at all. */
-        {
-          char got[2] = { 'x', 'y' };
-          firstLineOf("one\ntwo", got, 0);
-          if (got[0] != 'x' || got[1] != 'y') {
-            fprintf(stderr, "FATAL: firstLineOf wrote into a zero-sized buffer\n");
-            fflush(stderr);
-            ExitProcess(3);
-          } else
-            nchecks++;
-        }
-        /* The live string too: every row above would pass on a catalog whose LANG_F22s
-           has no break, and the whole body would then land in the title bar. */
-        {
-          const char *stopped = LANG(LANG_F22s);
-          const char *brk = strpbrk(stopped, "\r\n");
-          char title[sizeof(end_mirror_title)];
+      for(size_t k=0 ; k<_countof(lines) ; k++) {
+        char got[64];
+        size_t written;
 
-          firstLineOf(stopped, title, sizeof(title));
-          if (title[0] == '\0') {
-            fprintf(stderr, "FATAL: LANG_F22s has no first line to title the panel with\n");
+        memset(got, 'x', sizeof(got));
+        firstLineOf(lines[k].msg, got, lines[k].size);
+        if (strcmp(got, lines[k].want) != 0) {
+          fprintf(stderr, "FATAL: first line of '%s' in %d bytes is '%s', expected '%s'\n",
+                  lines[k].msg, (int) lines[k].size, got, lines[k].want);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+        /* strcmp stops at the NUL, so on its own it cannot see a copy that ran past the
+           source's NUL or past SIZE. Both overrun the live 256-byte title. */
+        written = strlen(got) + 1;
+        for(size_t j=written ; j<sizeof(got) ; j++) {
+          if (got[j] != 'x') {
+            fprintf(stderr, "FATAL: first line of '%s' wrote %d bytes but touched byte %d\n",
+                    lines[k].msg, (int) written, (int) j);
             fflush(stderr);
             ExitProcess(3);
-          } else
-            nchecks++;
-          if (brk == NULL || (size_t) (brk - stopped) >= sizeof(title)) {
-            fprintf(stderr, "FATAL: LANG_F22s breaks at %d of %d bytes, so the title would be "
-                            "the message\n", brk != NULL ? (int) (brk - stopped) : -1,
-                    (int) sizeof(title));
-            fflush(stderr);
-            ExitProcess(3);
-          } else
-            nchecks++;
+          }
         }
+        nchecks++;
+      }
+      /* size 0 has nowhere to put the NUL, so it must write nothing at all. */
+      {
+        char got[2] = { 'x', 'y' };
+        firstLineOf("one\ntwo", got, 0);
+        if (got[0] != 'x' || got[1] != 'y') {
+          fprintf(stderr, "FATAL: firstLineOf wrote into a zero-sized buffer\n");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* The live string too, because tools/check-stop-title.py only reads the catalogs
+         the engine ships and this one is whatever the running language loaded. */
+      {
+        const char *stopped = LANG(LANG_F22s);
+        const char *brk = strpbrk(stopped, "\r\n");
+        char title[sizeof(end_mirror_title)];
+
+        firstLineOf(stopped, title, sizeof(title));
+        if (title[0] == '\0') {
+          fprintf(stderr, "FATAL: LANG_F22s has no first line to title the panel with\n");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+        if (brk == NULL || (size_t) (brk - stopped) >= sizeof(title)) {
+          fprintf(stderr, "FATAL: LANG_F22s breaks at %d of %d bytes, so the title would be "
+                          "the message\n", brk != NULL ? (int) (brk - stopped) : -1,
+                  (int) sizeof(title));
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
       }
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
-      if (nchecks != 14) {
-        fprintf(stderr, "FATAL: end-of-mirror verdict ran %d checks, expected 14\n", nchecks);
+      if (nchecks != 21) {
+        fprintf(stderr, "FATAL: end-of-mirror verdict ran %d checks, expected 21\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -1344,9 +1344,67 @@ BOOL CWinHTTrackApp::InitInstance()
         ExitProcess(3);
       } else
         nchecks++;
+      /* The stopped panel titles itself from its own first line, so pin the cut. */
+      {
+        static const struct { const char *msg; size_t size; const char *want; } lines[] = {
+          { "one\ntwo", 64, "one" },
+          { "one\r\ntwo", 64, "one" },
+          { "no break at all", 64, "no break at all" },
+          { "", 64, "" },
+          { "\nsecond", 64, "" },
+          { "abcdef", 4, "abc" },
+          { "abcdef", 1, "" }
+        };
+        for(size_t k=0 ; k<_countof(lines) ; k++) {
+          char got[64];
+          memset(got, 'x', sizeof(got));
+          firstLineOf(lines[k].msg, got, lines[k].size);
+          if (strcmp(got, lines[k].want) != 0) {
+            fprintf(stderr, "FATAL: first line of '%s' in %d bytes is '%s', expected '%s'\n",
+                    lines[k].msg, (int) lines[k].size, got, lines[k].want);
+            fflush(stderr);
+            ExitProcess(3);
+          } else
+            nchecks++;
+        }
+        /* size 0 has nowhere to put the NUL, so it must write nothing at all. */
+        {
+          char got[2] = { 'x', 'y' };
+          firstLineOf("one\ntwo", got, 0);
+          if (got[0] != 'x' || got[1] != 'y') {
+            fprintf(stderr, "FATAL: firstLineOf wrote into a zero-sized buffer\n");
+            fflush(stderr);
+            ExitProcess(3);
+          } else
+            nchecks++;
+        }
+        /* The live string too: every row above would pass on a catalog whose LANG_F22s
+           has no break, and the whole body would then land in the title bar. */
+        {
+          const char *stopped = LANG(LANG_F22s);
+          const char *brk = strpbrk(stopped, "\r\n");
+          char title[sizeof(end_mirror_title)];
+
+          firstLineOf(stopped, title, sizeof(title));
+          if (title[0] == '\0') {
+            fprintf(stderr, "FATAL: LANG_F22s has no first line to title the panel with\n");
+            fflush(stderr);
+            ExitProcess(3);
+          } else
+            nchecks++;
+          if (brk == NULL || (size_t) (brk - stopped) >= sizeof(title)) {
+            fprintf(stderr, "FATAL: LANG_F22s breaks at %d of %d bytes, so the title would be "
+                            "the message\n", brk != NULL ? (int) (brk - stopped) : -1,
+                    (int) sizeof(title));
+            fflush(stderr);
+            ExitProcess(3);
+          } else
+            nchecks++;
+        }
+      }
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
-      if (nchecks != 4) {
-        fprintf(stderr, "FATAL: end-of-mirror verdict ran %d checks, expected 4\n", nchecks);
+      if (nchecks != 14) {
+        fprintf(stderr, "FATAL: end-of-mirror verdict ran %d checks, expected 14\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }

--- a/WinHTTrack/inprogress.cpp
+++ b/WinHTTrack/inprogress.cpp
@@ -94,6 +94,7 @@ extern CWizTab* this_intCWizTab;
 
 // Pour la fin
 char end_mirror_msg[8192]="";
+char end_mirror_title[256]="";
 
 
 

--- a/tools/check-stop-title.py
+++ b/tools/check-stop-title.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Fail if a language catalog's LANG_F22s has no line break to title the panel with.
+
+The stopped-mirror panel titles itself from the first line of its own message
+(httrack-windows#176), so a catalog whose LANG_F22s runs on unbroken would put the
+whole message in the title bar. Nothing on the engine side pins that: its
+62_lang-linebreaks test counts per-catalog drift and names no key, and it skips
+English, which is the one every untranslated copy inherits.
+
+Offsets are counted in the catalog's UTF-8 bytes. The GUI converts to the ANSI
+codepage before cutting, and no codepage is longer than UTF-8 for the same text,
+so a break inside the buffer here is inside the buffer there.
+"""
+import sys
+from pathlib import Path
+
+KEY = "LANG_F22s"
+TITLE_MAX = 256  # sizeof(end_mirror_title) in WinHTTrack/Shell.h
+
+
+def value_of(lines, key):
+    """KEY's value, or None. Both files are strict key/value pairs from the first line,
+    and stepping by two is what keeps an untranslated entry, whose value repeats its key,
+    from matching as a key and handing back the next entry's."""
+    for i in range(0, len(lines) - 1, 2):
+        if lines[i] == key:
+            return lines[i + 1]
+    return None
+
+
+def main():
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "httrack")
+    defs = (root / "lang.def").read_text(encoding="utf-8").split("\n")
+    # The catalogs are keyed by the English text, which lang.def maps the macro to.
+    msgid = value_of(defs, KEY)
+    if not msgid:
+        sys.exit("%s carries no %s" % (root / "lang.def", KEY))
+
+    catalogs = sorted((root / "lang").glob("*.txt"))
+    bad, checked = [], 0
+    for path in catalogs:
+        lines = path.read_text(encoding="utf-8").split("\n")
+        text = value_of(lines, msgid)
+        if text is None:
+            bad.append("%s: no %s entry" % (path.name, KEY))
+            continue
+        checked += 1
+        at = text.find("\\n")
+        if at < 0:
+            bad.append("%s: %s runs on with no line break, so its whole body would be "
+                       "the window title" % (path.name, KEY))
+        elif len(text[:at].encode("utf-8")) >= TITLE_MAX:
+            bad.append("%s: %s breaks at %d bytes, past the %d-byte title"
+                       % (path.name, KEY, len(text[:at].encode("utf-8")), TITLE_MAX))
+    # The floor is the control: a msgid that matched nothing would report every catalog clean.
+    if checked < 20:
+        sys.exit("only %d of %d catalogs carry %s: this check would prove nothing"
+                 % (checked, len(catalogs), KEY))
+    if bad:
+        sys.exit("\n".join(bad))
+    print("%s breaks inside the title in all %d catalogs" % (KEY, checked))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check-stop-title.py
+++ b/tools/check-stop-title.py
@@ -2,63 +2,94 @@
 """Fail if a language catalog's LANG_F22s has no line break to title the panel with.
 
 The stopped-mirror panel titles itself from the first line of its own message
-(httrack-windows#176), so a catalog whose LANG_F22s runs on unbroken would put the
-whole message in the title bar. Nothing on the engine side pins that: its
-62_lang-linebreaks test counts per-catalog drift and names no key, and it skips
-English, which is the one every untranslated copy inherits.
+(httrack-windows#176). A catalog whose LANG_F22s runs on unbroken would put the whole
+message in the title bar, and one that opens with a break would leave the title empty,
+which falls back to LANG_F18b and says the mirror finished again.
 
-Offsets are counted in the catalog's UTF-8 bytes. The GUI converts to the ANSI
-codepage before cutting, and no codepage is longer than UTF-8 for the same text,
-so a break inside the buffer here is inside the buffer there.
+Nothing on the engine side pins this: its 62_lang-linebreaks test counts per-catalog
+drift, names no key, and skips English, the copy every untranslated catalog inherits.
+
+Offsets are counted in the catalog's UTF-8 bytes. The GUI converts to the ANSI codepage
+before cutting, and no codepage this project ships is longer than UTF-8 for the same
+text, because the engine blocks best-fit and an unmappable character becomes one default
+byte. So a break inside the buffer here is inside the buffer there.
 """
 import sys
 from pathlib import Path
 
 KEY = "LANG_F22s"
 TITLE_MAX = 256  # sizeof(end_mirror_title) in WinHTTrack/Shell.h
+BREAKS = "\n\r"  # firstLineOf() stops at either
 
 
-def value_of(lines, key):
-    """KEY's value, or None. Both files are strict key/value pairs from the first line,
-    and stepping by two is what keeps an untranslated entry, whose value repeats its key,
-    from matching as a key and handing back the next entry's."""
-    for i in range(0, len(lines) - 1, 2):
-        if lines[i] == key:
-            return lines[i + 1]
+def decode(text):
+    """The catalog's escapes resolved, as the engine resolves them before the GUI cuts.
+
+    A doubled backslash is one backslash and not the start of an escape, so "a\\\\nb" has
+    no break in it at all.
+    """
+    out, i = [], 0
+    while i < len(text):
+        if text[i] == "\\" and i + 1 < len(text):
+            out.append({"n": "\n", "r": "\r", "t": "\t"}.get(text[i + 1], text[i + 1]))
+            i += 2
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def entries(path):
+    """A file's key/value pairs. Both files are strict pairs from the first line, so a
+    line inserted anywhere shifts every later key onto an odd index. Stepping by two
+    would then read one entry's value as a key, so the parity is checked, not assumed."""
+    lines = path.read_text(encoding="utf-8").split("\n")
+    if len(lines) % 2 != 1:
+        sys.exit(f"{path.name} has {len(lines) - 1} lines, an odd number, so its key/value "
+                 f"pairs do not line up and every key past the gap would be read as a value")
+    return {lines[i]: lines[i + 1] for i in range(0, len(lines) - 1, 2)}
+
+
+def complain(name, text):
+    """What is wrong with this catalog's LANG_F22s, or None."""
+    at = min((text.find(b) for b in BREAKS if b in text), default=-1)
+    if at < 0:
+        return (f"{name}: {KEY} runs on with no line break, so its whole body would be "
+                f"the window title")
+    if at == 0:
+        # An empty title falls back to LANG_F18b, which is the bug #176 is about.
+        return f"{name}: {KEY} opens with a line break, so the title would be empty"
+    width = len(text[:at].encode("utf-8"))
+    if width >= TITLE_MAX:
+        return f"{name}: {KEY} breaks at {width} bytes, past the {TITLE_MAX}-byte title"
     return None
 
 
 def main():
     root = Path(sys.argv[1] if len(sys.argv) > 1 else "httrack")
-    defs = (root / "lang.def").read_text(encoding="utf-8").split("\n")
     # The catalogs are keyed by the English text, which lang.def maps the macro to.
-    msgid = value_of(defs, KEY)
+    msgid = entries(root / "lang.def").get(KEY)
     if not msgid:
-        sys.exit("%s carries no %s" % (root / "lang.def", KEY))
+        sys.exit(f"{root / 'lang.def'} carries no {KEY}")
 
     catalogs = sorted((root / "lang").glob("*.txt"))
     bad, checked = [], 0
     for path in catalogs:
-        lines = path.read_text(encoding="utf-8").split("\n")
-        text = value_of(lines, msgid)
+        text = entries(path).get(msgid)
         if text is None:
-            bad.append("%s: no %s entry" % (path.name, KEY))
+            bad.append(f"{path.name}: no {KEY} entry")
             continue
         checked += 1
-        at = text.find("\\n")
-        if at < 0:
-            bad.append("%s: %s runs on with no line break, so its whole body would be "
-                       "the window title" % (path.name, KEY))
-        elif len(text[:at].encode("utf-8")) >= TITLE_MAX:
-            bad.append("%s: %s breaks at %d bytes, past the %d-byte title"
-                       % (path.name, KEY, len(text[:at].encode("utf-8")), TITLE_MAX))
-    # The floor is the control: a msgid that matched nothing would report every catalog clean.
+        hit = complain(path.name, decode(text))
+        if hit:
+            bad.append(hit)
+    # The floor is the control: a msgid matching nothing would report every catalog clean.
     if checked < 20:
-        sys.exit("only %d of %d catalogs carry %s: this check would prove nothing"
-                 % (checked, len(catalogs), KEY))
+        sys.exit(f"only {checked} of {len(catalogs)} catalogs carry {KEY}: this check would "
+                 f"prove nothing")
     if bad:
         sys.exit("\n".join(bad))
-    print("%s breaks inside the title in all %d catalogs" % (KEY, checked))
+    print(f"{KEY} breaks inside the title in all {checked} catalogs")
 
 
 if __name__ == "__main__":

--- a/tools/test-check-stop-title.py
+++ b/tools/test-check-stop-title.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Table test for check-stop-title.py, over a synthesised catalog tree.
+
+Needs no engine checkout, so it runs in the encoding job while the guard itself
+runs where httrack/lang exists. Four of the rows below are shapes the first version
+of the guard passed, so they are the reason this file exists (#176).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+MOD = Path(__file__).with_name("check-stop-title.py")
+spec = importlib.util.spec_from_file_location("check_stop_title", MOD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+MSGID = r"Mirroring operation stopped before the end.\nThe files already downloaded are kept."
+fail = 0
+ran = 0
+
+
+def expect(what, got, want):
+    global fail, ran
+    ran += 1
+    if got != want:
+        print(f"  FAIL {what} : got {got!r}, wanted {want!r}")
+        fail += 1
+    else:
+        print(f"  ok   {what}")
+
+
+print("--- decode() resolves the escapes the engine resolves ---")
+DECODED = [
+    (r"a\nb", "a\nb", "a line break"),
+    (r"a\rb", "a\rb", "a carriage return"),
+    (r"a\tb", "a\tb", "a tab"),
+    (r"a\\nb", "a\\nb", "a doubled backslash is one backslash, so no break at all"),
+    (r"a\\\nb", "a\\\nb", "three backslashes are one backslash then a break"),
+    ("a\\", "a\\", "a trailing backslash with nothing to escape"),
+    (r"a\qb", "aqb", "an escape nothing maps drops the backslash"),
+    ("plain", "plain", "no escapes"),
+]
+for raw, want, why in DECODED:
+    expect(f"{why}: {raw}", guard.decode(raw), want)
+
+print("--- complain() judges a decoded value ---")
+JUDGED = [
+    ("Stopped.\nFiles kept.", None, "a break inside the title"),
+    ("Stopped.\rFiles kept.", None, "a carriage return counts, as firstLineOf does"),
+    ("Stopped before the end. Files kept.", "runs on", "no break at all"),
+    ("\nStopped.\nFiles kept.", "opens with", "a leading break leaves the title empty"),
+    ("x" * 255 + "\ny", None, "a first line just inside the title"),
+    ("x" * 256 + "\ny", "past the", "a first line one byte too long"),
+    ("Ø" * 128 + "\ny", "past the", "256 bytes of two-byte characters, not 256 characters"),
+    ("Stopped.\tFiles kept.", "runs on", "a tab is not a line break"),
+]
+for text, want, why in JUDGED:
+    got = guard.complain("Cat.txt", text)
+    # Spelt out rather than a conditional: `want in got` raises when want is None and got
+    # is a string, so a failing row would crash instead of naming itself.
+    ok = got is None if want is None else got is not None and want in got
+    expect(f"{why} -> {got}", ok, True)
+
+print("--- entries() refuses a file whose pairs do not line up ---")
+with TemporaryDirectory() as d:
+    root = Path(d)
+    (root / "lang").mkdir()
+    good = f"LANGUAGE_NAME\nTest\n{MSGID}\n{MSGID}\n"
+    for name, text, want in [
+        ("pairs.txt", good, {"LANGUAGE_NAME": "Test", MSGID: MSGID}),
+        ("odd.txt", good + "ORPHAN_KEY\n", None),
+    ]:
+        (root / "lang" / name).write_text(text, encoding="utf-8")
+        try:
+            got = guard.entries(root / "lang" / name)
+        except SystemExit:
+            got = None
+        expect(name, got, want)
+    # The value repeats the key here, as it does in all 30 shipped catalogs, so a guard
+    # scanning line by line would match the value and hand back the next entry's text.
+    expect("an untranslated entry is read as itself, not as a key",
+           guard.entries(root / "lang" / "pairs.txt")[MSGID], MSGID)
+
+print("--- main() over a whole tree ---")
+
+
+def tree(d, values):
+    root = Path(d)
+    (root / "lang").mkdir()
+    (root / "lang.def").write_text(f"LANG_F22s\n{MSGID}\n", encoding="utf-8")
+    for i, v in enumerate(values):
+        (root / "lang" / f"Lang{i:02d}.txt").write_text(
+            f"LANGUAGE_NAME\nLang{i:02d}\n{MSGID}\n{v}\n", encoding="utf-8")
+    return root
+
+
+def run(values):
+    """main()'s exit status over a tree of these LANG_F22s values: None when it passes."""
+    with TemporaryDirectory() as d:
+        argv = sys.argv
+        try:
+            sys.argv = ["check-stop-title.py", str(tree(d, values))]
+            guard.main()
+            return None
+        except SystemExit as e:
+            return e.code
+        finally:
+            sys.argv = argv
+
+
+OK = MSGID
+for values, want, why in [
+    ([OK] * 30, None, "thirty sound catalogs pass"),
+    ([OK] * 29 + [r"Stopped before the end. Files kept."], "runs on",
+     "one catalog in thirty with no break"),
+    ([OK] * 29 + [r"\nStopped.\nKept."], "opens with", "one catalog opening with a break"),
+    ([OK] * 29 + [r"Stopped.\\nKept."], "runs on", "one catalog whose backslash is escaped"),
+    ([OK] * 19, "would prove nothing", "too few catalogs to prove anything"),
+]:
+    got = run(values)
+    ok = got is None if want is None else got is not None and want in str(got)
+    expect(f"{why} -> {got}", ok, True)
+
+# Exact, not a floor: a floor passes the deletion it exists to catch (#126, #127).
+if ran != 24:
+    sys.exit(f"{ran} cases ran, expected 24: rows have gone missing or been added")
+if fail:
+    sys.exit(f"{fail} stopped-title case(s) failed")
+print(f"::notice::stopped-title guard: {ran} cases pass")


### PR DESCRIPTION
`Cinfoend::OnSetActive()` set the main window title to `LANG_F18b`, "Site mirroring finished!", whatever the engine's verdict was. #169 gave a stopped mirror its own panel text, so since then the title has said finished while the body said stopped. Xavier confirmed on Windows that the body itself is right.

`lance()` now takes the title from the first line of `LANG_F22s`, the message it has just put in the panel. The title is then translated wherever the body is, and no new catalog key is needed. The other arms clear it, the RAS one included, because it replaces the body after the verdict was read.

That rests on `LANG_F22s` keeping a line break, which nothing pinned. The engine's `62_lang-linebreaks` test counts per-catalog drift, names no key, and skips English, the copy the other 29 inherit. `tools/check-stop-title.py` decodes each shipped catalog and requires a real break inside the 256-byte title.

`--selftest` pins `firstLineOf()` at 21 checks. Eight mutants are caught with no sanitizer, which is what MSVC gives CI, and eleven more against the catalog guard.

Step 5 of #176 is still owed. Someone has to read the title bar of the stopped panel on the VM, so the issue stays open.

Refs #176