### PR TITLE
WinHTTrack reads a mirror's result before the engine has written it

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -310,7 +310,7 @@ runs:
         if ("$so" -notmatch 'end-of-mirror verdict ok on 21 checks') {
           throw "selftest did not check the end-of-mirror verdict"
         }
-        # The wait that keeps lance() from reading results the engine has not written yet.
+        # Only the wait itself: no mirror runs here, so lance() calling it is not covered.
         if ("$so" -notmatch 'engine results wait ok on 16 checks') {
           throw "selftest did not check the wait on the engine's results"
         }

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -311,8 +311,8 @@ runs:
           throw "selftest did not check the end-of-mirror verdict"
         }
         # The wait that keeps lance() from reading results the engine has not written yet.
-        if ("$so" -notmatch 'engine thread wait ok on 9 checks') {
-          throw "selftest did not check the wait on the engine thread"
+        if ("$so" -notmatch 'engine results wait ok on 16 checks') {
+          throw "selftest did not check the wait on the engine's results"
         }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -310,6 +310,10 @@ runs:
         if ("$so" -notmatch 'end-of-mirror verdict ok on 21 checks') {
           throw "selftest did not check the end-of-mirror verdict"
         }
+        # The wait that keeps lance() from reading results the engine has not written yet.
+        if ("$so" -notmatch 'engine thread wait ok on 9 checks') {
+          throw "selftest did not check the wait on the engine thread"
+        }
 
         # --selftest throws once on purpose. Without shipped PDBs this only proves the hook
         # ran and caught the throw stack; the build job checks resolution against staged.

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -119,6 +119,15 @@ extern "C" {
 //int INREDRAW_LOCKED=0;      // refresh graphique en cours
 //int INFILLMEM_LOCKED=0;     // refresh mémoire en cours
 int HTTRACK_result=0;
+/* Raised by the engine thread as it leaves, and the only signal that says HTTRACK_result
+   has been written. Never closed, because a thread outliving its wait would then raise a
+   recycled handle. */
+static HANDLE engineThreadDone = NULL;
+/* How long the engine may spend closing the cache and renaming files after its
+   end-of-mirror callback. Past it the GUI gives up waiting rather than wedging. */
+#define ENGINE_EXIT_TIMEOUT_MS 60000
+/* HTTRACK_result for a mirror the engine never saw, next to -100 for one it crashed on. */
+#define HTTRACK_NO_THREAD (-101)
 //
 CInfoUrl* _Cinprogress_inst=NULL;
 
@@ -1761,6 +1770,17 @@ static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtr
   }
 }
 
+/* Frees the argv lance() built for the engine thread. */
+static void freeEngineArgv(char** argv) {
+  if (argv != NULL) {
+    for(int i = 0 ; argv[i] != NULL ; i++) {
+      freet(argv[i]);
+      argv[i] = NULL;
+    }
+    freet(argv);
+  }
+}
+
 void __cdecl RunBackRobot(void* al_p) {
   int argc;
   char** argv;
@@ -1822,14 +1842,10 @@ void __cdecl RunBackRobot(void* al_p) {
     htsthread_wait_n(1);
     hts_uninit();
 
-    // Cleanup argv
-    if (argv != NULL) {
-      for(int i = 0 ; argv[i] != NULL ; i++) {
-        freet(argv[i]);
-        argv[i] = NULL;
-      }
-      freet(argv);
-    }
+    freeEngineArgv(argv);
+    /* Last of all, because lance() reads this thread's results the moment it is raised. */
+    if (engineThreadDone != NULL)
+      SetEvent(engineThreadDone);
 }
 #endif
 
@@ -2008,6 +2024,18 @@ BOOL isSingleFileMaxArgument(const CString &value) {
   v = strtoll((LPCSTR) value, &end, 10);
   // leading zeros keep the value small however long the string is, so argv still caps it
   return *end == '\0' && errno != ERANGE && v > 0 && fitsEngineArgument(value, HTS_CDLMAXSIZE);
+}
+
+// see Shell.h
+BOOL waitForEngineThread(HANDLE done, const volatile int* ended, DWORD timeoutMs) {
+  /* The engine can also leave without the callback, on an error, so watch both. */
+  while (!*ended) {
+    const DWORD waited = WaitForSingleObject(done, 100);
+    /* Anything but a timeout ends the wait, because a handle we never got never times out. */
+    if (waited != WAIT_TIMEOUT)
+      return waited == WAIT_OBJECT_0;
+  }
+  return WaitForSingleObject(done, timeoutMs) == WAIT_OBJECT_0;
 }
 
 // see Shell.h
@@ -2371,7 +2399,20 @@ void lance(void) {
     Robot_params al;
     al.argc=argc;
     al.argv=argv;
-    hts_newthread( RunBackRobot, (void*) &al);
+    if (engineThreadDone == NULL)
+      engineThreadDone = CreateEvent(NULL, TRUE, FALSE, NULL);
+    else
+      ResetEvent(engineThreadDone);
+    if (hts_newthread( RunBackRobot, (void*) &al) != 0) {
+      /* Nothing would ever raise the wait below, so end the mirror here. */
+      freeEngineArgv(argv);
+      WHTT_LOCK();
+      HTTRACK_result = HTTRACK_NO_THREAD;
+      termine = 1;
+      WHTT_UNLOCK();
+      if (engineThreadDone != NULL)
+        SetEvent(engineThreadDone);
+    }
     
     //
     if (fp_debug) {
@@ -2379,12 +2420,18 @@ void lance(void) {
       fflush(fp_debug);
     }
     //
-    // domodal du refresh
-    /* XXC A SUPPRIMER */
-    while(!termine) {
-      Sleep(100);
+    /* 'termine' only says the engine reached its end-of-mirror callback, which it fires
+       while still closing the cache and before it writes HTTRACK_result. Wait for the
+       thread itself, bounded so a wedged one cannot strand the end panel (#173). */
+    if (engineThreadDone == NULL) {
+      while (!termine)     // no event to wait on, so fall back to the callback
+        Sleep(100);
+    } else if (!waitForEngineThread(engineThreadDone, &termine, ENGINE_EXIT_TIMEOUT_MS)
+               && fp_debug) {
+      fprintf(fp_debug,"Engine thread still running after %lu ms, results may be stale\r\n",
+              (unsigned long) ENGINE_EXIT_TIMEOUT_MS);
+      fflush(fp_debug);
     }
-    //inprogress->DoModal();
     WHTT_LOCK();
     shell_terminated=1;
     result=HTTRACK_result;
@@ -2430,10 +2477,12 @@ void lance(void) {
     if (result) {      // erreur?
       strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
-      if (result != -100) {
-        strcatbuff(end_mirror_msg,hts_errmsg(global_opt));
+      if (result == -100) {
+        strcatbuff(end_mirror_msg, "The engine unexpectedly crashed.");
+      } else if (result == HTTRACK_NO_THREAD) {
+        strcatbuff(end_mirror_msg, "The engine thread could not be started.");
       } else {
-				strcatbuff(end_mirror_msg, "The engine unexpectedly crashed.");
+        strcatbuff(end_mirror_msg,hts_errmsg(global_opt));
       }
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F20 /*"\" \nDuring:\n  ","\" \nDurant:\n  "*/));
@@ -2443,7 +2492,7 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
-    } else if (global_opt != NULL   /* nothing joins this thread, so the UI can clear it (#173) */
+    } else if (global_opt != NULL   /* no mirror ran at all when the thread never started */
                && isMirrorCutShort(hts_mirror_completed(global_opt))) {
       strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
       /* Its own first line, so the title is translated wherever the body is (#176). */

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -119,13 +119,6 @@ extern "C" {
 //int INREDRAW_LOCKED=0;      // refresh graphique en cours
 //int INFILLMEM_LOCKED=0;     // refresh mémoire en cours
 int HTTRACK_result=0;
-/* Raised by the engine thread as it leaves, and the only signal that says HTTRACK_result
-   has been written. Never closed, because a thread outliving its wait would then raise a
-   recycled handle. */
-static HANDLE engineThreadDone = NULL;
-/* How long the engine may spend closing the cache and renaming files after its
-   end-of-mirror callback. Past it the GUI gives up waiting rather than wedging. */
-#define ENGINE_EXIT_TIMEOUT_MS 60000
 /* HTTRACK_result for a mirror the engine never saw, next to -100 for one it crashed on. */
 #define HTTRACK_NO_THREAD (-101)
 //
@@ -1770,7 +1763,7 @@ static int __cdecl ExcFilter_(DWORD dwExceptCode, PEXCEPTION_POINTERS pExceptPtr
   }
 }
 
-/* Frees the argv lance() built for the engine thread. */
+/* Shared by the engine thread and by lance() when that thread never starts. */
 static void freeEngineArgv(char** argv) {
   if (argv != NULL) {
     for(int i = 0 ; argv[i] != NULL ; i++) {
@@ -1784,6 +1777,7 @@ static void freeEngineArgv(char** argv) {
 void __cdecl RunBackRobot(void* al_p) {
   int argc;
   char** argv;
+  HANDLE resultsReady;
 
   /* Both spins are bounded only by 'termine', which no writer sets this early: keep the operator honest. */
   while ((!inprogress) && (!termine)) Sleep(10);
@@ -1795,6 +1789,7 @@ void __cdecl RunBackRobot(void* al_p) {
     Robot_params* al=(Robot_params*) al_p;
     argc = al->argc;
     argv = al->argv;
+    resultsReady = al->resultsReady;
     /* launch the engine */
     hts_init();
 #ifndef _DEBUG
@@ -1839,13 +1834,13 @@ void __cdecl RunBackRobot(void* al_p) {
     WHTT_LOCK();
     termine=1;
     WHTT_UNLOCK();
+    /* hts_main2() has returned, so the results are final. Raise it before the call below,
+       which waits for the thread that runs lance(), or the two wait for each other. */
+    SetEvent(resultsReady);
     htsthread_wait_n(1);
     hts_uninit();
 
     freeEngineArgv(argv);
-    /* Last of all, because lance() reads this thread's results the moment it is raised. */
-    if (engineThreadDone != NULL)
-      SetEvent(engineThreadDone);
 }
 #endif
 
@@ -2027,15 +2022,18 @@ BOOL isSingleFileMaxArgument(const CString &value) {
 }
 
 // see Shell.h
-BOOL waitForEngineThread(HANDLE done, const volatile int* ended, DWORD timeoutMs) {
-  /* The engine can also leave without the callback, on an error, so watch both. */
-  while (!*ended) {
-    const DWORD waited = WaitForSingleObject(done, 100);
-    /* Anything but a timeout ends the wait, because a handle we never got never times out. */
-    if (waited != WAIT_TIMEOUT)
-      return waited == WAIT_OBJECT_0;
+BOOL waitForEngineResults(HANDLE ready, const volatile int* endCalled, DWORD timeoutMs) {
+  if (ready == NULL) {
+    while (!*endCalled)     // no event to wait on, so fall back to the callback
+      Sleep(100);
+    return FALSE;
   }
-  return WaitForSingleObject(done, timeoutMs) == WAIT_OBJECT_0;
+  /* The engine can also return without the callback, on an error, so watch both. */
+  while (!*endCalled) {
+    if (WaitForSingleObject(ready, 100) == WAIT_OBJECT_0)
+      return TRUE;
+  }
+  return WaitForSingleObject(ready, timeoutMs) == WAIT_OBJECT_0;
 }
 
 // see Shell.h
@@ -2399,10 +2397,9 @@ void lance(void) {
     Robot_params al;
     al.argc=argc;
     al.argv=argv;
-    if (engineThreadDone == NULL)
-      engineThreadDone = CreateEvent(NULL, TRUE, FALSE, NULL);
-    else
-      ResetEvent(engineThreadDone);
+    /* One per mirror, so a thread that outlived its bounded wait cannot raise the next
+       mirror's event. */
+    al.resultsReady = CreateEvent(NULL, TRUE, FALSE, NULL);
     if (hts_newthread( RunBackRobot, (void*) &al) != 0) {
       /* Nothing would ever raise the wait below, so end the mirror here. */
       freeEngineArgv(argv);
@@ -2410,8 +2407,7 @@ void lance(void) {
       HTTRACK_result = HTTRACK_NO_THREAD;
       termine = 1;
       WHTT_UNLOCK();
-      if (engineThreadDone != NULL)
-        SetEvent(engineThreadDone);
+      SetEvent(al.resultsReady);
     }
     
     //
@@ -2422,14 +2418,12 @@ void lance(void) {
     //
     /* 'termine' only says the engine reached its end-of-mirror callback, which it fires
        while still closing the cache and before it writes HTTRACK_result. Wait for the
-       thread itself, bounded so a wedged one cannot strand the end panel (#173). */
-    if (engineThreadDone == NULL) {
-      while (!termine)     // no event to wait on, so fall back to the callback
-        Sleep(100);
-    } else if (!waitForEngineThread(engineThreadDone, &termine, ENGINE_EXIT_TIMEOUT_MS)
-               && fp_debug) {
-      fprintf(fp_debug,"Engine thread still running after %lu ms, results may be stale\r\n",
-              (unsigned long) ENGINE_EXIT_TIMEOUT_MS);
+       results, bounded so a wedged engine cannot strand the end panel (#173). */
+    if (waitForEngineResults(al.resultsReady, &termine, ENGINE_RESULTS_TIMEOUT_MS)) {
+      CloseHandle(al.resultsReady);    // the engine is gone, so nothing can raise it again
+    } else if (fp_debug) {
+      fprintf(fp_debug,"Engine still running after %lu ms, results may be stale\r\n",
+              (unsigned long) ENGINE_RESULTS_TIMEOUT_MS);
       fflush(fp_debug);
     }
     WHTT_LOCK();
@@ -2477,12 +2471,12 @@ void lance(void) {
     if (result) {      // erreur?
       strcpybuff(end_mirror_msg,LANG(LANG_F19 /*"A problem occured during the mirror\n  \"","Un problème est survenu pendant le miroir\n  \""*/));
       strcatbuff(end_mirror_msg,"\"");
-      if (result == -100) {
-        strcatbuff(end_mirror_msg, "The engine unexpectedly crashed.");
-      } else if (result == HTTRACK_NO_THREAD) {
+      if (result == HTTRACK_NO_THREAD) {
         strcatbuff(end_mirror_msg, "The engine thread could not be started.");
-      } else {
+      } else if (result != -100) {
         strcatbuff(end_mirror_msg,hts_errmsg(global_opt));
+      } else {
+				strcatbuff(end_mirror_msg, "The engine unexpectedly crashed.");
       }
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F20 /*"\" \nDuring:\n  ","\" \nDurant:\n  "*/));
@@ -2492,7 +2486,7 @@ void lance(void) {
       strcatbuff(end_mirror_msg,"\"");
       strcatbuff(end_mirror_msg,LANG(LANG_F21 /*"\nSee the log file if necessary.\n\nClick OK to quit WinHTTrack.\n\nThanks for using WinHTTrack!","\nVoir le fichier log au besoin\n\nCliquez sur OK pour quitter WinHTTrack\n\nMerci d'utiliser WinHTTrack."*/));
       //AfxMessageBox(s,MB_OK+MB_ICONINFORMATION);
-    } else if (global_opt != NULL   /* no mirror ran at all when the thread never started */
+    } else if (global_opt != NULL
                && isMirrorCutShort(hts_mirror_completed(global_opt))) {
       strcpybuff(end_mirror_msg,LANG(LANG_F22s /*"Mirroring operation stopped before the end.\nThe files already downloaded are kept.\nSee log file(s) if necessary.\n\nThanks for using WinHTTrack!"*/));
       /* Its own first line, so the title is translated wherever the body is (#176). */

--- a/WinHTTrack/Shell.cpp
+++ b/WinHTTrack/Shell.cpp
@@ -119,7 +119,8 @@ extern "C" {
 //int INREDRAW_LOCKED=0;      // refresh graphique en cours
 //int INFILLMEM_LOCKED=0;     // refresh mémoire en cours
 int HTTRACK_result=0;
-/* HTTRACK_result for a mirror the engine never saw, next to -100 for one it crashed on. */
+/* HTTRACK_result for a mirror the engine never saw, next to -100 for one it crashed on.
+   Both sit outside the 0, 1 and -1 that hts_main2() returns. */
 #define HTTRACK_NO_THREAD (-101)
 //
 CInfoUrl* _Cinprogress_inst=NULL;
@@ -2422,8 +2423,7 @@ void lance(void) {
     if (waitForEngineResults(al.resultsReady, &termine, ENGINE_RESULTS_TIMEOUT_MS)) {
       CloseHandle(al.resultsReady);    // the engine is gone, so nothing can raise it again
     } else if (fp_debug) {
-      fprintf(fp_debug,"Engine still running after %lu ms, results may be stale\r\n",
-              (unsigned long) ENGINE_RESULTS_TIMEOUT_MS);
+      fprintf(fp_debug,"Engine gave no signal that its results were written\r\n");
       fflush(fp_debug);
     }
     WHTT_LOCK();

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -283,6 +283,12 @@ BOOL isMirrorCutShort(hts_tristate completed);
    Exposed for --selftest. */
 void firstLineOf(const char *msg, char *dest, size_t size);
 
+/* TRUE once the engine thread raised DONE. The wait has no bound while *ENDED reads zero,
+   because that is the mirror itself running. Once *ENDED is raised the wait is TIMEOUTMS at
+   most, which covers the teardown the engine raises it in the middle of. FALSE means the
+   thread still runs, so its results are not ours to read. Exposed for --selftest. */
+BOOL waitForEngineThread(HANDLE done, const volatile int *ended, DWORD timeoutMs);
+
 /* The end-of-mirror panel wears this title, or LANG_F18b when it is empty. lance() picks it
    as the mirror ends, because the verdict is gone by then. */
 extern char end_mirror_title[256];

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -283,11 +283,14 @@ BOOL isMirrorCutShort(hts_tristate completed);
    Exposed for --selftest. */
 void firstLineOf(const char *msg, char *dest, size_t size);
 
-/* TRUE once the engine thread raised DONE. The wait has no bound while *ENDED reads zero,
-   because that is the mirror itself running. Once *ENDED is raised the wait is TIMEOUTMS at
-   most, which covers the teardown the engine raises it in the middle of. FALSE means the
-   thread still runs, so its results are not ours to read. Exposed for --selftest. */
-BOOL waitForEngineThread(HANDLE done, const volatile int *ended, DWORD timeoutMs);
+/* How long the engine may spend closing the cache and renaming files after its
+   end-of-mirror callback. Past it the GUI gives up waiting rather than wedging. */
+#define ENGINE_RESULTS_TIMEOUT_MS 60000
+
+/* TRUE once READY says the mirror's results are written. The wait has no bound while
+   *ENDCALLED reads zero, then TIMEOUTMS at most. A NULL READY waits on *ENDCALLED alone and
+   returns FALSE. Exposed for --selftest. */
+BOOL waitForEngineResults(HANDLE ready, const volatile int *endCalled, DWORD timeoutMs);
 
 /* The end-of-mirror panel wears this title, or LANG_F18b when it is empty. lance() picks it
    as the mirror ends, because the verdict is gone by then. */
@@ -337,6 +340,8 @@ public:
 typedef struct Robot_params {
   int argc;
   char** argv;
+  /* The engine thread raises this once hts_main2() has returned; see waitForEngineResults(). */
+  HANDLE resultsReady;
 } Robot_params;
 
 // Lancement du miroir

--- a/WinHTTrack/Shell.h
+++ b/WinHTTrack/Shell.h
@@ -340,7 +340,8 @@ public:
 typedef struct Robot_params {
   int argc;
   char** argv;
-  /* The engine thread raises this once hts_main2() has returned; see waitForEngineResults(). */
+  /* The engine thread raises this once hts_main2() has returned, and never closes it.
+     lance() creates it, and closes it only once the wait has seen it. */
   HANDLE resultsReady;
 } Robot_params;
 

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -234,11 +234,15 @@ static void httrackErrorCallback(const char* msg, const char* file, int line) {
   CrashReportReport(msg, file, line);
 }
 
-/* How late --selftest's engine answers, how much less than that the clock may read, and
-   how long a wait whose answer is already there may still take. */
+/* How late --selftest's engine answers, and how much less than that the clock may read. */
 #define SELFTEST_WAIT_MS 250
 #define SELFTEST_SLACK_MS 50
-#define SELFTEST_PROMPT_MS 500
+/* What a wait whose answer is already there may spend. Tight on purpose, because a wait
+   that ignored its bound and used one of its own would sit inside a loose window. */
+#define SELFTEST_PROMPT_MS 150
+/* What a wait for a late answer may spend on top of it. The poll steps 100 ms, so those
+   land nearer 300 ms than 250. */
+#define SELFTEST_LATE_SLACK_MS 500
 
 /* The end-of-mirror callback and the results, both arriving late. */
 static volatile int selftestEndCalled = 0;
@@ -265,26 +269,30 @@ static HANDLE selftestStartLateEngine(void) {
   return late;
 }
 
-/* Runs one wait and checks its verdict and how long it took. Returns the checks it made. */
+/* Runs one wait and checks its verdict and how long it took. Returns the checks it made,
+   counted here rather than returned as a literal, which would drift from them (#147). */
 static int checkEngineWait(const char *what, HANDLE ready, const volatile int *endCalled,
-                           DWORD timeoutMs, BOOL want, DWORD leastMs, DWORD mostMs) {
+                           DWORD timeoutMs, BOOL wantWritten, DWORD leastMs, DWORD mostMs) {
   const DWORD t0 = GetTickCount();
   const BOOL written = waitForEngineResults(ready, endCalled, timeoutMs);
   const DWORD elapsed = GetTickCount() - t0;
+  int nchecks = 0;
 
-  if (written != want) {
+  if (written != wantWritten) {
     fprintf(stderr, "FATAL: %s was judged %s\n", what,
-            want ? "still running, expected written" : "written, expected still running");
+            wantWritten ? "still running, expected written" : "written, expected still running");
     fflush(stderr);
     ExitProcess(3);
-  }
+  } else
+    nchecks++;
   if (elapsed < leastMs || elapsed > mostMs) {
     fprintf(stderr, "FATAL: %s answered after %lu ms, wanted %lu to %lu\n", what,
             (unsigned long) elapsed, (unsigned long) leastMs, (unsigned long) mostMs);
     fflush(stderr);
     ExitProcess(3);
-  }
-  return 2;
+  } else
+    nchecks++;
+  return nchecks;
 }
 
 /* Set by --selftest. Startup failures must then report on stderr and exit non-zero
@@ -1480,7 +1488,7 @@ BOOL CWinHTTrackApp::InitInstance()
       const HANDLE ready = CreateEvent(NULL, TRUE, TRUE, NULL);
       const HANDLE pending = CreateEvent(NULL, TRUE, FALSE, NULL);
       const DWORD lateLeast = SELFTEST_WAIT_MS - SELFTEST_SLACK_MS;
-      const DWORD lateMost = SELFTEST_WAIT_MS + SELFTEST_PROMPT_MS;
+      const DWORD lateMost = SELFTEST_WAIT_MS + SELFTEST_LATE_SLACK_MS;
       int endCalled = 1, endPending = 0;
       int nchecks = 0;
       HANDLE late;
@@ -1503,9 +1511,10 @@ BOOL CWinHTTrackApp::InitInstance()
       /* CreateEvent can fail, and the callback is then all the wait has to go on. */
       nchecks += checkEngineWait("no event, mirror over", NULL, &endCalled, 0, FALSE,
                                  0, SELFTEST_PROMPT_MS);
-      /* The bound covers the teardown the callback fires in the middle of. */
+      /* The bound covers the teardown the callback fires in the middle of. This case has
+         nothing to poll, so it lands ON its bound: a wait that scaled the bound lands off it. */
       nchecks += checkEngineWait("engine never returns", pending, &endCalled, SELFTEST_WAIT_MS,
-                                 FALSE, lateLeast, lateMost);
+                                 FALSE, lateLeast, SELFTEST_WAIT_MS + SELFTEST_PROMPT_MS);
       /* The mirror half has no bound, so end the mirror late and ask for a bound of zero,
          which a wait that skipped that half would return from at once. */
       late = selftestStartLateEngine();
@@ -1529,6 +1538,7 @@ BOOL CWinHTTrackApp::InitInstance()
       CloseHandle(ready);
       CloseHandle(pending);
       CloseHandle(selftestLateResults);
+      selftestLateResults = NULL;
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
       if (nchecks != 16) {
         fprintf(stderr, "FATAL: engine results wait ran %d checks, expected 16\n", nchecks);

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -234,6 +234,18 @@ static void httrackErrorCallback(const char* msg, const char* file, int line) {
   CrashReportReport(msg, file, line);
 }
 
+/* How long --selftest makes a wait last, and how much less the clock may read. */
+#define SELFTEST_WAIT_MS 250
+#define SELFTEST_WAIT_SLACK_MS 50
+
+/* Raised late, so --selftest can see that the wait on a running mirror has no bound. */
+static volatile int selftestMirrorEnded = 0;
+static DWORD WINAPI selftestEndMirror(LPVOID) {
+  Sleep(SELFTEST_WAIT_MS);
+  selftestMirrorEnded = 1;
+  return 0;
+}
+
 /* Set by --selftest. Startup failures must then report on stderr and exit non-zero
    rather than raise a message box: nobody is there to click it, and a modal dialog
    would hang a headless run instead of failing it. */
@@ -1421,6 +1433,96 @@ BOOL CWinHTTrackApp::InitInstance()
         ExitProcess(3);
       }
       printf("end-of-mirror verdict ok on %d checks\n", nchecks);
+    }
+    /* No mirror runs under --selftest, so the wait that guards its results is pinned here. */
+    {
+      HANDLE raised = CreateEvent(NULL, TRUE, TRUE, NULL);
+      HANDLE pending = CreateEvent(NULL, TRUE, FALSE, NULL);
+      HANDLE ender;
+      int ended = 1, running = 0;
+      const struct { const char *what; HANDLE done; const int *ended; BOOL want; } waits[] = {
+        { "thread gone", raised, &ended, TRUE },
+        { "thread still tearing down", pending, &ended, FALSE },
+        /* The engine can leave without its end-of-mirror callback, on an error. */
+        { "thread gone with no callback", raised, &running, TRUE },
+        /* A handle CreateEvent never gave us. Waiting on it fails rather than times out,
+           so both halves have to tell that apart from a thread that is merely slow. */
+        { "no event, mirror over", NULL, &ended, FALSE },
+        { "no event, mirror running", NULL, &running, FALSE }
+      };
+      int nchecks = 0;
+
+      if (raised == NULL || pending == NULL) {
+        fprintf(stderr, "FATAL: could not create the events the engine wait is tested with\n");
+        fflush(stderr);
+        ExitProcess(3);
+      }
+      for(size_t k=0 ; k<_countof(waits) ; k++) {
+        if (waitForEngineThread(waits[k].done, waits[k].ended, 0) != waits[k].want) {
+          fprintf(stderr, "FATAL: %s was judged %s\n", waits[k].what,
+                  waits[k].want ? "still running, expected gone" : "gone, expected still running");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* A wait that drops its bound reads as a pass above, because both return FALSE. */
+      {
+        const DWORD t0 = GetTickCount();
+        const BOOL gone = waitForEngineThread(pending, &ended, SELFTEST_WAIT_MS);
+        const DWORD elapsed = GetTickCount() - t0;
+
+        if (gone) {
+          fprintf(stderr, "FATAL: a bounded wait on a running thread said it was gone\n");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+        if (elapsed < SELFTEST_WAIT_MS - SELFTEST_WAIT_SLACK_MS) {
+          fprintf(stderr, "FATAL: a %d ms wait gave up after %lu ms\n", SELFTEST_WAIT_MS,
+                  (unsigned long) elapsed);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      /* Nothing above can see that the mirror half has no bound, so end the mirror late
+         and ask for a bound of zero, which a wait that skipped that half returns from at once. */
+      ender = CreateThread(NULL, 0, selftestEndMirror, NULL, 0, NULL);
+      if (ender == NULL) {
+        fprintf(stderr, "FATAL: could not start the thread that ends the tested mirror\n");
+        fflush(stderr);
+        ExitProcess(3);
+      } else {
+        const DWORD t0 = GetTickCount();
+        const BOOL gone = waitForEngineThread(pending, &selftestMirrorEnded, 0);
+        const DWORD elapsed = GetTickCount() - t0;
+
+        WaitForSingleObject(ender, INFINITE);
+        CloseHandle(ender);
+        if (gone) {
+          fprintf(stderr, "FATAL: an unsignalled thread was judged gone once the mirror ended\n");
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+        if (elapsed < SELFTEST_WAIT_MS - SELFTEST_WAIT_SLACK_MS) {
+          fprintf(stderr, "FATAL: the wait returned after %lu ms, before the mirror ended\n",
+                  (unsigned long) elapsed);
+          fflush(stderr);
+          ExitProcess(3);
+        } else
+          nchecks++;
+      }
+      CloseHandle(raised);
+      CloseHandle(pending);
+      /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
+      if (nchecks != 9) {
+        fprintf(stderr, "FATAL: engine thread wait ran %d checks, expected 9\n", nchecks);
+        fflush(stderr);
+        ExitProcess(3);
+      }
+      printf("engine thread wait ok on %d checks\n", nchecks);
     }
     /* Portable mode decides which store this run writes to. The two CI legs assert
        opposite suffixes, so a mode wired to a constant reds one of them. */

--- a/WinHTTrack/WinHTTrack.cpp
+++ b/WinHTTrack/WinHTTrack.cpp
@@ -234,16 +234,57 @@ static void httrackErrorCallback(const char* msg, const char* file, int line) {
   CrashReportReport(msg, file, line);
 }
 
-/* How long --selftest makes a wait last, and how much less the clock may read. */
+/* How late --selftest's engine answers, how much less than that the clock may read, and
+   how long a wait whose answer is already there may still take. */
 #define SELFTEST_WAIT_MS 250
-#define SELFTEST_WAIT_SLACK_MS 50
+#define SELFTEST_SLACK_MS 50
+#define SELFTEST_PROMPT_MS 500
 
-/* Raised late, so --selftest can see that the wait on a running mirror has no bound. */
-static volatile int selftestMirrorEnded = 0;
-static DWORD WINAPI selftestEndMirror(LPVOID) {
+/* The end-of-mirror callback and the results, both arriving late. */
+static volatile int selftestEndCalled = 0;
+static HANDLE selftestLateResults = NULL;
+static DWORD WINAPI selftestEndLate(LPVOID) {
   Sleep(SELFTEST_WAIT_MS);
-  selftestMirrorEnded = 1;
+  selftestEndCalled = 1;
+  SetEvent(selftestLateResults);
   return 0;
+}
+
+/* Arms both late signals and hands back the thread that will raise them. */
+static HANDLE selftestStartLateEngine(void) {
+  HANDLE late;
+
+  selftestEndCalled = 0;
+  ResetEvent(selftestLateResults);
+  late = CreateThread(NULL, 0, selftestEndLate, NULL, 0, NULL);
+  if (late == NULL) {
+    fprintf(stderr, "FATAL: could not start the thread that ends the tested mirror\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  return late;
+}
+
+/* Runs one wait and checks its verdict and how long it took. Returns the checks it made. */
+static int checkEngineWait(const char *what, HANDLE ready, const volatile int *endCalled,
+                           DWORD timeoutMs, BOOL want, DWORD leastMs, DWORD mostMs) {
+  const DWORD t0 = GetTickCount();
+  const BOOL written = waitForEngineResults(ready, endCalled, timeoutMs);
+  const DWORD elapsed = GetTickCount() - t0;
+
+  if (written != want) {
+    fprintf(stderr, "FATAL: %s was judged %s\n", what,
+            want ? "still running, expected written" : "written, expected still running");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  if (elapsed < leastMs || elapsed > mostMs) {
+    fprintf(stderr, "FATAL: %s answered after %lu ms, wanted %lu to %lu\n", what,
+            (unsigned long) elapsed, (unsigned long) leastMs, (unsigned long) mostMs);
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  return 2;
 }
 
 /* Set by --selftest. Startup failures must then report on stderr and exit non-zero
@@ -1436,93 +1477,65 @@ BOOL CWinHTTrackApp::InitInstance()
     }
     /* No mirror runs under --selftest, so the wait that guards its results is pinned here. */
     {
-      HANDLE raised = CreateEvent(NULL, TRUE, TRUE, NULL);
-      HANDLE pending = CreateEvent(NULL, TRUE, FALSE, NULL);
-      HANDLE ender;
-      int ended = 1, running = 0;
-      const struct { const char *what; HANDLE done; const int *ended; BOOL want; } waits[] = {
-        { "thread gone", raised, &ended, TRUE },
-        { "thread still tearing down", pending, &ended, FALSE },
-        /* The engine can leave without its end-of-mirror callback, on an error. */
-        { "thread gone with no callback", raised, &running, TRUE },
-        /* A handle CreateEvent never gave us. Waiting on it fails rather than times out,
-           so both halves have to tell that apart from a thread that is merely slow. */
-        { "no event, mirror over", NULL, &ended, FALSE },
-        { "no event, mirror running", NULL, &running, FALSE }
-      };
+      const HANDLE ready = CreateEvent(NULL, TRUE, TRUE, NULL);
+      const HANDLE pending = CreateEvent(NULL, TRUE, FALSE, NULL);
+      const DWORD lateLeast = SELFTEST_WAIT_MS - SELFTEST_SLACK_MS;
+      const DWORD lateMost = SELFTEST_WAIT_MS + SELFTEST_PROMPT_MS;
+      int endCalled = 1, endPending = 0;
       int nchecks = 0;
+      HANDLE late;
 
-      if (raised == NULL || pending == NULL) {
+      selftestLateResults = CreateEvent(NULL, TRUE, FALSE, NULL);
+      if (ready == NULL || pending == NULL || selftestLateResults == NULL) {
         fprintf(stderr, "FATAL: could not create the events the engine wait is tested with\n");
         fflush(stderr);
         ExitProcess(3);
       }
-      for(size_t k=0 ; k<_countof(waits) ; k++) {
-        if (waitForEngineThread(waits[k].done, waits[k].ended, 0) != waits[k].want) {
-          fprintf(stderr, "FATAL: %s was judged %s\n", waits[k].what,
-                  waits[k].want ? "still running, expected gone" : "gone, expected still running");
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
-      }
-      /* A wait that drops its bound reads as a pass above, because both return FALSE. */
-      {
-        const DWORD t0 = GetTickCount();
-        const BOOL gone = waitForEngineThread(pending, &ended, SELFTEST_WAIT_MS);
-        const DWORD elapsed = GetTickCount() - t0;
-
-        if (gone) {
-          fprintf(stderr, "FATAL: a bounded wait on a running thread said it was gone\n");
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
-        if (elapsed < SELFTEST_WAIT_MS - SELFTEST_WAIT_SLACK_MS) {
-          fprintf(stderr, "FATAL: a %d ms wait gave up after %lu ms\n", SELFTEST_WAIT_MS,
-                  (unsigned long) elapsed);
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
-      }
-      /* Nothing above can see that the mirror half has no bound, so end the mirror late
-         and ask for a bound of zero, which a wait that skipped that half returns from at once. */
-      ender = CreateThread(NULL, 0, selftestEndMirror, NULL, 0, NULL);
-      if (ender == NULL) {
-        fprintf(stderr, "FATAL: could not start the thread that ends the tested mirror\n");
-        fflush(stderr);
-        ExitProcess(3);
-      } else {
-        const DWORD t0 = GetTickCount();
-        const BOOL gone = waitForEngineThread(pending, &selftestMirrorEnded, 0);
-        const DWORD elapsed = GetTickCount() - t0;
-
-        WaitForSingleObject(ender, INFINITE);
-        CloseHandle(ender);
-        if (gone) {
-          fprintf(stderr, "FATAL: an unsignalled thread was judged gone once the mirror ended\n");
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
-        if (elapsed < SELFTEST_WAIT_MS - SELFTEST_WAIT_SLACK_MS) {
-          fprintf(stderr, "FATAL: the wait returned after %lu ms, before the mirror ended\n",
-                  (unsigned long) elapsed);
-          fflush(stderr);
-          ExitProcess(3);
-        } else
-          nchecks++;
-      }
-      CloseHandle(raised);
+      /* Each answer below is already there, so the wait must come back at once. Without that
+         upper bound a wait that always burns its whole timeout reads as a pass. */
+      nchecks += checkEngineWait("results written", ready, &endCalled, 0, TRUE,
+                                 0, SELFTEST_PROMPT_MS);
+      nchecks += checkEngineWait("engine still tearing down", pending, &endCalled, 0, FALSE,
+                                 0, SELFTEST_PROMPT_MS);
+      /* The engine can return without its end-of-mirror callback, on an error. */
+      nchecks += checkEngineWait("results written with no callback", ready, &endPending, 0, TRUE,
+                                 0, SELFTEST_PROMPT_MS);
+      /* CreateEvent can fail, and the callback is then all the wait has to go on. */
+      nchecks += checkEngineWait("no event, mirror over", NULL, &endCalled, 0, FALSE,
+                                 0, SELFTEST_PROMPT_MS);
+      /* The bound covers the teardown the callback fires in the middle of. */
+      nchecks += checkEngineWait("engine never returns", pending, &endCalled, SELFTEST_WAIT_MS,
+                                 FALSE, lateLeast, lateMost);
+      /* The mirror half has no bound, so end the mirror late and ask for a bound of zero,
+         which a wait that skipped that half would return from at once. */
+      late = selftestStartLateEngine();
+      nchecks += checkEngineWait("mirror ends late", pending, &selftestEndCalled, 0, FALSE,
+                                 lateLeast, lateMost);
+      WaitForSingleObject(late, INFINITE);
+      CloseHandle(late);
+      /* Same for the fallback, which must wait for the callback rather than give up at once. */
+      late = selftestStartLateEngine();
+      nchecks += checkEngineWait("no event, mirror ends late", NULL, &selftestEndCalled, 0, FALSE,
+                                 lateLeast, lateMost);
+      WaitForSingleObject(late, INFINITE);
+      CloseHandle(late);
+      /* Results arriving DURING the bounded wait, which nothing above exercises. The bound is
+         the real one, so a wait that sleeps it away answers 60 s late instead of 250 ms. */
+      late = selftestStartLateEngine();
+      nchecks += checkEngineWait("results written late", selftestLateResults, &endCalled,
+                                 ENGINE_RESULTS_TIMEOUT_MS, TRUE, lateLeast, lateMost);
+      WaitForSingleObject(late, INFINITE);
+      CloseHandle(late);
+      CloseHandle(ready);
       CloseHandle(pending);
+      CloseHandle(selftestLateResults);
       /* Pinned where the count is produced: a truncated list runs nothing and still prints. */
-      if (nchecks != 9) {
-        fprintf(stderr, "FATAL: engine thread wait ran %d checks, expected 9\n", nchecks);
+      if (nchecks != 16) {
+        fprintf(stderr, "FATAL: engine results wait ran %d checks, expected 16\n", nchecks);
         fflush(stderr);
         ExitProcess(3);
       }
-      printf("engine thread wait ok on %d checks\n", nchecks);
+      printf("engine results wait ok on %d checks\n", nchecks);
     }
     /* Portable mode decides which store this run writes to. The two CI legs assert
        opposite suffixes, so a mode wired to a constant reds one of them. */


### PR DESCRIPTION
`lance()` waited for `termine`, which the end-of-mirror callback raises from inside the engine's teardown. `hts_main2()` has not returned there. So `HTTRACK_result` could still hold the previous mirror's value, and nothing stopped the UI from freeing `global_opt` under the running engine.

The engine thread now raises an event once `hts_main2()` has returned, and `lance()` waits for that. `termine` keeps its other job of closing the progress window. The wait has no bound while the mirror runs, then 60 seconds for the teardown, so a wedged engine cannot strand the end panel.

A mirror whose thread never started hung the GUI forever, because nothing would then raise `termine`. It now ends with a message of its own.

No mirror runs under `--selftest`, so a new block there drives the wait through eight cases. I damaged the wait thirteen ways, and ten of them fail by name. Nothing covers `lance()` calling that wait, nor the order the engine thread raises the event in, because reaching either needs a real mirror.

Closes #173
