### PR TITLE
A catalog short of a repeated key would render blank, and nothing says so

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -50,6 +50,9 @@ jobs:
       # The guard itself runs in the build job, where the engine's catalogs are checked out.
       - name: Stopped-panel title cases
         run: python3 tools/test-check-stop-title.py
+      # Same reason.
+      - name: Repeated catalog key cases
+        run: python3 tools/test-check-duplicate-keys.py
       # Same reason: a spent acceptance only blocks a tagged build, so nothing else runs it.
       - name: Advisory accept/stale cases
         run: python3 tools/test-check-native-deps.py
@@ -342,6 +345,13 @@ jobs:
       - name: The stopped panel can title itself in every language
         shell: pwsh
         run: python httrack-windows/tools/check-stop-title.py httrack
+
+      # #171 is unreachable only while every catalog carries every repeated key, and the
+      # engine is unpinned, so a translator's edit upstream decides that with nothing in
+      # between. This says when it stops holding; it does not fix the blank.
+      - name: Every catalog carries every repeated key
+        shell: pwsh
+        run: python httrack-windows/tools/check-duplicate-keys.py httrack
 
       - name: Help anchors resolve in the engine's guide
         shell: pwsh

--- a/tools/check-duplicate-keys.py
+++ b/tools/check-duplicate-keys.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Fail if a catalog carries fewer copies of a repeated English key than English does.
+
+Two catalog lines can share one English text, and LANG_LOAD() in WinHTTrack/newlang.cpp
+tells them apart by position: the Nth line resolves through the Nth spelling, "Exit",
+then "Exit1", then "Exit2". Its English backfill pass does not walk that chain. It stops
+at the first spelling that already holds a value, so it can fill at most the first copy,
+and any later copy the catalog itself did not carry renders blank (httrack-windows#171).
+
+Every shipped catalog carries every copy today, which is why #171 is unreachable and was
+left unfixed. This is the tripwire for the day that stops being true, not a fix. It fires
+on the catalog that would expose the bug, before the blank reaches a user.
+
+A catalog missing a key English states ONCE is fine and common, because the backfill does
+cover that. Only a short count on a repeated key is the reachable shape.
+"""
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Controls. Both guard against a parse that silently yields nothing, which would report
+# every catalog clean. English repeats 27 keys, and 29 other catalogs ship beside it.
+MIN_REPEATED = 20
+MIN_CATALOGS = 25
+
+
+def key_lines(path):
+    """The key half of a catalog, in file order, repeats kept.
+
+    check-stop-title.py parses the same files into a dict, which collapses exactly the
+    repeats this guard exists to count, so the two parsers stay apart on purpose.
+
+    Both files are strict pairs from the first line, so a line inserted anywhere shifts
+    every later key onto an odd index. Stepping by two would then read one entry's value
+    as a key, so the parity is checked, not assumed.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+    if len(lines) % 2 != 1:
+        sys.exit(f"{path.name} has {len(lines) - 1} lines, an odd number, so its key/value "
+                 f"pairs do not line up and every key past the gap would be read as a value")
+    return [lines[i] for i in range(0, len(lines) - 1, 2)]
+
+
+def shortfalls(name, counts, repeated):
+    """Which repeated keys this catalog is short of, worst first."""
+    short = [(want - counts.get(key, 0), key, counts.get(key, 0), want)
+             for key, want in repeated.items() if counts.get(key, 0) < want]
+    return [f"{name}: {got} of English's {want} copies of {key!r}, and the backfill fills "
+            f"at most one, so a later copy renders blank (#171)"
+            for _, key, got, want in sorted(short, reverse=True)]
+
+
+def main():
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "httrack")
+    english = root / "lang" / "English.txt"
+    repeated = {k: n for k, n in Counter(key_lines(english)).items() if n > 1}
+    if len(repeated) < MIN_REPEATED:
+        sys.exit(f"English.txt repeats only {len(repeated)} keys, under the {MIN_REPEATED} this "
+                 f"check needs to prove anything")
+
+    bad, checked = [], 0
+    # English against itself can never be short, so that row would be a vacuous pass.
+    for path in sorted((root / "lang").glob("*.txt")):
+        if path.name == english.name:
+            continue
+        checked += 1
+        bad += shortfalls(path.name, Counter(key_lines(path)), repeated)
+    if checked < MIN_CATALOGS:
+        sys.exit(f"only {checked} catalogs read, under the {MIN_CATALOGS} this check needs to "
+                 f"prove anything")
+    if bad:
+        sys.exit("\n".join(bad))
+    print(f"all {len(repeated)} repeated keys are complete in all {checked} catalogs")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check-duplicate-keys.py
+++ b/tools/check-duplicate-keys.py
@@ -24,21 +24,52 @@ MIN_REPEATED = 20
 MIN_CATALOGS = 25
 
 
-def key_lines(path):
-    """The key half of a catalog, in file order, repeats kept.
+# What linput() drops before the catalog text is ever compared (engine htslib.c).
+DROPPED = {ord(c): None for c in "\r\t\f"}
+
+
+def logical_lines(path):
+    """The file's lines as linput_cpp() hands them over, not as they sit on disk.
+
+    It drops CR, tab and form feed, trims spaces and tabs off both ends, and joins a line
+    ending in a backslash to the one after it. A guard comparing raw text would fail a
+    catalog over a trailing space the program never sees, and a continuation would shift
+    every later key onto the wrong half of its pair without the guard noticing.
+    """
+    out, joined = [], ""
+    # newline="" keeps CRLF and a lone CR intact, so the drop below is this guard's own and
+    # not Python's. The engine does not end a line on CR, and universal newlines would.
+    with path.open(encoding="utf-8", newline="") as fp:
+        text = fp.read()
+    for raw in text.split("\n"):
+        line = raw.translate(DROPPED).strip(" \t")
+        if line.endswith("\\"):
+            joined += line[:-1]
+            continue
+        out.append(joined + line)
+        joined = ""
+    if joined:
+        out.append(joined)
+    if out and out[-1] == "":
+        out.pop()  # the newline every catalog ends with
+    return out
+
+
+def carried(path):
+    """Every key this catalog actually defines, in file order, repeats kept.
+
+    A pair whose key or value is empty is skipped by LANG_LOAD(), so its key line does not
+    define anything however present it looks. Empty values already ship in quantity, none
+    yet on a repeated key, and one landing there is exactly the blank this guard is for.
 
     check-stop-title.py parses the same files into a dict, which collapses exactly the
     repeats this guard exists to count, so the two parsers stay apart on purpose.
-
-    Both files are strict pairs from the first line, so a line inserted anywhere shifts
-    every later key onto an odd index. Stepping by two would then read one entry's value
-    as a key, so the parity is checked, not assumed.
     """
-    lines = path.read_text(encoding="utf-8").split("\n")
-    if len(lines) % 2 != 1:
-        sys.exit(f"{path.name} has {len(lines) - 1} lines, an odd number, so its key/value "
+    lines = logical_lines(path)
+    if len(lines) % 2 != 0:
+        sys.exit(f"{path.name} holds {len(lines)} lines, an odd number, so its key/value "
                  f"pairs do not line up and every key past the gap would be read as a value")
-    return [lines[i] for i in range(0, len(lines) - 1, 2)]
+    return [lines[i] for i in range(0, len(lines), 2) if lines[i] and lines[i + 1]]
 
 
 def shortfalls(name, counts, repeated):
@@ -53,7 +84,7 @@ def shortfalls(name, counts, repeated):
 def main():
     root = Path(sys.argv[1] if len(sys.argv) > 1 else "httrack")
     english = root / "lang" / "English.txt"
-    repeated = {k: n for k, n in Counter(key_lines(english)).items() if n > 1}
+    repeated = {k: n for k, n in Counter(carried(english)).items() if n > 1}
     if len(repeated) < MIN_REPEATED:
         sys.exit(f"English.txt repeats only {len(repeated)} keys, under the {MIN_REPEATED} this "
                  f"check needs to prove anything")
@@ -64,7 +95,7 @@ def main():
         if path.name == english.name:
             continue
         checked += 1
-        bad += shortfalls(path.name, Counter(key_lines(path)), repeated)
+        bad += shortfalls(path.name, Counter(carried(path)), repeated)
     if checked < MIN_CATALOGS:
         sys.exit(f"only {checked} catalogs read, under the {MIN_CATALOGS} this check needs to "
                  f"prove anything")

--- a/tools/test-check-duplicate-keys.py
+++ b/tools/test-check-duplicate-keys.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Table test for check-duplicate-keys.py, over a synthesised catalog tree.
+
+Needs no engine checkout, so it runs in the encoding job while the guard itself runs
+where httrack/lang exists. Every row below damages the tree in one way and states what
+the guard must say about it, because a guard nobody has damaged has never been proved
+to notice anything (#167).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+MOD = Path(__file__).with_name("check-duplicate-keys.py")
+spec = importlib.util.spec_from_file_location("check_duplicate_keys", MOD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+fail = 0
+ran = 0
+
+
+def expect(what, got, want):
+    global fail, ran
+    ran += 1
+    if got != want:
+        print(f"  FAIL {what} : got {got!r}, wanted {want!r}")
+        fail += 1
+    else:
+        print(f"  ok   {what}")
+
+
+def catalog(keys):
+    """A catalog whose every value is the key back, so only the key column varies."""
+    return "\n".join(f"{k}\n{k} translated" for k in keys) + "\n"
+
+
+# English repeats "Exit" three times and "Cancel" twice, plus filler to clear the floors.
+FILLER = [f"Key{i}" for i in range(40)]
+ENGLISH = ["Exit", "Cancel", "Exit", "Only once", "Exit", "Cancel"] + FILLER
+# Each filler key is repeated too, so the tree clears MIN_REPEATED without the rows above.
+ENGLISH += FILLER
+
+
+def tree(tmp, catalogs):
+    """A lang/ tree: English plus MIN_CATALOGS copies of the given catalogs."""
+    root = Path(tmp)
+    (root / "lang").mkdir(parents=True)
+    (root / "lang" / "English.txt").write_text(catalog(ENGLISH), encoding="utf-8")
+    for i, keys in enumerate(catalogs):
+        (root / "lang" / f"Lang{i:02d}.txt").write_text(catalog(keys), encoding="utf-8")
+    return root
+
+
+def run(catalogs):
+    """The guard's verdict on a tree: None when it passes, else what it exited with."""
+    with TemporaryDirectory() as tmp:
+        root = tree(tmp, catalogs)
+        argv = sys.argv
+        sys.argv = ["check-duplicate-keys.py", str(root)]
+        try:
+            guard.main()
+            return None
+        except SystemExit as e:
+            return str(e.code)
+        finally:
+            sys.argv = argv
+
+
+COMPLETE = [ENGLISH] * guard.MIN_CATALOGS
+
+print("--- a tree nothing is wrong with passes ---")
+expect("every catalog carries every copy", run(COMPLETE), None)
+
+print("--- a short count on a repeated key fails, and names it ---")
+ROWS = [
+    ("two of three copies of Exit",
+     [k for k in ENGLISH if k != "Exit"] + ["Exit", "Exit"], "Exit", "2 of English's 3"),
+    ("one of three copies of Exit",
+     [k for k in ENGLISH if k != "Exit"] + ["Exit"], "Exit", "1 of English's 3"),
+    # The backfill fills the first copy only, so losing every copy still blanks the rest.
+    ("no copies of Cancel at all",
+     [k for k in ENGLISH if k != "Cancel"], "Cancel", "0 of English's 2"),
+]
+for what, keys, key, want in ROWS:
+    got = run([keys] + [ENGLISH] * (guard.MIN_CATALOGS - 1))
+    expect(f"{what} is reported", got is not None and key in got and want in got, True)
+    expect(f"{what} names the catalog", got is not None and "Lang00.txt" in got, True)
+
+print("--- shapes the bug cannot take are left alone ---")
+expect("a key English states once may be missing",
+       run([[k for k in ENGLISH if k != "Only once"]] + [ENGLISH] * (guard.MIN_CATALOGS - 1)),
+       None)
+expect("more copies than English is not this bug",
+       run([ENGLISH + ["Exit"]] + [ENGLISH] * (guard.MIN_CATALOGS - 1)), None)
+
+print("--- the controls fire rather than pass vacuously ---")
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    (root / "lang" / "English.txt").write_text(catalog(["One", "Two", "Three"]), encoding="utf-8")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("English with nothing repeated proves nothing",
+           verdict is not None and "repeats only" in verdict, True)
+
+expect("too few catalogs proves nothing",
+       "only" in (run([ENGLISH] * 3) or ""), True)
+
+print("--- an odd line count is refused rather than misread ---")
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    bad = root / "lang" / "Lang00.txt"
+    bad.write_text(bad.read_text(encoding="utf-8") + "orphan key\n", encoding="utf-8")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("a value with no key is refused",
+           verdict is not None and "odd number" in verdict, True)
+
+print(f"\n{ran - fail}/{ran} checks passed")
+sys.exit(1 if fail else 0)

--- a/tools/test-check-duplicate-keys.py
+++ b/tools/test-check-duplicate-keys.py
@@ -30,9 +30,10 @@ def expect(what, got, want):
         print(f"  ok   {what}")
 
 
-def catalog(keys):
-    """A catalog whose every value is the key back, so only the key column varies."""
-    return "\n".join(f"{k}\n{k} translated" for k in keys) + "\n"
+def catalog(keys, tag="translated"):
+    """A catalog of these keys. TAG varies the value column independently of the keys, so
+    a row can tell a guard that reads the key half from one that reads the value half."""
+    return "\n".join(f"{k}\n{k} {tag}" for k in keys) + "\n"
 
 
 # English repeats "Exit" three times and "Cancel" twice, plus filler to clear the floors.
@@ -42,20 +43,22 @@ ENGLISH = ["Exit", "Cancel", "Exit", "Only once", "Exit", "Cancel"] + FILLER
 ENGLISH += FILLER
 
 
-def tree(tmp, catalogs):
-    """A lang/ tree: English plus MIN_CATALOGS copies of the given catalogs."""
+def tree(tmp, catalogs, tag="translated", extra=None, english=None):
+    """A lang/ tree: English plus one file per entry in CATALOGS, plus any EXTRA files."""
     root = Path(tmp)
     (root / "lang").mkdir(parents=True)
-    (root / "lang" / "English.txt").write_text(catalog(ENGLISH), encoding="utf-8")
+    (root / "lang" / "English.txt").write_text(catalog(english or ENGLISH), encoding="utf-8")
     for i, keys in enumerate(catalogs):
-        (root / "lang" / f"Lang{i:02d}.txt").write_text(catalog(keys), encoding="utf-8")
+        (root / "lang" / f"Lang{i:02d}.txt").write_text(catalog(keys, tag), encoding="utf-8")
+    for name, text in (extra or {}).items():
+        (root / "lang" / name).write_text(text, encoding="utf-8")
     return root
 
 
-def run(catalogs):
+def run(catalogs, tag="translated", extra=None, english=None):
     """The guard's verdict on a tree: None when it passes, else what it exited with."""
     with TemporaryDirectory() as tmp:
-        root = tree(tmp, catalogs)
+        root = tree(tmp, catalogs, tag, extra, english)
         argv = sys.argv
         sys.argv = ["check-duplicate-keys.py", str(root)]
         try:
@@ -84,7 +87,7 @@ ROWS = [
 ]
 for what, keys, key, want in ROWS:
     got = run([keys] + [ENGLISH] * (guard.MIN_CATALOGS - 1))
-    expect(f"{what} is reported", got is not None and key in got and want in got, True)
+    expect(f"{what} is reported", got is not None and repr(key) in got and want in got, True)
     expect(f"{what} names the catalog", got is not None and "Lang00.txt" in got, True)
 
 print("--- shapes the bug cannot take are left alone ---")
@@ -93,6 +96,61 @@ expect("a key English states once may be missing",
        None)
 expect("more copies than English is not this bug",
        run([ENGLISH + ["Exit"]] + [ENGLISH] * (guard.MIN_CATALOGS - 1)), None)
+# Values that carry none of their key: a guard reading the value half sees English's
+# values missing everywhere, so only a row whose columns differ can tell the halves apart.
+expect("a catalog whose values are all translated",
+       run(COMPLETE, tag="traduit"), None)
+# lang/ really does hold Makefile.am and README.md, and neither is a catalog.
+expect("a non-catalog file in lang/ is left alone",
+       run(COMPLETE, extra={"README.md": "one\ntwo\nthree\n"}), None)
+
+print("--- the guard reads a catalog the way LANG_LOAD does ---")
+# An empty value makes LANG_LOAD skip the pair, so the key line defines nothing.
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    short = root / "lang" / "Lang00.txt"
+    text = short.read_text(encoding="utf-8").split("\n")
+    text[text.index("Exit", text.index("Exit", text.index("Exit") + 1) + 1) + 1] = ""
+    short.write_text("\n".join(text), encoding="utf-8")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("a copy whose value is empty defines nothing",
+           verdict is not None and repr("Exit") in verdict and "2 of English's 3" in verdict, True)
+# linput() drops CR and tab and linput_trim() strips the ends, so a catalog saved on
+# Windows, or padded, carries the same keys. Only a CRLF row can see the CR being dropped.
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    padded = root / "lang" / "Lang00.txt"
+    padded.write_text(catalog([f"\t {k} " for k in ENGLISH]).replace("\n", "\r\n"),
+                      encoding="utf-8")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("CRLF and padding the program never sees are not a shortfall", verdict, None)
+# linput() treats CR as a character to drop, not as a line ending, so a file terminated
+# with lone CRs is ONE line to the engine. Reading it with universal newlines would split
+# it into many and report a tidy answer about a file the program cannot read at all.
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    mac = root / "lang" / "Lang00.txt"
+    mac.write_text(catalog(ENGLISH).replace("\n", "\r"), encoding="utf-8", newline="")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("CR alone does not end a line", verdict is not None and "odd number" in verdict, True)
+# LANG_LOAD skips a pair with no key too, so a repeated empty key is not a repeated key.
+expect("a pair with no key defines nothing",
+       run([ENGLISH + [""]] * guard.MIN_CATALOGS, english=ENGLISH + ["", ""]), None)
 
 print("--- the controls fire rather than pass vacuously ---")
 with TemporaryDirectory() as tmp:
@@ -107,10 +165,29 @@ with TemporaryDirectory() as tmp:
     expect("English with nothing repeated proves nothing",
            verdict is not None and "repeats only" in verdict, True)
 
+# Exactly one under the floor: a guard that counted English too would clear it here.
 expect("too few catalogs proves nothing",
-       "only" in (run([ENGLISH] * 3) or ""), True)
+       "only" in (run([ENGLISH] * (guard.MIN_CATALOGS - 1)) or ""), True)
 
-print("--- an odd line count is refused rather than misread ---")
+print("--- a file whose pairs do not line up is refused rather than misread ---")
+# linput_cpp() joins a line ending in a backslash, so a value ending in one eats the next
+# key. The program loses that key too, which is why refusing the file is the right answer.
+with TemporaryDirectory() as tmp:
+    root = tree(tmp, COMPLETE)
+    bad = root / "lang" / "Lang00.txt"
+    text = bad.read_text(encoding="utf-8").split("\n")
+    text[1] += "\\"
+    bad.write_text("\n".join(text), encoding="utf-8")
+    sys.argv = ["check-duplicate-keys.py", str(root)]
+    try:
+        guard.main()
+        verdict = None
+    except SystemExit as e:
+        verdict = str(e.code)
+    expect("a value ending in a backslash swallows the next key",
+           verdict is not None and "odd number" in verdict, True)
+
+
 with TemporaryDirectory() as tmp:
     root = tree(tmp, COMPLETE)
     bad = root / "lang" / "Lang00.txt"
@@ -124,5 +201,9 @@ with TemporaryDirectory() as tmp:
     expect("a value with no key is refused",
            verdict is not None and "odd number" in verdict, True)
 
-print(f"\n{ran - fail}/{ran} checks passed")
-sys.exit(1 if fail else 0)
+# Exact, not a floor: a floor passes the deletion it exists to catch (#126, #127).
+if ran != 19:
+    sys.exit(f"{ran} cases ran, expected 19: rows have gone missing or been added")
+if fail:
+    sys.exit(f"{fail} repeated-key case(s) failed")
+print(f"::notice::repeated-key guard: {ran} cases pass")


### PR DESCRIPTION
Two catalog lines can share one English text. `LANG_LOAD()` tells them apart by position, so the Nth line resolves through the Nth spelling: `Exit`, then `Exit1`, then `Exit2`. Its English backfill pass stops at the first spelling that already holds a value, so it fills at most the first copy. A later copy the catalog did not carry renders blank.

All 29 shipped catalogs carry all 27 repeated keys today, so nothing reaches this. That is why #171 stays open, and why PR #170 was closed. The obvious patch walks to the first free slot, which is a different rule, and would trade a blank string for a wrong one.

This is not that fix. It is the tripwire for the day a catalog goes short, so the blank turns into a build failure instead of reaching a user. The engine is unpinned, so a translator's edit upstream decides this with nothing in between.

The guard reads a catalog the way `linput_cpp()` does. Comparing raw text would fail a file saved on Windows, and would go blind on a continuation line. It counts a copy only when its value is non-empty, which is what `LANG_LOAD` stores.

I dropped one `Exit` line from a real catalog and the guard named the file, the key and the count. Its 19 cases run in the encoding job, and I damaged the guard sixteen ways: all sixteen fail.
